### PR TITLE
[BSE-4415] Support large counts in MPI scatterv

### DIFF
--- a/bodo/libs/_distributed.h
+++ b/bodo/libs/_distributed.h
@@ -123,9 +123,9 @@ static void c_gatherv(void* send_data, int sendcount, void* recv_data,
                       int* recv_counts, int* displs, int typ_enum,
                       bool allgather, int root,
                       int64_t comm_ptr = 0) __UNUSED__;
-static void c_scatterv(void* send_data, int* sendcounts, int* displs,
-                       void* recv_data, int recv_count, int typ_enum, int root,
-                       int64_t comm_ptr) __UNUSED__;
+static void c_scatterv(void* send_data, MPI_Count* sendcounts, MPI_Aint* displs,
+                       void* recv_data, MPI_Count recv_count, int typ_enum,
+                       int root, int64_t comm_ptr) __UNUSED__;
 static void c_allgatherv(void* send_data, int sendcount, void* recv_data,
                          int* recv_counts, int* displs,
                          int typ_enum) __UNUSED__;
@@ -1022,17 +1022,18 @@ static void c_allgatherv(void* send_data, int sendcount, void* recv_data,
     return;
 }
 
-static void c_scatterv(void* send_data, int* sendcounts, int* displs,
-                       void* recv_data, int recv_count, int typ_enum, int root,
-                       int64_t comm_ptr) {
+static void c_scatterv(void* send_data, MPI_Count* sendcounts, MPI_Aint* displs,
+                       void* recv_data, MPI_Count recv_count, int typ_enum,
+                       int root, int64_t comm_ptr) {
+    static_assert(sizeof(MPI_Count) == sizeof(uint64_t));
     MPI_Datatype mpi_typ = get_MPI_typ(typ_enum);
     MPI_Comm comm = MPI_COMM_WORLD;
     // Use provided comm pointer if available (0 means not provided)
     if (comm_ptr != 0) {
         comm = (*reinterpret_cast<MPI_Comm*>(comm_ptr));
     }
-    CHECK_MPI(MPI_Scatterv(send_data, sendcounts, displs, mpi_typ, recv_data,
-                           recv_count, mpi_typ, root, comm),
+    CHECK_MPI(MPI_Scatterv_c(send_data, sendcounts, displs, mpi_typ, recv_data,
+                             recv_count, mpi_typ, root, comm),
               "_distributed.h::c_scatterv: MPI error on MPI_Scatterv:");
 }
 

--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -2310,7 +2310,7 @@ def scatterv_impl_jit(
             displs = bodo.ir.join.calc_disp(send_counts)
 
             # compute send counts for items
-            send_counts_item = np.empty(n_pes, np.int32)
+            send_counts_item = np.empty(n_pes, np.int64)
             if is_sender:
                 curr_item = 0
                 for i in range(n_pes):

--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -596,7 +596,7 @@ c_scatterv = types.ExternalFunction(
         types.voidptr,
         types.voidptr,
         types.voidptr,
-        types.int32,
+        types.int64,
         types.int32,
         types.int32,
         types.int64,
@@ -1759,7 +1759,7 @@ def _get_scatterv_send_counts(send_counts, n_pes, n):
 
     def impl(send_counts, n_pes, n):  # pragma: no cover
         # compute send counts if not available
-        send_counts = np.empty(n_pes, np.int32)
+        send_counts = np.empty(n_pes, np.int64)
         for i in range(n_pes):
             send_counts[i] = get_node_portion(n, n_pes, i)
         return send_counts
@@ -1813,7 +1813,7 @@ def _scatterv_np(data, send_counts=None, warn_if_dist=True, root=DEFAULT_ROOT, c
             send_counts.ctypes,
             displs.ctypes,
             recv_data.ctypes,
-            np.int32(n_loc),
+            np.int64(n_loc),
             np.int32(typ_val),
             root,
             comm,
@@ -2188,7 +2188,7 @@ def scatterv_impl_jit(
             displs = bodo.ir.join.calc_disp(send_counts)
 
             # compute send counts for characters
-            send_counts_char = np.empty(n_pes, np.int32)
+            send_counts_char = np.empty(n_pes, np.int64)
             if is_sender:
                 curr_str = 0
                 for i in range(n_pes):
@@ -2206,7 +2206,7 @@ def scatterv_impl_jit(
             displs_char = bodo.ir.join.calc_disp(send_counts_char)
 
             # compute send counts for nulls
-            send_counts_nulls = np.empty(n_pes, np.int32)
+            send_counts_nulls = np.empty(n_pes, np.int64)
             for i in range(n_pes):
                 send_counts_nulls[i] = (send_counts[i] + 7) >> 3
 
@@ -2226,7 +2226,7 @@ def scatterv_impl_jit(
                 send_counts.ctypes,
                 displs.ctypes,
                 recv_lens.ctypes,
-                np.int32(n_loc),
+                np.int64(n_loc),
                 int32_typ_enum,
                 root,
                 comm,
@@ -2245,7 +2245,7 @@ def scatterv_impl_jit(
                 send_counts_char.ctypes,
                 displs_char.ctypes,
                 bodo.libs.str_arr_ext.get_data_ptr(recv_arr),
-                np.int32(n_loc_char),
+                np.int64(n_loc_char),
                 char_typ_enum,
                 root,
                 comm,
@@ -2267,7 +2267,7 @@ def scatterv_impl_jit(
                 send_counts_nulls.ctypes,
                 displs_nulls.ctypes,
                 bodo.libs.str_arr_ext.get_null_bitmap_ptr(recv_arr),
-                np.int32(n_recv_bytes),
+                np.int64(n_recv_bytes),
                 char_typ_enum,
                 root,
                 comm,
@@ -2325,7 +2325,7 @@ def scatterv_impl_jit(
             )
 
             # compute send counts for nulls
-            send_counts_nulls = np.empty(n_pes, np.int32)
+            send_counts_nulls = np.empty(n_pes, np.int64)
             for i in range(n_pes):
                 send_counts_nulls[i] = (send_counts[i] + 7) >> 3
 
@@ -2350,7 +2350,7 @@ def scatterv_impl_jit(
                 send_counts.ctypes,
                 displs.ctypes,
                 recv_lens.ctypes,
-                np.int32(n_loc),
+                np.int64(n_loc),
                 int32_typ_enum,
                 root,
                 comm,
@@ -2371,7 +2371,7 @@ def scatterv_impl_jit(
                 send_counts_nulls.ctypes,
                 displs_nulls.ctypes,
                 recv_null_bitmap_arr.ctypes,
-                np.int32(n_recv_null_bytes),
+                np.int64(n_recv_null_bytes),
                 char_typ_enum,
                 root,
                 comm,
@@ -2406,7 +2406,7 @@ def scatterv_impl_jit(
             # Calculate number of local output elements
             n_loc = np.int64(0 if (is_intercomm and is_sender) else send_counts[rank])
             # compute send counts bytes
-            send_counts_bytes = np.empty(n_pes, np.int32)
+            send_counts_bytes = np.empty(n_pes, np.int64)
             for i in range(n_pes):
                 send_counts_bytes[i] = (send_counts[i] + 7) >> 3
 
@@ -2430,7 +2430,7 @@ def scatterv_impl_jit(
                 send_counts_bytes.ctypes,
                 displs_bytes.ctypes,
                 data_recv.ctypes,
-                np.int32(n_recv_bytes),
+                np.int64(n_recv_bytes),
                 char_typ_enum,
                 root,
                 comm,
@@ -2440,7 +2440,7 @@ def scatterv_impl_jit(
                 send_counts_bytes.ctypes,
                 displs_bytes.ctypes,
                 bitmap_recv.ctypes,
-                np.int32(n_recv_bytes),
+                np.int64(n_recv_bytes),
                 char_typ_enum,
                 root,
                 comm,
@@ -2595,7 +2595,7 @@ def scatterv_impl_jit(
             send_counts = _get_scatterv_send_counts(send_counts, n_pes, n_all)
 
             # compute send counts for nulls
-            send_counts_nulls = np.empty(n_pes, np.int32)
+            send_counts_nulls = np.empty(n_pes, np.int64)
             for i in range(n_pes):
                 send_counts_nulls[i] = (send_counts[i] + 7) >> 3
 
@@ -2611,7 +2611,7 @@ def scatterv_impl_jit(
                 send_counts_nulls.ctypes,
                 displs_nulls.ctypes,
                 bitmap_recv.ctypes,
-                np.int32(n_recv_bytes),
+                np.int64(n_recv_bytes),
                 char_typ_enum,
                 root,
                 comm,
@@ -3011,7 +3011,7 @@ def _scatterv_null_bitmap(null_bitmap, send_counts, n_in, root, comm):
     bitmap_recv = np.empty(n_recv_bytes, np.uint8)
 
     # compute send counts for nulls
-    send_counts_nulls = np.empty(n_pes, np.int32)
+    send_counts_nulls = np.empty(n_pes, np.int64)
     for i in range(n_pes):
         send_counts_nulls[i] = (send_counts[i] + 7) >> 3
 
@@ -3027,7 +3027,7 @@ def _scatterv_null_bitmap(null_bitmap, send_counts, n_in, root, comm):
         send_counts_nulls.ctypes,
         displs_nulls.ctypes,
         bitmap_recv.ctypes,
-        np.int32(n_recv_bytes),
+        np.int64(n_recv_bytes),
         char_typ_enum,
         root,
         comm,

--- a/bodo/tests/test_distributed.py
+++ b/bodo/tests/test_distributed.py
@@ -2364,6 +2364,7 @@ def get_random_int64index(n):
             .astype(dtype=pd.ArrowDtype(pa.large_list(pa.large_string())))
             .values,
             marks=pytest.mark.slow,
+            id="array_item_array_string",
         ),
         pytest.param(
             pd.Series(


### PR DESCRIPTION
## Changes included in this PR

Changes scatterv to use [scatterv_c](https://www.mpich.org/static/docs/v4.0.2/www3/MPI_Scatterv_c.html) to support larger send counts. 

## Testing strategy

PR CI, Nightly, local testing:

```py
import pandas as pd
import bodo

@bodo.jit
def test(df):
    return df.A.str.len().sum()

df = pd.DataFrame({"A": ["abcd"*10000]*1000000})
print(test(df))
```
Now fails with a different error:
`bodo.utils.typing.BodoError: data type string for column A not supported yet`
which is really supposed to be pyarrow memory error `Could not find an empty frame of required size (68719476736)!` from trying to fit an array that is too large (37 gb) into memory, but the exception gets caught in `boxing._infer_series_arr_type` and overwritten. I think we should ideally fix the error handling here so that the error is more helpful.

But if we decrease the size of the outer array to 100000 (~4 gb) then it runs on this branch but not on main.

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.