### PR TITLE
[BSE-4333] Avoid Cythonizing transform files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,36 +669,3 @@ add_dependencies(ext datasketches)
 set_target_properties(ext PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
 
 install(TARGETS ext DESTINATION "bodo/")
-
-
-# ------------------------- Cythonize Transform Files -------------------------
-set(transform_files)
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
-  set(transform_files
-    "bodo/transforms/dataframe_pass.py"
-    "bodo/transforms/distributed_analysis.py"
-    "bodo/transforms/distributed_pass.py"
-    "bodo/transforms/series_pass.py"
-    "bodo/transforms/table_column_del_pass.py"
-    "bodo/transforms/typing_pass.py"
-    "bodo/transforms/untyped_pass.py"
-  )
-endif()
-
-foreach (file_path ${transform_files})
-  cmake_path(GET file_path FILENAME file_name)
-  cmake_path(REMOVE_EXTENSION file_name OUTPUT_VARIABLE cython_module)
-  cmake_path(REPLACE_EXTENSION file_path ".c" OUTPUT_VARIABLE out_path)
-
-  add_custom_command(
-    OUTPUT ${out_path}
-    DEPENDS ${file_path}
-    VERBATIM
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMAND "${CYTHON_EXECUTABLE}" -3 --output-file "${CMAKE_CURRENT_BINARY_DIR}/${out_path}" "${file_path}"
-    COMMENT "Cythonizing Source ${file_path} into ${out_path}"
-  )
-
-  python_add_library(${cython_module} MODULE WITH_SOABI ${out_path})
-  install(TARGETS ${cython_module} DESTINATION "bodo/transforms/")
-endforeach()

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -4766,7 +4766,7 @@ class TypingTransforms:
                     inputs_unified_arg = get_overload_const_bool(inputs_unified_type)
                     inputs_unified_txt = f"input_dicts_unified={inputs_unified_arg}"
 
-                args = []
+                args = ()
                 new_type = bodo.libs.table_builder.TableBuilderStateType(
                     input_table_type, should_use_chunked_builder_arg
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ logging.level = "INFO"
 
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 build-dir = "build/type_{build_type}"
-# Exclude bodo/transforms since it should be Cythonized in production builds
 wheel.exclude = [
     "bodo/**/*.h",
     "bodo/**/*.cpp",
@@ -86,13 +85,6 @@ wheel.exclude = [
     "bodo/**/*.hpp",
     "bodo/libs/HashLibs/TSL",
     "bodo/bench",
-    "bodo/transforms/dataframe_pass.py",
-    "bodo/transforms/distributed_analysis.py",
-    "bodo/transforms/distributed_pass.py",
-    "bodo/transforms/series_pass.py",
-    "bodo/transforms/table_column_del_pass.py",
-    "bodo/transforms/typing_pass.py",
-    "bodo/transforms/untyped_pass.py",
     "bodo/transforms/**/*.pyc",
     "bodo/tests/*",
 ]


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Avoids Cythonizing compiler transform files since obfuscation is not necessary anymore. This should fix the quick start notebook issue. See https://bodo.atlassian.net/browse/BSE-4333.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

This should impact the next release (when the pipelines are setup). The change is straightforward so not worth extensive testing right now.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
NA
## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/develop/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.