### PR TITLE
Fix BodoSQL use in Jupyter (without JIT)

### DIFF
--- a/BodoSQL/bodosql/context.py
+++ b/BodoSQL/bodosql/context.py
@@ -1104,6 +1104,9 @@ class BodoSQLContext:
             # are not visible to cloudpickle as used by the function. See:
             # test_json_fns.py::test_object_construct_keep_null[no_nested-no_null-with_case]
             if isinstance(dispatcher, SubmitDispatcher):
+                # __builtins__ which is added to glbls by exec causes issues in
+                # Jupyter/IPython pickling.
+                glbls.pop("__builtins__", None)
                 dispatcher.add_extra_globals(glbls)
 
             return dispatcher(

--- a/examples/Getting-Started/quickstart.ipynb
+++ b/examples/Getting-Started/quickstart.ipynb
@@ -337,35 +337,28 @@
        "9                6    6764732.0      12.0"
       ]
      },
-     "execution_count": 1,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "import bodo\n",
     "import bodosql\n",
+    "\n",
     "# File stored in public S3 bucket hosted by Bodo\n",
     "s3_file_path = \"s3://bodo-example-data/nyc-taxi/yellow_tripdata_2019_half.pq\" \n",
     "\n",
-    "@bodo.jit\n",
-    "def simple_query():\n",
-    "    \n",
-    "    # reading file directly from S3\n",
-    "    bc = bodosql.BodoSQLContext( {\"NYCTAXI\": bodosql.TablePath(s3_file_path, \"parquet\")})\n",
-    "    \n",
-    "    # executing SQL query \n",
-    "    df1 = bc.sql('''\n",
-    "                SELECT DISTINCT \"passenger_count\"\n",
-    "                , ROUND (SUM (\"fare_amount\"),0) as TotalFares\n",
-    "                , ROUND (AVG (\"fare_amount\"),0) as AvgFares\n",
-    "                FROM NYCTAXI\n",
-    "                GROUP BY \"passenger_count\"\n",
-    "                ''')\n",
-    "    \n",
-    "    return df1 \n",
+    "# reading file directly from S3\n",
+    "bc = bodosql.BodoSQLContext( {\"NYCTAXI\": bodosql.TablePath(s3_file_path, \"parquet\")})\n",
     "\n",
-    "simple_query()"
+    "# executing SQL query \n",
+    "df1 = bc.sql('''\n",
+    "            SELECT DISTINCT \"passenger_count\"\n",
+    "            , ROUND (SUM (\"fare_amount\"),0) as TotalFares\n",
+    "            , ROUND (AVG (\"fare_amount\"),0) as AvgFares\n",
+    "            FROM NYCTAXI\n",
+    "            GROUP BY \"passenger_count\"\n",
+    "            ''')\n",
+    "display(df1)"
    ]
   },
   {
@@ -395,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Fixes BodoSQL use inside Jupyter without JIT (spawn mode). Updates the quickstart example to not use a JIT function.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

Tested it manually since we don't have unit test infrastructure for Jupyter yet.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.