### PR TITLE
Move intervalToNanos out of the Calcite files and into our parser utils functions

### DIFF
--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.rex;
 
 import com.bodosql.calcite.application.BodoSQLTypeSystems.BodoSQLRelDataTypeSystem;
+import com.bodosql.calcite.sql.parser.SqlBodoParserUtil;
 import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.avatica.util.DateTimeUtils;
 import org.apache.calcite.avatica.util.TimeUnit;
@@ -857,7 +858,7 @@ public class RexLiteral extends RexNode {
       // Bodo Change: Compute nanoseconds instead of milliseconds
       // Bodo Change: Include the type system
       long nanos =
-          SqlParserUtil.intervalToNanos(
+          SqlBodoParserUtil.intervalToNanos(
               literal,
               castNonNull(type.getIntervalQualifier()),
               typeSystem);

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/SqlLiteral.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/SqlLiteral.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.sql;
 
 import com.bodosql.calcite.application.BodoSQLTypeSystems.BodoSQLRelDataTypeSystem;
+import com.bodosql.calcite.sql.parser.SqlBodoParserUtil;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.rel.metadata.NullSentinel;
@@ -408,7 +409,7 @@ public class SqlLiteral extends SqlNode {
         return clazz.cast(getValueAs(BigDecimal.class, typeSystem).longValue());
       } else if (clazz == BigDecimal.class) {
         // Bodo Change: Include typeSystem and compute with nanoseconds
-        long timeInNanos = valTime.getSign() * SqlParserUtil.intervalToNanos(valTime, typeSystem);
+        long timeInNanos = valTime.getSign() * SqlBodoParserUtil.intervalToNanos(valTime, typeSystem);
         BigDecimal factor = BigDecimal.ONE.scaleByPowerOfTen(6);
         BigDecimal timeInMillis = null;
         if (typeName != SqlTypeName.INTERVAL_SECOND) {
@@ -506,7 +507,7 @@ public class SqlLiteral extends SqlNode {
         final SqlIntervalLiteral.IntervalValue valTime =
             literal.getValueAs(SqlIntervalLiteral.IntervalValue.class);
         // Bodo Change: Include typeSystem
-        return valTime.getSign() * SqlParserUtil.intervalToNanos(valTime, typeSystem);
+        return valTime.getSign() * SqlBodoParserUtil.intervalToNanos(valTime, typeSystem);
       default:
         break;
       }

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -479,51 +479,6 @@ public final class SqlParserUtil {
   }
 
   /**
-   * Converts the interval value into a millisecond representation.
-   *
-   * @param interval Interval
-   * @return a long value that represents millisecond equivalent of the
-   * interval value.
-   *
-   * Bodo Change: intervalToMillis has been replaced by intervalToNanos.
-   */
-  public static long intervalToNanos(
-      SqlIntervalLiteral.IntervalValue interval, RelDataTypeSystem typeSystem) {
-    return intervalToNanos(
-        interval.getIntervalLiteral(),
-        interval.getIntervalQualifier(),
-        typeSystem);
-  }
-
-  public static long intervalToNanos(
-      String literal,
-      SqlIntervalQualifier intervalQualifier, RelDataTypeSystem typeSystem) {
-    checkArgument(!intervalQualifier.isYearMonth(),
-        "interval must be day time");
-    int[] ret;
-    try {
-      ret =
-          intervalQualifier.evaluateIntervalLiteral(literal,
-              intervalQualifier.getParserPosition(), typeSystem);
-    } catch (CalciteContextException e) {
-      throw new RuntimeException("while parsing day-to-second interval "
-          + literal, e);
-    }
-    long l = 0;
-    long[] conv = new long[6];
-    conv[5] = 1; // nanosecond
-    conv[4] = 1000000; // millisecond
-    conv[3] = conv[4] * 1000; // second
-    conv[2] = conv[3] * 60; // minute
-    conv[1] = conv[2] * 60; // hour
-    conv[0] = conv[1] * 24; // day
-    for (int i = 1; i < ret.length; i++) {
-      l += conv[i - 1] * ret[i];
-    }
-    return ret[0] * l;
-  }
-
-  /**
    * Converts the interval value into a months representation.
    *
    * @param interval Interval


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Changes to `SqlParserUtil.java` should only be those breaking changes that we need to back port into importing Calcite (and should only be done when we do not actively include all uses of the file already in our source code). Since `intervalToNanos`, which is meant to replace the `intervalToMilli` in Calcite requires a new function signature, every usage must exist inside our source code, so it should existing our extension files.

Ideally in the future we could also remove `SqlParserUtil` in general, but right now we need the remaining changes to ensure we get some default precisions because of its reuse in the validator. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.