### PR TITLE
Handle slicing with negative start/step in lazy wrappers

### DIFF
--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -21,9 +21,6 @@ on:
 
 jobs:
   run:
-    permissions:
-      id-token: write
-      contents: read
     name: Build and Run Tests Helper
     runs-on: self-hosted-medium
     steps:

--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -188,8 +188,8 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
         """
         axis = self._normalize_axis(axis)
 
-        start = slobj.start if slobj.start else 0
-        stop = slobj.stop if slobj.stop else 0
+        # Normalize negative and None start/stop/step values
+        start, stop, step = slobj.indices(len(self))
 
         # TODO Check if this condition is correct.
         if (
@@ -198,6 +198,7 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
             and stop <= self._md_head.shape[1]
             and axis == 0
         ):
+            slobj = slice(start, stop, step)
             tmp_arrs = self._md_head.arrays
             arrays = [arr[slobj] for arr in tmp_arrs]
             new_axes = list(self._axes)
@@ -437,14 +438,16 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
         if axis >= self.ndim:
             raise IndexError("Requested axis not found in manager")
 
-        start = slobj.start if slobj.start else 0
-        stop = slobj.stop if slobj.stop else 0
+        # Normalize negative and None start/stop/step values
+        start, stop, step = slobj.indices(len(self))
+
         if (
             (self._md_head is not None)
             and start <= len(self._md_head)
             and stop <= len(self._md_head)
             and axis == 0
         ):
+            slobj = slice(start, stop, step)
             tmp_arrs = self._md_head.arrays
             arrays = [arr[slobj] for arr in tmp_arrs]
             new_axes = list(self._axes)
@@ -491,9 +494,6 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
         if name == "arrays":
             self._collect()
         return SingleArrayManager.__getattribute__(self, name)
-
-    # BSE-4097
-    # TODO Override __len__
 
     def __del__(self):
         """

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -463,14 +463,16 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
         if axis >= self.ndim:
             raise IndexError("Requested axis not found in manager")
 
-        start = slobj.start if slobj.start else 0
-        stop = slobj.stop if slobj.stop else 0
+        # Normalize negative and None start/stop/step values
+        start, stop, step = slobj.indices(len(self))
+
         if (
             (self._md_head is not None)
             and start <= len(self._md_head)
             and stop <= len(self._md_head)
             and axis == 0
         ):
+            slobj = slice(start, stop, step)
             tmp_block = self._md_head._block
             array = tmp_block.values[slobj]
             bp = BlockPlacement(slice(0, len(array)))

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -421,6 +421,26 @@ def test_slice(pandas_managers, head_df, collect_func):
     lam_sliced_twice_df = lam_sliced_df[10:30]
     assert lam_sliced_twice_df.equals(collect_func(0)["A0"][10:30])
 
+    # Slicing with negative indices (does not trigger a data fetch)
+    lam = lazy_manager(
+        [],
+        [],
+        result_id="abc",
+        nrows=40,
+        head=head_df._mgr,
+        collect_func=collect_func,
+        del_func=del_func,
+    )
+    lam_df: BodoDataFrame = BodoDataFrame.from_lazy_mgr(lam, head_df)
+    lam_sliced_head_df = lam_df.iloc[-38:-37]
+    assert lam_df._lazy
+    assert lam_sliced_head_df.equals(head_df[2:3])
+
+    # Trigger a fetch
+    lam_sliced_head_df = lam_df.iloc[-3:]
+    assert not lam_df._lazy
+    pd.testing.assert_frame_equal(lam_sliced_head_df, collect_func(0)[-3:])
+
 
 @pytest_mark_spawn_mode
 def test_parquet(collect_func):

--- a/bodo/tests/test_lazy/test_bodo_series.py
+++ b/bodo/tests/test_lazy/test_bodo_series.py
@@ -285,3 +285,23 @@ def test_slice(single_pandas_managers, head_s, collect_func, del_func):
     lam_sliced_s = lam_s[10:30]
     assert not lam_s._lazy
     assert lam_sliced_s.tolist() == (collect_func(0)[10:30]).tolist()
+
+    # Slicing with negative indices (does not trigger a data fetch)
+    lsam = lazy_manager(
+        [],
+        [],
+        result_id="abc",
+        nrows=40,
+        head=head_s._mgr,
+        collect_func=collect_func,
+        del_func=del_func,
+    )
+    lam_s: BodoSeries = BodoSeries._from_mgr(lsam, [])
+    lam_sliced_head_s = lam_s[-38:-37]
+    assert lam_s._lazy
+    pd.testing.assert_series_equal(lam_sliced_head_s, head_s[2:3])
+
+    # Triggers a fetch
+    lam_sliced_head_s = lam_s[-3:]
+    assert not lam_s._lazy
+    pd.testing.assert_series_equal(lam_sliced_head_s, collect_func(0)[-3:])


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

As title. The output was wrong, leading to wrong results for prints as well since the print formatters slice the last rows of DataFrame/Series values.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.