### PR TITLE
Disable the ARM Nightly Tests

### DIFF
--- a/azure-release-pipelines.yml
+++ b/azure-release-pipelines.yml
@@ -131,100 +131,100 @@ stages:
 
 
  # ------------------------------- ARM Tests -------------------------------- #
-- stage: Test_Bodo_ARM
-  displayName: 'Test Bodo on Linux ARM'
-  dependsOn: []
-  jobs:
-  - template: buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
-    parameters:
-      # Note: name is used later in the buildscripts to determine which version of conda to install
-      name: Bodo_Tests
-      caching_test: false
-      spawn_mode_test: false
-      pool_name: 'ARM-VMSet'
-      matrix:
-        ${{ each slice in split(variables.bodo_1p_each, ',') }}:
-          ${{ format('BODO_1P_{0}_OF_{1}', slice, variables.bodo_1p_total) }}:
-            NP: 1
-            PYTEST_MARKER: ${{ format('bodo_{0}of{1} and ({2})', slice, variables.bodo_1p_total, parameters.PYTEST_MARKER) }}
-        ${{ each slice in split(variables.bodo_2p_each, ',') }}:
-          ${{ format('BODO_2P_{0}_OF_{1}', slice, variables.bodo_2p_total) }}:
-            NP: 2
-            PYTEST_MARKER: ${{ format('bodo_{0}of{1} and ({2})', slice, variables.bodo_2p_total, parameters.PYTEST_MARKER) }}
+# - stage: Test_Bodo_ARM
+#   displayName: 'Test Bodo on Linux ARM'
+#   dependsOn: []
+#   jobs:
+#   - template: buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+#     parameters:
+#       # Note: name is used later in the buildscripts to determine which version of conda to install
+#       name: Bodo_Tests
+#       caching_test: false
+#       spawn_mode_test: false
+#       pool_name: 'ARM-VMSet'
+#       matrix:
+#         ${{ each slice in split(variables.bodo_1p_each, ',') }}:
+#           ${{ format('BODO_1P_{0}_OF_{1}', slice, variables.bodo_1p_total) }}:
+#             NP: 1
+#             PYTEST_MARKER: ${{ format('bodo_{0}of{1} and ({2})', slice, variables.bodo_1p_total, parameters.PYTEST_MARKER) }}
+#         ${{ each slice in split(variables.bodo_2p_each, ',') }}:
+#           ${{ format('BODO_2P_{0}_OF_{1}', slice, variables.bodo_2p_total) }}:
+#             NP: 2
+#             PYTEST_MARKER: ${{ format('bodo_{0}of{1} and ({2})', slice, variables.bodo_2p_total, parameters.PYTEST_MARKER) }}
 
-  - template: buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
-    parameters:
-      name: Linux_cache
-      caching_test: true
-      spawn_mode_test: false
-      pool_name: 'ARM-VMSet'
-      matrix:
-        TEST_2P:
-          NP: 2
-          PYTEST_MARKER: ""
+#   - template: buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+#     parameters:
+#       name: Linux_cache
+#       caching_test: true
+#       spawn_mode_test: false
+#       pool_name: 'ARM-VMSet'
+#       matrix:
+#         TEST_2P:
+#           NP: 2
+#           PYTEST_MARKER: ""
     
-  - template: buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
-    parameters:
-      name: Bodo_Spawn_mode_tests
-      caching_test: false
-      spawn_mode_test: true
-      pool_name: 'ARM-VMSet'
-      matrix:
-        TEST_1P:
-          NP: 1
-          PYTEST_MARKER: "spawn_mode"
-        TEST_2P:
-          NP: 2
-          PYTEST_MARKER: "spawn_mode"
+#   - template: buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+#     parameters:
+#       name: Bodo_Spawn_mode_tests
+#       caching_test: false
+#       spawn_mode_test: true
+#       pool_name: 'ARM-VMSet'
+#       matrix:
+#         TEST_1P:
+#           NP: 1
+#           PYTEST_MARKER: "spawn_mode"
+#         TEST_2P:
+#           NP: 2
+#           PYTEST_MARKER: "spawn_mode"
 
 
-- stage: Test_BodoSQL_ARM
-  displayName: 'Test BodoSQL on Linux ARM'
-  dependsOn: []
-  jobs:
+# - stage: Test_BodoSQL_ARM
+#   displayName: 'Test BodoSQL on Linux ARM'
+#   dependsOn: []
+#   jobs:
 
-  - template: buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
-    parameters:
-      # Note: this name is not important, as we explicitly check uname to determine the os
-      # for the bodoSQL tests
-      name: BodoSQL_Streaming_Tests
-      SPAWN_MODE_TEST: false
-      pool_name: 'ARM-VMSet'
-      matrix:
-        ${{ each slice in split(variables.bodosql_1p_each, ',') }}:
-          ${{ format('BODOSQL_1P_{0}_OF_{1}', slice, variables.bodosql_1p_total) }}:
-            NP: 1
-            PYTEST_MARKER: ${{ format('bodosql_{0}of{1} and ({2})', slice, variables.bodosql_1p_total, parameters.PYTEST_MARKER) }}
-        ${{ each slice in split(variables.bodosql_2p_each, ',') }}:
-          ${{ format('BODOSQL_2P_{0}_OF_{1}', slice, variables.bodosql_2p_total) }}:
-            NP: 2
-            PYTEST_MARKER: ${{ format('bodosql_{0}of{1} and ({2})', slice, variables.bodosql_2p_total, parameters.PYTEST_MARKER) }}
+#   - template: buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
+#     parameters:
+#       # Note: this name is not important, as we explicitly check uname to determine the os
+#       # for the bodoSQL tests
+#       name: BodoSQL_Streaming_Tests
+#       SPAWN_MODE_TEST: false
+#       pool_name: 'ARM-VMSet'
+#       matrix:
+#         ${{ each slice in split(variables.bodosql_1p_each, ',') }}:
+#           ${{ format('BODOSQL_1P_{0}_OF_{1}', slice, variables.bodosql_1p_total) }}:
+#             NP: 1
+#             PYTEST_MARKER: ${{ format('bodosql_{0}of{1} and ({2})', slice, variables.bodosql_1p_total, parameters.PYTEST_MARKER) }}
+#         ${{ each slice in split(variables.bodosql_2p_each, ',') }}:
+#           ${{ format('BODOSQL_2P_{0}_OF_{1}', slice, variables.bodosql_2p_total) }}:
+#             NP: 2
+#             PYTEST_MARKER: ${{ format('bodosql_{0}of{1} and ({2})', slice, variables.bodosql_2p_total, parameters.PYTEST_MARKER) }}
 
-  - template: buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
-    parameters:
-      # Note: this name is not important, as we explicitly pass CACHE_TEST and
-      # check uname to determine the os for the bodoSQL tests
-      name: BodoSQL_Streaming_Caching_Tests
-      CACHE_TEST: true
-      SPAWN_MODE_TEST: false
-      pool_name: 'ARM-VMSet'
-      matrix:
-        TEST_2P:
-          NP: 2
-          PYTEST_MARKER: ""
+#   - template: buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
+#     parameters:
+#       # Note: this name is not important, as we explicitly pass CACHE_TEST and
+#       # check uname to determine the os for the bodoSQL tests
+#       name: BodoSQL_Streaming_Caching_Tests
+#       CACHE_TEST: true
+#       SPAWN_MODE_TEST: false
+#       pool_name: 'ARM-VMSet'
+#       matrix:
+#         TEST_2P:
+#           NP: 2
+#           PYTEST_MARKER: ""
   
-  - template: buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
-    parameters:
-      # Note: this name is not important, as we explicitly pass CACHE_TEST and
-      # check uname to determine the os for the bodoSQL tests
-      name: BodoSQL_Streaming_Spawn_mode_tests
-      CACHE_TEST: false
-      SPAWN_MODE_TEST: true
-      pool_name: 'ARM-VMSet'
-      matrix:
-        TEST_1P:
-          NP: 1
-          PYTEST_MARKER: "spawn_mode"
-        TEST_2P:
-          NP: 2
-          PYTEST_MARKER: "spawn_mode"
+#   - template: buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
+#     parameters:
+#       # Note: this name is not important, as we explicitly pass CACHE_TEST and
+#       # check uname to determine the os for the bodoSQL tests
+#       name: BodoSQL_Streaming_Spawn_mode_tests
+#       CACHE_TEST: false
+#       SPAWN_MODE_TEST: true
+#       pool_name: 'ARM-VMSet'
+#       matrix:
+#         TEST_1P:
+#           NP: 1
+#           PYTEST_MARKER: "spawn_mode"
+#         TEST_2P:
+#           NP: 2
+#           PYTEST_MARKER: "spawn_mode"


### PR DESCRIPTION
## Changes included in this PR

This PR fixes a mistake made in the Linux ARM PR. We had some permission issues setting up a VM agent pool on Azure for ARM testing, but it was accidentally merged into main. Thus, we will disable the ARM parts for now.

## Testing strategy

N/A

## User facing changes

Internal only

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.