### PR TITLE
Add GitHub Repo Link to PyPi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://bodo.ai"
 Documentation = "https://docs.bodo.ai"
+Repository = "https://github.com/bodo-ai/Bodo"
 
 [project.optional-dependencies]
 hdf5 = ["h5py"]


### PR DESCRIPTION
## Changes included in this PR

Add GitHub link to PyProject file so Pip packages, and thus PyPi, will have the location to our repo. https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

## Testing strategy

N/A

## User facing changes

Link to GitHub from PyPi.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.