### PR TITLE
Support caching for IPython cells

### DIFF
--- a/bodo/submit/spawner.py
+++ b/bodo/submit/spawner.py
@@ -2,7 +2,9 @@
 
 import atexit
 import contextlib
+import inspect
 import itertools
+import linecache
 import logging
 import os
 import signal
@@ -606,12 +608,25 @@ class SubmitDispatcher:
         )
 
     @classmethod
-    def get_dispatcher(cls, py_func, decorator_args, extra_globals):
+    def get_dispatcher(cls, py_func, decorator_args, extra_globals, linecache_entry):
         # Instead of unpickling into a new SubmitDispatcher, we call bodo.jit to
         # return the real dispatcher
         py_func.__globals__.update(extra_globals)
         decorator = bodo.jit(**decorator_args)
+        if linecache_entry:
+            linecache.cache[linecache_entry[0]] = linecache_entry[1]
         return decorator(py_func)
+
+    def _get_ipython_cache_entry(self):
+        """Get IPython cell entry in linecache for the function to send to workers,
+        which is necessary for inspect.getsource to work (used in caching).
+        """
+        linecache_entry = None
+        source_path = inspect.getfile(self.py_func)
+        if source_path.startswith("<ipython-"):
+            linecache_entry = (source_path, linecache.cache[source_path])
+
+        return linecache_entry
 
     def __reduce__(self):
         # Pickle this object by pickling the underlying function (which is
@@ -621,6 +636,7 @@ class SubmitDispatcher:
             self.py_func,
             self.decorator_args,
             self.extra_globals,
+            self._get_ipython_cache_entry(),
         )
 
     def add_extra_globals(self, glbls):

--- a/bodo/submit/spawner.py
+++ b/bodo/submit/spawner.py
@@ -623,7 +623,9 @@ class SubmitDispatcher:
         """
         linecache_entry = None
         source_path = inspect.getfile(self.py_func)
-        if source_path.startswith("<ipython-"):
+        if source_path.startswith("<ipython-") or os.path.basename(
+            os.path.dirname(source_path)
+        ).startswith("ipykernel_"):
             linecache_entry = (source_path, linecache.cache[source_path])
 
         return linecache_entry


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Adds support for caching in IPython by sending linecache entry to workers. Some Jupyter and other notebook environments like Colab still use IPython (instead of ipykernel).

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

I tested it manually inside IPython. Doesn't seem like it's possible to test from command line.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.