### PR TITLE
Avoid importing BodoSQL unnecessarily

### DIFF
--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -74,6 +74,7 @@ from bodo.utils.typing import (
     ExternalFunctionErrorChecked,
     MetaType,
     decode_if_dict_array,
+    is_bodosql_context_type,
     is_overload_false,
     is_overload_none,
     is_str_arr_type,
@@ -1428,15 +1429,8 @@ def gatherv_impl_jit(
 
         return impl_dict
 
-    if type(data).__name__ == "BodoSQLContextType":
-        try:
-            import bodosql
-            from bodosql.context_ext import BodoSQLContextType
-        except ImportError:  # pragma: no cover
-            raise ImportError(
-                "Install bodosql to use gatherv() with BodoSQLContextType"
-            )
-        assert isinstance(data, BodoSQLContextType)
+    if is_bodosql_context_type(data):
+        import bodosql
 
         func_text = f"def impl_bodosql_context(data, allgather=False, warn_if_rep=True, root={DEFAULT_ROOT}, comm=0):\n"
         comma_sep_names = ", ".join([f"'{name}'" for name in data.names])
@@ -1454,7 +1448,6 @@ def gatherv_impl_jit(
 
     if type(data).__name__ == "TablePathType":
         try:
-            import bodosql
             from bodosql import TablePathType
         except ImportError:  # pragma: no cover
             raise ImportError("Install bodosql to use gatherv() with TablePathType")

--- a/bodo/tests/test_distributed.py
+++ b/bodo/tests/test_distributed.py
@@ -3293,3 +3293,16 @@ def test_get_value_for_type(dtype):
     """
     data = bodo.libs.distributed_api.get_value_for_type(dtype)
     assert bodo.typeof(data) == dtype
+
+
+@pytest.mark.slow
+def test_no_bodosql_import(memory_leak_check):
+    """Make sure BodoSQL isn't imported unnecessarily during compilation"""
+
+    @bodo.jit(spawn=False)
+    def f(df):
+        return (df.A.unique(), 3)
+
+    df = pd.DataFrame({"A": np.arange(10)})
+    f(df)
+    assert "bodosql" not in sys.modules

--- a/bodo/tests/test_spawn/test_spawn_mode.py
+++ b/bodo/tests/test_spawn/test_spawn_mode.py
@@ -264,18 +264,21 @@ def test_args():
     # Test BodoSQLContext if bodosql installed in test environment
     try:
         import bodosql
+
+        @bodo.jit(spawn=True)
+        def impl3(a, bc, b):
+            df = bc.sql('select * from "source"')
+            return df
+
+        df1 = pd.DataFrame({"id": [1, 1], "dep": ["software", "hr"]})
+        df2 = pd.DataFrame({"id": [1, 2], "dep": ["finance", "hardware"]})
+        bc = bodosql.context.BodoSQLContext({"target": df1, "source": df2})
+        _test_equal(impl3(1, bc, 4), df2)
     except ImportError:
         return
-
-    @bodo.jit(spawn=True)
-    def impl3(a, bc, b):
-        df = bc.sql('select * from "source"')
-        return df
-
-    df1 = pd.DataFrame({"id": [1, 1], "dep": ["software", "hr"]})
-    df2 = pd.DataFrame({"id": [1, 2], "dep": ["finance", "hardware"]})
-    bc = bodosql.context.BodoSQLContext({"target": df1, "source": df2})
-    _test_equal(impl3(1, bc, 4), df2)
+    finally:
+        # Make sure bodosql isn't in modules since checked in test_no_bodosql_import
+        sys.modules.pop("bodosql", None)
 
 
 def test_args_tuple_list_dict():

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -34,7 +34,7 @@ from numba.core.untyped_passes import PreserveIR
 
 import bodo
 from bodo.mpi4py import MPI
-from bodo.utils.typing import BodoWarning, dtype_to_array_type
+from bodo.utils.typing import BodoWarning, dtype_to_array_type, is_bodosql_context_type
 from bodo.utils.utils import (
     is_assign,
     is_distributable_tuple_typ,
@@ -937,13 +937,9 @@ def _get_dist_arg(
     if not (is_distributable_typ(bodo_typ) or is_distributable_tuple_typ(bodo_typ)):
         return a
 
-    try:
+    if is_bodosql_context_type(bodo_typ):
         from bodosql import BodoSQLContext
-        from bodosql.context_ext import BodoSQLContextType
-    except ImportError:  # pragma: no cover
-        BodoSQLContextType = None
 
-    if BodoSQLContextType is not None and isinstance(bodo_typ, BodoSQLContextType):
         # Distribute each of the DataFrames.
         new_dict = {
             name: _get_dist_arg(df, copy, var_length, check_typing_issues)

--- a/bodo/transforms/series_pass.py
+++ b/bodo/transforms/series_pass.py
@@ -112,6 +112,7 @@ from bodo.utils.typing import (
     get_overload_const_int,
     get_overload_const_str,
     get_overload_const_tuple,
+    is_bodosql_context_type,
     is_literal_type,
     is_overload_constant_str,
     is_overload_constant_tuple,
@@ -956,14 +957,7 @@ class SeriesPass:
                 "init_sql_context",
                 "bodosql.context_ext",
             ):
-                # Try import BodoSQL and check the type
-                # TODO: Remove from the main Bodo code base and handle by an extension
-                try:  # pragma: no cover
-                    from bodosql.context_ext import BodoSQLContextType
-                except ImportError:
-                    # workaround: something that makes isinstance(type, BodoSQLContextType) always false
-                    BodoSQLContextType = int
-                if isinstance(rhs_type, BodoSQLContextType):
+                if is_bodosql_context_type(rhs_type):
                     assign.value = sql_ctx_def.args[1]
                     return [assign]
 

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -85,6 +85,7 @@ from bodo.utils.typing import (
     get_overload_const_int,
     get_overload_const_str,
     handle_bodosql_case_init_code,
+    is_bodosql_context_type,
     is_const_func_type,
     is_immutable,
     is_list_like_index_type,
@@ -2982,15 +2983,8 @@ class TypingTransforms:
             "convert_to_pandas",
         ):  # pragma: no cover
             # Try import BodoSQL and check the type
-            try:  # pragma: no cover
-                from bodosql.context_ext import BodoSQLContextType
-            except ImportError:
-                # workaround: something that makes isinstance(type, BodoSQLContextType) always false
-                BodoSQLContextType = int
 
-            if isinstance(
-                self._get_method_obj_type(func_mod, rhs.func), BodoSQLContextType
-            ):
+            if is_bodosql_context_type(self._get_method_obj_type(func_mod, rhs.func)):
                 return self._run_call_bodosql_sql(
                     assign, rhs, func_mod, func_name, label
                 )

--- a/bodo/utils/typing.py
+++ b/bodo/utils/typing.py
@@ -1293,6 +1293,21 @@ def get_index_name_types(t):
     return (t.name_typ,)
 
 
+def is_bodosql_context_type(t):
+    """Check for BodoSQLContextType without importing BodoSQL unnecessarily"""
+    if type(t).__name__ == "BodoSQLContextType":
+        try:
+            from bodosql.context_ext import BodoSQLContextType
+        except ImportError:  # pragma: no cover
+            raise ImportError("BodoSQL not installed properly")
+        assert isinstance(
+            t, BodoSQLContextType
+        ), "is_bodosql_context_type: expected BodoSQLContextType"
+        return True
+
+    return False
+
+
 class ListLiteral(types.Literal):
     """class for literal lists, only used when Bodo forces an argument to be a literal
     list (e.g. in typing pass for groupby/join/sort_values).

--- a/bodo/utils/utils.py
+++ b/bodo/utils/utils.py
@@ -62,6 +62,7 @@ from bodo.utils.typing import (
     BodoError,
     BodoWarning,
     MetaType,
+    is_bodosql_context_type,
     is_overload_none,
     is_str_arr_type,
 )
@@ -570,11 +571,6 @@ def is_bodosql_kernel_mod(module: pt.Any) -> bool:
 
 
 def is_distributable_tuple_typ(var_typ):
-    try:
-        from bodosql.context_ext import BodoSQLContextType
-    except ImportError:  # pragma: no cover
-        # ignore if None.
-        BodoSQLContextType = None
     return (
         (
             isinstance(var_typ, types.BaseTuple)
@@ -599,8 +595,7 @@ def is_distributable_tuple_typ(var_typ):
             )
         )
         or (
-            BodoSQLContextType is not None
-            and isinstance(var_typ, BodoSQLContextType)
+            is_bodosql_context_type(var_typ)
             and any(is_distributable_typ(df) for df in var_typ.dataframes)
         )
     )


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

This avoids importing BodoSQL unnecessarily which can cause issues issues if BodoSQL is not installed properly (e.g. Java issues). Also reduces compilation time a bit.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Tested it manually to make sure bodosql isn't imported.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.