### PR TITLE
Avoid logging in __del__ functions

### DIFF
--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -261,10 +261,6 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
         otherwise we do nothing because the data is already collected/deleted.
         """
         if (r_id := self._md_result_id) is not None:
-            debug_msg(
-                self.logger,
-                f"[LazyArrayManager] Asking workers to delete result '{r_id}'",
-            )
             assert self._del_func is not None
             self._del_func(r_id)
             self._del_func = None
@@ -501,10 +497,6 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
         otherwise we do nothing because the data is already collected/deleted.
         """
         if (r_id := self._md_result_id) is not None:
-            debug_msg(
-                self.logger,
-                f"[LazySingleArrayManager] Asking workers to delete result '{r_id}'",
-            )
             assert self._del_func is not None
             self._del_func(r_id)
             self._del_func = None

--- a/bodo/pandas/arrow/array.py
+++ b/bodo/pandas/arrow/array.py
@@ -128,10 +128,6 @@ class LazyArrowExtensionArray(
         Delete the result from workers if it exists.
         """
         if (r_id := self._md_result_id) is not None:
-            debug_msg(
-                self.logger,
-                f"[LazyArrowExtensionArray] Asking workers to delete result '{r_id}'",
-            )
             assert self._del_func is not None
             self._del_func(r_id)
             self._del_func = None

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -244,10 +244,6 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
         Delete the result from the workers if it hasn't been collected yet.
         """
         if (r_id := self._md_result_id) is not None:
-            debug_msg(
-                self.logger,
-                f"[LazyBlockManager] Asking workers to delete result '{r_id}'",
-            )
             assert self._del_func is not None
             self._del_func(r_id)
             self._del_func = None
@@ -437,10 +433,6 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
         Delete the result from the workers if it hasn't been collected yet.
         """
         if (r_id := self._md_result_id) is not None:
-            debug_msg(
-                self.logger,
-                f"[LazySingleBlockManager] Asking workers to delete result '{r_id}'",
-            )
             assert self._del_func is not None
             self._del_func(r_id)
             self._del_func = None


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes an issue I noticed when running examples on an AWS instance.
```
Exception ignored in: <function LazyArrowExtensionArray.__del__ at 0x7fc6700efb00>
Traceback (most recent call last):
  File "/home/bodo/.conda/envs/Bodo120/lib/python3.12/site-packages/bodo/pandas/arrow/array.py", line 131, in __del__
  File "/home/bodo/.conda/envs/Bodo120/lib/python3.12/site-packages/bodo/submit/utils.py", line 49, in debug_msg
AttributeError: 'NoneType' object has no attribute 'user_logging'
```
I think it's because logging during atexit is not safe. Adding logs here isn't that critical anyways.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.