### PR TITLE
[BSE-4352] Fix to_parquet nightly issues

### DIFF
--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -8,6 +8,7 @@ import bodo
 from bodo.pandas.frame import BodoDataFrame
 from bodo.pandas.managers import LazyBlockManager
 from bodo.tests.test_lazy.utils import pandas_managers  # noqa
+from bodo.tests.utils import pytest_mark_spawn_mode
 from bodo.utils.testing import ensure_clean2
 
 
@@ -416,7 +417,7 @@ def test_slice(pandas_managers, head_df, collect_func):
     assert lam_sliced_twice_df.equals(collect_func(0)["A0"][10:30])
 
 
-@pytest.mark.spawn_mode
+@pytest_mark_spawn_mode
 def test_parquet(collect_func):
     """Tests that to_parquet() writes the frame correctly and does not trigger data fetch"""
 
@@ -444,7 +445,7 @@ def test_parquet(collect_func):
     )
 
 
-@pytest.mark.spawn_mode
+@pytest_mark_spawn_mode
 def test_parquet_param(collect_func):
     """Tests that to_parquet() raises an error on unsupported parameters"""
 

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -416,6 +416,7 @@ def test_slice(pandas_managers, head_df, collect_func):
     assert lam_sliced_twice_df.equals(collect_func(0)["A0"][10:30])
 
 
+@pytest.mark.spawn_mode
 def test_parquet(collect_func):
     """Tests that to_parquet() writes the frame correctly and does not trigger data fetch"""
 
@@ -443,6 +444,7 @@ def test_parquet(collect_func):
     )
 
 
+@pytest.mark.spawn_mode
 def test_parquet_param(collect_func):
     """Tests that to_parquet() raises an error on unsupported parameters"""
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixing to_parquet nightly error
- Error was due to spawn not being able to identify the type of the dataframe passed as an argument at jitted function `def _get_bodo_df(df)`
- error replicated locally with mpiexec -n 5

Marking test as spawn_mode which only runs with 1 rank

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.