### PR TITLE
Handle nested objmode functions in UDF inlining

### DIFF
--- a/bodo/tests/test_dataframe_part2.py
+++ b/bodo/tests/test_dataframe_part2.py
@@ -1003,6 +1003,27 @@ def test_df_apply_udf_inline(memory_leak_check):
 
 
 @pytest.mark.slow
+def test_df_apply_udf_inline_objmode(memory_leak_check):
+    """make sure UDFs with nested objmode don't cause compiler failures"""
+
+    @bodo.jit
+    def g(a):
+        with bodo.objmode(out="int64"):
+            out = a + 1
+        return out
+
+    @bodo.jit
+    def f(a):
+        return g(a)
+
+    @bodo.jit
+    def test(S):
+        return S.map(f)
+
+    test(pd.Series([1, 2, 3]))
+
+
+@pytest.mark.slow
 def test_df_apply_supported_types(df_value, memory_leak_check):
     """Test DataFrame.apply with all Bodo supported Types"""
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Makes sure UDF inlining doesn't inline nested functions that have objmode in them since this causes compilation failures. Noticed the issue when trying an AI example.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

Added a unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.