### PR TITLE
Fix JSON write is_lines handling

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -323,42 +323,24 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         storage_options=None,
         mode="w",
     ):
-        # argument defaults should match that of to_json_overload in pd_dataframe_ext.py
+        # Argument defaults should match that of to_json_overload in pd_dataframe_ext.py
+        # Passing orient and lines as free vars to become literals in the compiler
 
         @bodo.jit(spawn=True)
         def to_json_wrapper(
             df: pd.DataFrame,
             path_or_buf,
-            orient,
             date_format,
             double_precision,
             force_ascii,
             date_unit,
             default_handler,
-            lines,
             compression,
             index,
             indent,
             storage_options,
             mode,
         ):
-            if orient == "records":
-                # leave out orient in forwarded arguments for it to default back to
-                # Literal["records"] instead of being unicode
-                return df.to_json(
-                    path_or_buf=path_or_buf,
-                    date_format=date_format,
-                    double_precision=double_precision,
-                    force_ascii=force_ascii,
-                    date_unit=date_unit,
-                    default_handler=default_handler,
-                    lines=lines,
-                    compression=compression,
-                    index=index,
-                    indent=indent,
-                    storage_options=storage_options,
-                    mode=mode,
-                )
             return df.to_json(
                 path_or_buf,
                 orient,
@@ -378,13 +360,11 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         to_json_wrapper(
             self,
             path_or_buf,
-            orient,
             date_format,
             double_precision,
             force_ascii,
             date_unit,
             default_handler,
-            lines,
             compression,
             index,
             indent,

--- a/bodo/transforms/distributed_pass.py
+++ b/bodo/transforms/distributed_pass.py
@@ -72,6 +72,7 @@ from bodo.utils.transform import (
 from bodo.utils.typing import (
     BodoError,
     decode_if_dict_array,
+    get_overload_const_bool,
     is_str_arr_type,
     list_cumulative,
     to_str_arr_if_dict_array,
@@ -2848,7 +2849,7 @@ class DistributedPass:
                 lines_var = get_call_expr_arg(
                     "to_json", rhs.args, kws, 7, "lines", None
                 )
-                is_lines = self.typemap[lines_var.name]
+                is_lines = get_overload_const_bool(self.typemap[lines_var.name])
 
             is_records_lines = ir.Var(
                 assign.target.scope, mk_unique_var("is_records_lines"), rhs.loc

--- a/bodo/transforms/distributed_pass.py
+++ b/bodo/transforms/distributed_pass.py
@@ -73,6 +73,8 @@ from bodo.utils.typing import (
     BodoError,
     decode_if_dict_array,
     get_overload_const_bool,
+    get_overload_const_str,
+    is_overload_constant_str,
     is_str_arr_type,
     list_cumulative,
     to_str_arr_if_dict_array,
@@ -2842,14 +2844,25 @@ class DistributedPass:
                     "to_json", rhs.args, kws, 1, "orient", None
                 )
                 orient_val = self.typemap[orient_var.name]
-                is_records = True if orient_val.literal_value == "records" else False
+                if not is_overload_constant_str(orient_val):
+                    raise BodoError(
+                        "orient argument in to_json() must be a constant string"
+                    )
+                is_records = (
+                    True if get_overload_const_str(orient_val) == "records" else False
+                )
 
             is_lines = False
             if "lines" in kws:
                 lines_var = get_call_expr_arg(
                     "to_json", rhs.args, kws, 7, "lines", None
                 )
-                is_lines = get_overload_const_bool(self.typemap[lines_var.name])
+                lines_val = self.typemap[lines_var.name]
+                if not is_overload_constant_str(lines_val):
+                    raise BodoError(
+                        "lines argument in to_json() must be a constant boolean"
+                    )
+                is_lines = get_overload_const_bool(lines_val)
 
             is_records_lines = ir.Var(
                 assign.target.scope, mk_unique_var("is_records_lines"), rhs.loc

--- a/bodo/transforms/distributed_pass.py
+++ b/bodo/transforms/distributed_pass.py
@@ -74,6 +74,7 @@ from bodo.utils.typing import (
     decode_if_dict_array,
     get_overload_const_bool,
     get_overload_const_str,
+    is_overload_constant_bool,
     is_overload_constant_str,
     is_str_arr_type,
     list_cumulative,
@@ -2858,7 +2859,7 @@ class DistributedPass:
                     "to_json", rhs.args, kws, 7, "lines", None
                 )
                 lines_val = self.typemap[lines_var.name]
-                if not is_overload_constant_str(lines_val):
+                if not is_overload_constant_bool(lines_val):
                     raise BodoError(
                         "lines argument in to_json() must be a constant boolean"
                     )


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes some CI failures. For context, the bug was introduced here: https://github.com/bodo-ai/Bodo/pull/17

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Fixes existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.