### PR TITLE
[BSE-4371] Replace Secret File with GitHub Secrets

### DIFF
--- a/.github/workflows/_build_azurefs_sas_token_provider_conda.yml
+++ b/.github/workflows/_build_azurefs_sas_token_provider_conda.yml
@@ -7,10 +7,7 @@ on:
 jobs:
   build:
     runs-on: [self-hosted, small]
-    timeout-minutes: 240
-
-    env:
-      BODO_CHANNEL_NAME: 'bodo.ai'
+    timeout-minutes: 240      
 
     steps:
       - uses: actions/checkout@v4
@@ -34,10 +31,12 @@ jobs:
       - name: 'Set Secret File Permissions and Conda Build and Publish Bodo-AzureFS-SAS-Token-Provider Binary to Artifactory'
         run: |
           set -eo pipefail
-          echo "${{ secrets.PUBLISH_BINARY_SECRETS }}" > $HOME/secret_file
-          sudo chmod a+r $HOME/secret_file
 
           artifactory_channel="bodo.ai"
-          echo "artifactory_channel: $artifactory_channel"
-          ./buildscripts/azurefs-sas-token-provider/publish_binary.sh $artifactory_channel
+          ./buildscripts/azurefs-sas-token-provider/publish_binary.sh "bodo.ai"
         shell: bash
+        env:
+          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          BODO_CHANNEL_NAME: 'bodo.ai'

--- a/.github/workflows/_build_bodo_conda_linux_comm.yml
+++ b/.github/workflows/_build_bodo_conda_linux_comm.yml
@@ -71,7 +71,7 @@ jobs:
           path: /github/home/conda-bld/
 
       - name: Publish to Artifactory / Anaconda
-        if: ${{ inputs.is-release }}
+        # if: ${{ inputs.is-release }}
         run: |
           set -exo pipefail
           source /opt/conda/etc/profile.d/conda.sh

--- a/.github/workflows/_build_bodo_conda_linux_comm.yml
+++ b/.github/workflows/_build_bodo_conda_linux_comm.yml
@@ -77,13 +77,12 @@ jobs:
           source /opt/conda/etc/profile.d/conda.sh
           conda activate bodo_build
 
-          # Secrets File
-          echo "${{ secrets.PUBLISH_BINARY_SECRETS }}" > $HOME/secret_file
-          sudo chmod a+r $HOME/secret_file
-
           echo "BODO_VERSION: $BODO_VERSION"
           echo "ARTIFACTORY_CHANNEL: $ARTIFACTORY_CHANNEL"
           ./buildscripts/bodo/publish_binary.sh $ARTIFACTORY_CHANNEL "linux-64" $BODO_VERSION
         env:
           IS_RELEASE: ${{ inputs.is-release }}
           ARTIFACTORY_CHANNEL: ${{ format('bodo.ai{0}', (inputs.is-release == false) && '-dev' || '') }}
+          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/_build_bodo_conda_linux_comm.yml
+++ b/.github/workflows/_build_bodo_conda_linux_comm.yml
@@ -71,7 +71,7 @@ jobs:
           path: /github/home/conda-bld/
 
       - name: Publish to Artifactory / Anaconda
-        # if: ${{ inputs.is-release }}
+        if: ${{ inputs.is-release }}
         run: |
           set -exo pipefail
           source /opt/conda/etc/profile.d/conda.sh

--- a/.github/workflows/_build_bodo_conda_native.yml
+++ b/.github/workflows/_build_bodo_conda_native.yml
@@ -94,7 +94,7 @@ jobs:
           path: ${{ env.CONDA_BLD_PATH }}
 
       - name: Publish to Artifactory / Anaconda
-        if: ${{ inputs.is-release }}
+        # if: ${{ inputs.is-release }}
         run: |
           set -exo pipefail
 

--- a/.github/workflows/_build_bodo_conda_native.yml
+++ b/.github/workflows/_build_bodo_conda_native.yml
@@ -98,10 +98,6 @@ jobs:
         run: |
           set -exo pipefail
 
-          # Secrets File
-          echo "${{ secrets.PUBLISH_BINARY_SECRETS }}" > $HOME/secret_file
-          sudo chmod a+r $HOME/secret_file
-
           echo "BODO_VERSION: $BODO_VERSION"
           echo "ARTIFACTORY_CHANNEL: $ARTIFACTORY_CHANNEL"
           ./buildscripts/bodo/publish_binary.sh $ARTIFACTORY_CHANNEL $OS_DIR $BODO_VERSION
@@ -109,3 +105,6 @@ jobs:
           IS_RELEASE: ${{ inputs.is-release }}
           ARTIFACTORY_CHANNEL: ${{ format('bodo.ai{0}{1}', (inputs.platform-build == true) && '-platform' || '', (inputs.is-release == false) && '-dev' || '') }}
           OS_DIR: ${{ format('{0}', (inputs.os == 'macos-13') && 'osx-64' || (inputs.os == 'macos-14') && 'osx-arm64' || 'linux-64') }}
+          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/_build_bodo_conda_native.yml
+++ b/.github/workflows/_build_bodo_conda_native.yml
@@ -94,7 +94,7 @@ jobs:
           path: ${{ env.CONDA_BLD_PATH }}
 
       - name: Publish to Artifactory / Anaconda
-        # if: ${{ inputs.is-release }}
+        if: ${{ inputs.is-release }}
         run: |
           set -exo pipefail
 

--- a/.github/workflows/_build_bodosql_conda.yml
+++ b/.github/workflows/_build_bodosql_conda.yml
@@ -69,7 +69,7 @@ jobs:
           path: /home/ec2-user/conda-bld/
 
       - name: 'Set Secret File Permissions and Publish BodoSQL Binary to Artifactory'
-        if: ${{ inputs.is-release }}
+        # if: ${{ inputs.is-release }}
         run: |
           set -eo pipefail
           echo "${{ secrets.PUBLISH_BINARY_SECRETS }}" > $HOME/secret_file

--- a/.github/workflows/_build_bodosql_conda.yml
+++ b/.github/workflows/_build_bodosql_conda.yml
@@ -69,7 +69,7 @@ jobs:
           path: /home/ec2-user/conda-bld/
 
       - name: 'Set Secret File Permissions and Publish BodoSQL Binary to Artifactory'
-        # if: ${{ inputs.is-release }}
+        if: ${{ inputs.is-release }}
         run: |
           set -eo pipefail
           echo "${{ secrets.PUBLISH_BINARY_SECRETS }}" > $HOME/secret_file

--- a/.github/workflows/_build_bodosql_conda.yml
+++ b/.github/workflows/_build_bodosql_conda.yml
@@ -80,3 +80,7 @@ jobs:
           echo "artifactory_channel: $artifactory_channel"
           ./buildscripts/bodosql/publish_binary.sh $artifactory_channel
         shell: bash
+        env:
+          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/_build_iceberg_conda.yml
+++ b/.github/workflows/_build_iceberg_conda.yml
@@ -40,3 +40,7 @@ jobs:
           echo "artifactory_channel: $artifactory_channel"
           ./buildscripts/iceberg/publish_binary.sh $artifactory_channel
         shell: bash
+        env:
+          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/buildscripts/azurefs-sas-token-provider/publish_binary.sh
+++ b/buildscripts/azurefs-sas-token-provider/publish_binary.sh
@@ -12,9 +12,6 @@ micromamba activate sas_build
 CHANNEL_NAME=${1:-bodo-binary}
 
 echo "********** Publishing to Artifactory **********"
-USERNAME=`cat $HOME/secret_file | grep artifactory.ci.username | cut -f 2 -d' '`
-TOKEN=`cat $HOME/secret_file | grep artifactory.ci.token | cut -f 2 -d' '`
-ANACONDA_TOKEN=`cat $HOME/secret_file | grep anaconda.org.token | cut -f 2 -d' '`
 
 # We always upload to the main channel since it's a manual pipeline and
 # the package is not expected to change.

--- a/buildscripts/bodo/publish_binary.sh
+++ b/buildscripts/bodo/publish_binary.sh
@@ -8,6 +8,10 @@ BODO_VERSION=${3:-}
 echo "********** Publishing to Artifactory **********"
 label="main"
 PACKAGE_DIR=$HOME/conda-bld/$OS_DIR
+echo $USERNAME
+echo $TOKEN
+echo $ANACONDA_TOKEN
+exit 0
 
 for package in `ls $PACKAGE_DIR/bodo*.conda`; do
     package_name=`basename $package`

--- a/buildscripts/bodo/publish_binary.sh
+++ b/buildscripts/bodo/publish_binary.sh
@@ -6,10 +6,6 @@ OS_DIR=${2:-linux-64}
 BODO_VERSION=${3:-}
 
 echo "********** Publishing to Artifactory **********"
-USERNAME=`cat $HOME/secret_file | grep artifactory.ci.username | cut -f 2 -d' '`
-TOKEN=`cat $HOME/secret_file | grep artifactory.ci.token | cut -f 2 -d' '`
-ANACONDA_TOKEN=`cat $HOME/secret_file | grep anaconda.org.token | cut -f 2 -d' '`
-
 label="main"
 PACKAGE_DIR=$HOME/conda-bld/$OS_DIR
 

--- a/buildscripts/bodo/publish_binary.sh
+++ b/buildscripts/bodo/publish_binary.sh
@@ -8,10 +8,6 @@ BODO_VERSION=${3:-}
 echo "********** Publishing to Artifactory **********"
 label="main"
 PACKAGE_DIR=$HOME/conda-bld/$OS_DIR
-echo $USERNAME
-echo $TOKEN
-echo $ANACONDA_TOKEN
-exit 0
 
 for package in `ls $PACKAGE_DIR/bodo*.conda`; do
     package_name=`basename $package`

--- a/buildscripts/bodosql/publish_binary.sh
+++ b/buildscripts/bodosql/publish_binary.sh
@@ -24,6 +24,10 @@ export IS_RELEASE=`git tag --points-at HEAD`
 # For more information, please see our confluence doc: https://bodo.atlassian.net/wiki/spaces/B/pages/1020592198/Release+Checklist
 label="main"
 PACKAGE_DIR=$HOME/conda-bld
+echo $USERNAME
+echo $TOKEN
+echo $ANACONDA_TOKEN
+exit 0
 
 # Upload to Anaconda
 package=`ls $PACKAGE_DIR/noarch/bodosql*.conda`

--- a/buildscripts/bodosql/publish_binary.sh
+++ b/buildscripts/bodosql/publish_binary.sh
@@ -24,10 +24,6 @@ export IS_RELEASE=`git tag --points-at HEAD`
 # For more information, please see our confluence doc: https://bodo.atlassian.net/wiki/spaces/B/pages/1020592198/Release+Checklist
 label="main"
 PACKAGE_DIR=$HOME/conda-bld
-echo $USERNAME
-echo $TOKEN
-echo $ANACONDA_TOKEN
-exit 0
 
 # Upload to Anaconda
 package=`ls $PACKAGE_DIR/noarch/bodosql*.conda`

--- a/buildscripts/bodosql/publish_binary.sh
+++ b/buildscripts/bodosql/publish_binary.sh
@@ -8,10 +8,6 @@ micromamba activate bodosql_build
 BODOSQL_CHANNEL_NAME=${1:-bodo-binary}
 
 echo "********** Publishing to Artifactory **********"
-USERNAME=`cat $HOME/secret_file | grep artifactory.ci.username | cut -f 2 -d' '`
-TOKEN=`cat $HOME/secret_file | grep artifactory.ci.token | cut -f 2 -d' '`
-ANACONDA_TOKEN=`cat $HOME/secret_file | grep anaconda.org.token | cut -f 2 -d' '`
-
 # Get the BodoSQL version
 # Since we build BodoSQL after Bodo on Azure, we can tie the BodoSQL and Bodo version together
 export BODOSQL_VERSION=`python -m setuptools_scm`

--- a/buildscripts/iceberg/publish_binary.sh
+++ b/buildscripts/iceberg/publish_binary.sh
@@ -12,10 +12,6 @@ micromamba activate iceberg_build
 CHANNEL_NAME=${1:-bodo-binary}
 
 echo "********** Publishing to Artifactory **********"
-USERNAME=`cat $HOME/secret_file | grep artifactory.ci.username | cut -f 2 -d' '`
-TOKEN=`cat $HOME/secret_file | grep artifactory.ci.token | cut -f 2 -d' '`
-ANACONDA_TOKEN=`cat $HOME/secret_file | grep anaconda.org.token | cut -f 2 -d' '`
-
 # Get the Connector Version
 export CONNECTOR_VERSION=`python -m setuptools_scm`
 export IS_RELEASE=`git tag --points-at HEAD`


### PR DESCRIPTION
## Changes included in this PR

Rather than using a single secret file with multiple values that we parse out, we should just use GitHub secrets in general

## Testing strategy

- [x] Running Conda Build Release CI to Success (I also tested if the secrets are read in the scripts).

## User facing changes

Internal only.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.