### PR TITLE
Raise error if VS Code Jupyter ZMQ is not disabled

### DIFF
--- a/bodo/submit/spawner.py
+++ b/bodo/submit/spawner.py
@@ -654,9 +654,10 @@ class SubmitDispatcher:
 # See https://github.com/microsoft/vscode-jupyter/issues/16283
 
 vs_code_nb_msg = """
-Please turn off VS Code Jupyter extension's ZMQ to use Bodo in VS Code notebooks.
-Add `"jupyter.disableZMQSupport": true,` to VS Code settings and restart VS Code
-(e.g., using
+VS Code has a problem running MPI (and therefore Bodo) inside Jupyter notebooks.
+To fix it, please turn off VS Code Jupyter extension's ZMQ to use Bodo in VS Code
+notebooks. Add `"jupyter.disableZMQSupport": true,` to VS Code settings and restart
+VS Code (e.g., using
 "Preferences: Open User Settings (JSON)" in Command Pallette (Ctrl/CMD+Shift+P),
 see https://code.visualstudio.com/docs/getstarted/settings#_user-settings).
 """

--- a/bodo/submit/worker.py
+++ b/bodo/submit/worker.py
@@ -493,6 +493,7 @@ def worker_loop(
             exec_func_handler(comm_world, spawner_intercomm, logger)
         elif command == CommandType.EXIT.value:
             debug_worker_msg(logger, "Exiting...")
+            spawner_intercomm.Disconnect()
             return
         elif command == CommandType.BROADCAST.value:
             bodo.libs.distributed_api.bcast(None, root=0, comm=spawner_intercomm)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Raises an error with instructions if Bodo is running inside VS Code notebooks and Jupyter ZMQ isn't disabled (to avoid crashes).

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

Tested manually.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.