### PR TITLE
Only Test Python 3.12 for MacOS Conda Builds in Pull Requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
       # Don't cancel other jobs if one fails
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.11', '3.10']
+        # On pull requests, only test building for 3.12
+        python-version: ${{ fromJson(github.event_name == 'pull_request' && '["3.12"]' || '["3.12", "3.11", "3.10"]') }}
         os: ['macos-13', 'macos-14']
     uses: ./.github/workflows/_build_bodo_conda_native.yml
     with:


### PR DESCRIPTION
## Changes included in this PR

When testing Conda Builds on PRs, we should avoid building the MacOS Py3.11 and Py3.10 packages. I've noticed that GitHub throttles the MacOS agents, so too many concurrent PRs making changes to these files are slowed down. Furthermore, we only really need to test older versions of Python on Linux, since its very uncommon for there to be a problem specifically on the MacOS <Py3.12 platforms. Usually its either global to MacOS or global to older versions of Python.

Note, if this is still needed, devs can trigger the CI manually with a workflow dispatch. Plus, Nightly and releases will still run all configurations.

## Testing strategy

- [x] Run the Conda Release CI to success

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.