### PR TITLE
BSE-4403: Fix hdf5 import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,10 +592,13 @@ if (NOT (CMAKE_BUILD_TYPE STREQUAL "Release") AND NOT DEFINED ENV{BODO_SKIP_CPP_
     "bodo/tests/test_theta_sketches.cpp")
 endif()
 
-set(NO_HDF5 "$ENV{NO_HDF5}")
-if(NOT NO_HDF5)
+if($"ENV{NO_HDF5}" STREQUAL "1")
+    set(NO_HDF5 TRUE)
+else()
     list(APPEND sources_list "bodo/io/_hdf5.cpp")
+    set(NO_HDF5 FALSE)
 endif()
+cmake_print_variables(NO_HDF5)
 
 python_add_library(ext MODULE WITH_SOABI "${sources_list}")
 

--- a/bodo/io/h5_api.py
+++ b/bodo/io/h5_api.py
@@ -29,7 +29,7 @@ if bodo.utils.utils.has_supported_h5py():
     import h5py
     import llvmlite.binding as ll
 
-    from bodo.io import _hdf5
+    from bodo.ext import _hdf5
 
     ll.add_symbol("h5_open", _hdf5.h5_open)
     ll.add_symbol("h5_open_dset_or_group_obj", _hdf5.h5_open_dset_or_group_obj)

--- a/bodo/utils/utils.py
+++ b/bodo/utils/utils.py
@@ -1489,7 +1489,7 @@ def has_supported_h5py() -> bool:
     try:
         import h5py  # noqa
 
-        from bodo.io import _hdf5  # noqa
+        from bodo.ext import _hdf5  # noqa
 
         # TODO: make sure h5py/hdf5 supports parallel
     except ImportError:


### PR DESCRIPTION
## Changes included in this PR
The import path for the hdf5 module changed and needed to be updated, also the CMake logic around NO_HDF5 was simplified.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
bodo/tests/test_basic.py::test_pure_func locally and PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
NA
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.