### PR TITLE
Make bodo compatible with newer pandas versions to enable UDF engine support

### DIFF
--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -5289,7 +5289,7 @@ def overload_union_dataframes(
 
 
 # Throw BodoError for top-level unsupported functions in Pandas
-pd_unsupported = (
+pd_unsupported = [
     # Input/output
     pd.read_pickle,
     pd.read_table,
@@ -5324,7 +5324,13 @@ pd_unsupported = (
     pd.test,
     # GroupBy
     pd.Grouper,
-)
+]
+
+# Newer versions of pandas do not have pd.read_gbq
+try:
+    pd_unsupported.append(pd.read_gbq)
+except ModuleNotFoundError:
+    pass
 
 
 pd_util_unsupported = (

--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -5329,7 +5329,7 @@ pd_unsupported = [
 # Newer versions of pandas do not have pd.read_gbq
 try:
     pd_unsupported.append(pd.read_gbq)
-except ModuleNotFoundError:
+except AttributeError:
     pass
 
 

--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -5304,7 +5304,6 @@ pd_unsupported = (
     pd.read_sas,
     pd.read_spss,
     pd.read_sql_query,
-    pd.read_gbq,
     pd.read_stata,
     pd.ExcelWriter,
     pd.json_normalize,

--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -5326,10 +5326,11 @@ pd_unsupported = [
     pd.Grouper,
 ]
 
-# Newer versions of pandas do not have pd.read_gbq
+
 try:
     pd_unsupported.append(pd.read_gbq)
 except AttributeError:
+    # pd.read_gbq is not supported in Pandas > 2.2
     pass
 
 

--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -7,7 +7,17 @@ import numpy as np
 import pandas as pd
 from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays.arrow.array import ArrowExtensionArray
-from pandas.core.internals.array_manager import ArrayManager, SingleArrayManager
+
+try:
+    from pandas.core.internals.array_manager import ArrayManager, SingleArrayManager
+except ModuleNotFoundError:
+    # newer versions of pandas do not support ArrayManager/SingleArrayManager (only use BlockManager)
+    class ArrayManager:
+        pass
+
+    class SingleArrayManager:
+        pass
+
 
 import bodo.user_logging
 from bodo.pandas.lazy_metadata import LazyMetadataMixin

--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -11,7 +11,7 @@ from pandas.core.arrays.arrow.array import ArrowExtensionArray
 try:
     from pandas.core.internals.array_manager import ArrayManager, SingleArrayManager
 except ModuleNotFoundError:
-    # newer versions of pandas do not support ArrayManager/SingleArrayManager (only use BlockManager)
+    # Pandas > 2.2 does not have an array_manager module (uses BlockManager/SinglBlockManager).
     class ArrayManager:
         pass
 

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -12,7 +12,7 @@ def get_data_manager_pandas() -> str:
         from pandas._config.config import _get_option
 
         return _get_option("mode.data_manager", silent=True)
-    except ModuleNotFoundError:
+    except ImportError:
         # _get_option and mode.data_manager are not supported in Pandas > 2.2.
         return "block"
 

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -1,4 +1,11 @@
-from pandas._config.config import _get_option
+try:
+    from pandas._config.config import _get_option
+except ModuleNotFoundError:
+    # newer versions of pandas remove _get_option API and `mode.data_manager` option
+    def _get_option(path, silent=True):
+        assert path == "mode.data_manager"
+        return "block"
+
 
 from bodo.pandas.array_manager import LazyArrayManager, LazySingleArrayManager
 from bodo.pandas.managers import LazyBlockManager, LazySingleBlockManager

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -13,7 +13,7 @@ def get_data_manager_pandas() -> str:
 
         return _get_option("mode.data_manager", silent=True)
     except ModuleNotFoundError:
-        # _get_option and mode.data_manager are not supported in newer Pandas versions.
+        # _get_option and mode.data_manager are not supported in Pandas > 2.2.
         return "block"
 
 

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -1,19 +1,25 @@
-try:
-    from pandas._config.config import _get_option
-except ModuleNotFoundError:
-    # newer versions of pandas remove _get_option API and `mode.data_manager` option
-    def _get_option(path, silent=True):
-        assert path == "mode.data_manager"
-        return "block"
-
-
 from bodo.pandas.array_manager import LazyArrayManager, LazySingleArrayManager
 from bodo.pandas.managers import LazyBlockManager, LazySingleBlockManager
 
 
+def get_data_manager_pandas() -> str:
+    """Get the value of mode.data_manager from pandas config.
+
+    Returns:
+        str: The value of the mode.data_manager option or 'block'
+    """
+    try:
+        from pandas._config.config import _get_option
+
+        return _get_option("mode.data_manager", silent=True)
+    except ModuleNotFoundError:
+        # _get_option and mode.data_manager are not supported in newer Pandas versions.
+        return "block"
+
+
 def get_lazy_manager_class() -> type[LazyArrayManager | LazyBlockManager]:
     """Get the lazy manager class based on the pandas option mode.data_manager, suitable for DataFrame."""
-    data_manager = _get_option("mode.data_manager", silent=True)
+    data_manager = get_data_manager_pandas()
     if data_manager == "block":
         return LazyBlockManager
     elif data_manager == "array":
@@ -27,7 +33,7 @@ def get_lazy_single_manager_class() -> (
     type[LazySingleArrayManager | LazySingleBlockManager]
 ):
     """Get the lazy manager class based on the pandas option mode.data_manager, suitable for Series."""
-    data_manager = _get_option("mode.data_manager", silent=True)
+    data_manager = get_data_manager_pandas()
     if data_manager == "block":
         return LazySingleBlockManager
     elif data_manager == "array":


### PR DESCRIPTION
## Changes included in this PR

Currently import bodo and running simple jit functions in the pandas development environment does not work because the pandas version is newer and some module/apis have been removed.

`SingleArrayManager`, `ArrayManager` and `_get_option` are removed in newer versions of pandas. Fill them with dummy values if they can't be imported since `BlockManager`/`SingleBlockManager` is always used.

`pd.read_gbq` was removed in newer pandas versions

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

Unit tests added to pandas repo

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

No.

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.