### PR TITLE
BSE-4460: Add java test infra to PR CI

### DIFF
--- a/.github/workflows/_test_java_source.yml
+++ b/.github/workflows/_test_java_source.yml
@@ -14,7 +14,7 @@ jobs:
             distribution: 'temurin'
             java-version: '11'
             cache: 'maven'
-            cache-dependency-path: 'Bodo/BodoSQL/calcite_sql/bodosql-calcite-application/pom.xml'
+            cache-dependency-path: 'BodoSQL/calcite_sql/bodosql-calcite-application/pom.xml'
         - name: Set up Maven
           uses: stCarolas/setup-maven@v5
           with:

--- a/.github/workflows/_test_java_source.yml
+++ b/.github/workflows/_test_java_source.yml
@@ -1,0 +1,33 @@
+name: Run Java Tests (Linux)
+on:
+  workflow_call:
+jobs:
+  run:
+    name: Build and Run Tests
+    runs-on: ubuntu-latest
+    steps:
+        # Setup
+        - uses: actions/checkout@v4
+        - name: Install Java
+          uses: actions/setup-java@v4
+          with:
+            distribution: 'temurin'
+            java-version: '11'
+            cache: 'maven'
+            cache-dependency-path: 'Bodo/BodoSQL/calcite_sql/bodosql-calcite-application/pom.xml'
+        - name: Set up Maven
+          uses: stCarolas/setup-maven@v5
+          with:
+            maven-version: 3.9.9
+        - name: Run Tests
+          working-directory: BodoSQL/calcite_sql
+          run: |
+            mvn -B -U test
+        # Publishing Test Results
+        # Always run both even if tests fail
+        - name: Publish Test Result Failures
+          uses: mikepenz/action-junit-report@v4
+
+          if: success() || failure()
+          with:
+            report_paths: 'BodoSQL/calcite_sql/bodosql-calcite-application/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -121,6 +121,10 @@ jobs:
 
   java-ci:
     name: Test Java
+    needs: [validate]
+    if: |
+      needs.validate.outputs.run_tests == 'true' &&
+      needs.validate.outputs.run_bodosql_customer_tests == 'true'
     uses: ./.github/workflows/_test_java_source.yml
 
 

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -43,7 +43,7 @@ jobs:
         id: check_msg
         run: |
           set -xe pipefail
-          echo "commit_message=$(git log -1 --pretty=format:'%s')" >> $GITHUB_OUTPUT
+          echo "commit_message=$(git log -1 --pretty=format:'%s')" >> "$GITHUB_OUTPUT"
 
   # 2) Trigger BodoSQL Customer tests
   bodosql-customer-tests:
@@ -118,6 +118,12 @@ jobs:
       pytest-marker: "spawn_mode"
       collect-coverage: false
     secrets: inherit
+
+  java-ci:
+    name: Test Java
+    uses: ./.github/workflows/_test_java_source.yml
+
+
 
   # 5) Collect and combine any results from runs
   collect-results:

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/CodegenFrameTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/CodegenFrameTest.kt
@@ -1,0 +1,134 @@
+package com.bodosql.calcite.ir
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CodegenFrameTest {
+    @Test
+    fun testEmit() {
+        val frame = CodegenFrame()
+        frame.add(Op.Assign(Variable("v1"), Expr.Raw("1")))
+        frame.add(Op.Assign(Variable("v2"), Expr.Raw("v1 + 3")))
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            v1 = 1
+            v2 = v1 + 3
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testAppend() {
+        val frame = CodegenFrame()
+        // Single line.
+        frame.append("a = 1\n")
+        // Test multiple lines being explicitly appended
+        frame.append("b = [\n")
+        frame.append("  1,\n")
+        frame.append("  2,\n")
+        frame.append("]\n")
+
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            a = 1
+            b = [
+              1,
+              2,
+            ]
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testPrependAll() {
+        val frame = CodegenFrame()
+        val op1 = Op.Assign(Variable("first"), Expr.IntegerLiteral(1))
+        val op2 = Op.Assign(Variable("second"), Expr.IntegerLiteral(2))
+        val op3 = Op.Assign(Variable("third"), Expr.IntegerLiteral(3))
+        frame.add(op3)
+        frame.prependAll(listOf(op1, op2))
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            first = 1
+            second = 2
+            third = 3
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testPrependAllEmpty() {
+        val frame = CodegenFrame()
+        val op1 = Op.Assign(Variable("first"), Expr.IntegerLiteral(1))
+        frame.add(op1)
+        frame.prependAll(listOf())
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            first = 1
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testAddBeforeReturn() {
+        val frame = CodegenFrame()
+        val op1 = Op.Assign(Variable("first"), Expr.IntegerLiteral(1))
+        val ret = Op.ReturnStatement(Variable("first"))
+        val op2 = Op.Assign(Variable("second"), Expr.IntegerLiteral(2))
+        frame.add(op1)
+        frame.add(ret)
+        frame.addBeforeReturn(op2)
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            first = 1
+            second = 2
+            return first
+            
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testAddBeforeReturnNoReturn() {
+        val frame = CodegenFrame()
+        val op1 = Op.Assign(Variable("first"), Expr.IntegerLiteral(1))
+        val op2 = Op.Assign(Variable("second"), Expr.IntegerLiteral(2))
+        frame.add(op1)
+        frame.addBeforeReturn(op2)
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            first = 1
+            second = 2
+            
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+}

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/ExprTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/ExprTest.kt
@@ -1,0 +1,499 @@
+package com.bodosql.calcite.ir
+
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExprTest {
+    @Test
+    fun emitRaw() {
+        val expr = Expr.Raw("1 + 2")
+        assertEquals("1 + 2", expr.emit())
+    }
+
+    @Test
+    fun emitCall() {
+        // Call with a single argument.
+        val call1 = Expr.Call("foo", listOf(Variable("a")))
+        assertEquals("foo(a)", call1.emit())
+
+        // No arguments works fine.
+        val call2 = Expr.Call("noargs")
+        assertEquals("noargs()", call2.emit())
+
+        // Multiple parameters produce commas.
+        val call3 =
+            Expr.Call(
+                "manyparams",
+                listOf(
+                    Variable("a"),
+                    Variable("b"),
+                ),
+            )
+        assertEquals("manyparams(a, b)", call3.emit())
+
+        // Nested calls work fine.
+        val call4 =
+            Expr.Call(
+                "nested",
+                listOf(
+                    Variable("a"),
+                    Expr.Call(
+                        "call",
+                        listOf(Variable("b")),
+                    ),
+                ),
+            )
+        assertEquals("nested(a, call(b))", call4.emit())
+
+        // Alternate constructor using varargs.
+        val call5 = Expr.Call("foo", Variable("a"))
+        assertEquals("foo(a)", call5.emit())
+
+        // Call with an expression works fine.
+        val call6 =
+            Expr.Call(
+                Expr.Attribute(Variable("a"), "foo"),
+                Expr.StringLiteral("bar"),
+            )
+        assertEquals("a.foo(\"bar\")", call6.emit())
+    }
+
+    @Test
+    fun emitAttribute() {
+        // Attribute access uses dot notation.
+        val attribute1 =
+            Expr.Attribute(
+                Variable("a"),
+                "foo",
+            )
+        assertEquals("a.foo", attribute1.emit())
+
+        val attribute2 =
+            Expr.Attribute(
+                Variable("bodo"),
+                "boolean_array_type",
+            )
+        assertEquals("bodo.boolean_array_type", attribute2.emit())
+    }
+
+    @Test
+    fun emitBodoSQLKernel() {
+        val kernelName = "upper"
+        val args = listOf(Expr.StringLiteral("test_string"))
+        val kernel1 = bodoSQLKernel(kernelName, args)
+        assertEquals("bodosql.kernels.upper(\"test_string\")", kernel1.emit())
+    }
+
+    @Test
+    fun emitInitRangeIndex() {
+        val args = listOf(Expr.IntegerLiteral(0), Expr.IntegerLiteral(1), Expr.IntegerLiteral(2))
+        val initRangeIndexExpr = initRangeIndex(args)
+        assertEquals("bodo.hiframes.pd_index_ext.init_range_index(0, 1, 2)", initRangeIndexExpr.emit())
+    }
+
+    @Test
+    fun emitMethod() {
+        // Call with a single argument.
+        val inputVar = Variable("df")
+        val call1 = Expr.Method(inputVar, "foo", listOf(Variable("a")))
+        assertEquals("df.foo(a)", call1.emit())
+
+        // No arguments works fine.
+        val call2 = Expr.Method(inputVar, "foo")
+        assertEquals("df.foo()", call2.emit())
+
+        // Only keyword args
+        val call3 = Expr.Method(inputVar, "foo", listOf(), listOf(Pair("argname", Expr.Call("bar"))))
+        assertEquals("df.foo(argname=bar())", call3.emit())
+
+        // Expr input, args, and kwargs
+        val call4 =
+            Expr.Method(
+                Expr.Call("genDf", Variable("k")),
+                "foo",
+                listOf(Variable("q"), Expr.BooleanLiteral(false)),
+                listOf(Pair("argname", Variable("L"))),
+            )
+        assertEquals("genDf(k).foo(q, False, argname=L)", call4.emit())
+    }
+
+    @Test
+    fun emitGroupby() {
+        val inputVar = Variable("df")
+        val keys1 = Expr.List(listOf(Expr.StringLiteral("A")))
+        val keys2 = Expr.List(listOf(Expr.StringLiteral("A"), Expr.StringLiteral("B")))
+        val groupby1 = Expr.Groupby(inputVar, keys1, false, false)
+        assertEquals("df.groupby([\"A\"], as_index=False, dropna=False, _is_bodosql=True)", groupby1.emit())
+        val groupby2 = Expr.Groupby(inputVar, keys2, true, true)
+        assertEquals("df.groupby([\"A\", \"B\"], as_index=True, dropna=True, _is_bodosql=True)", groupby2.emit())
+    }
+
+    @Test
+    fun emitSortValues() {
+        val inputVar = Variable("df")
+        val ascending = Expr.List(listOf(Expr.BooleanLiteral(true)))
+        val naPosition = Expr.List(listOf(Expr.StringLiteral("last")))
+
+        val byColumns = Expr.List(listOf(Expr.StringLiteral("A"), Expr.StringLiteral("B")))
+        val sortValues1 = Expr.SortValues(inputVar, byColumns, ascending, naPosition)
+        assertEquals(
+            "df.sort_values(by=[\"A\", \"B\"], ascending=[True], na_position=[\"last\"])",
+            sortValues1.emit(),
+        )
+
+        val noAscending = Expr.List(listOf())
+        val noNaPosition = Expr.List(listOf())
+        val noByColumns = Expr.List(listOf())
+
+        val sortValues2 = Expr.SortValues(inputVar, noByColumns, noAscending, noNaPosition)
+
+        assertEquals("df", sortValues2.emit())
+    }
+
+    @Test
+    fun emitIndex() {
+        // Single index value.
+        val index1 =
+            Expr.Index(
+                Variable("a"),
+                Expr.IntegerLiteral(1),
+            )
+        assertEquals("a[1]", index1.emit())
+
+        // Multiple indices can be passed to the index operator in python.
+        val index2 =
+            Expr.Index(
+                Variable("a"),
+                Expr.IntegerLiteral(1),
+                Expr.IntegerLiteral(2),
+            )
+        assertEquals("a[1, 2]", index2.emit())
+
+        // Nested expressions like lists are fine.
+        val index3 =
+            Expr.Index(
+                Variable("a"),
+                Expr.List(
+                    Expr.IntegerLiteral(1),
+                    Expr.IntegerLiteral(2),
+                ),
+            )
+        assertEquals("a[[1, 2]]", index3.emit())
+    }
+
+    @Test
+    fun emitGetItem() {
+        val df = Variable("df")
+        // Test integer index
+        assertEquals("df[1]", Expr.GetItem(df, Expr.IntegerLiteral(1)).emit())
+        // Test string index
+        assertEquals("df[\"col_name\"]", Expr.GetItem(df, Expr.StringLiteral("col_name")).emit())
+    }
+
+    @Test
+    fun emitUnary() {
+        // Test -
+        val unary1 = Expr.Unary("-", Expr.IntegerLiteral(100))
+        assertEquals("-(100)", unary1.emit())
+
+        // Test not
+        val unary2 = Expr.Unary("not", Variable("var"))
+        assertEquals("not(var)", unary2.emit())
+    }
+
+    @Test
+    fun emitBinary() {
+        // Test ==
+        val binary1 = Expr.Binary("==", Expr.IntegerLiteral(100), Variable("var"))
+        assertEquals("(100 == var)", binary1.emit())
+
+        // Test and
+        val binary2 =
+            Expr.Binary(
+                "and",
+                Variable("var"),
+                Expr.Call("bodo.libs.array_kernels.isna", listOf(Variable("arr"), Expr.IntegerLiteral(1))),
+            )
+        assertEquals("(var and bodo.libs.array_kernels.isna(arr, 1))", binary2.emit())
+    }
+
+    @Test
+    fun emitRange() {
+        // Test start and end
+        val range1 = Expr.Range(Variable("start"), Expr.IntegerLiteral(100))
+        assertEquals("range(start, 100)", range1.emit())
+
+        // Test Step
+        val range2 = Expr.Range(Expr.IntegerLiteral(0), Variable("end"), Expr.IntegerLiteral(2))
+        assertEquals("range(0, end, 2)", range2.emit())
+    }
+
+    @Test
+    fun emitLen() {
+        val var1 = Variable("df")
+        val lenExpr = Expr.Len(var1)
+        assertEquals("len(df)", lenExpr.emit())
+    }
+
+    @Test
+    fun emitTuple() {
+        // Test for empty Python tuples
+        val tuple1 = Expr.Tuple(listOf())
+        assertEquals("()", tuple1.emit())
+
+        // Test for 1 element Python tuples
+        val tuple2 = Expr.Tuple(listOf(Expr.Raw("1")))
+        assertEquals("(1,)", tuple2.emit())
+
+        // Test for 3 element Python tuples
+        val tuple3 = Expr.Tuple(listOf(Expr.Raw("1"), Expr.Raw("2"), Expr.Raw("3")))
+        assertEquals("(1, 2, 3)", tuple3.emit())
+    }
+
+    @Test
+    fun emitTripleQuotedString() {
+        val test = { arg: String, expected: String ->
+            val literal = Expr.TripleQuotedString(arg)
+            assertEquals(expected, literal.emit())
+        }
+
+        // Standard text that has no escapes but would have an escape if it was a standard string.
+        test(
+            "\"There may be a reason this string \\\" contains anything 1.",
+            "\"\"\"" + """"There may be a reason this string \" contains anything 1.""" + "\"\"\"",
+        )
+        // String contains triple quotes itself and would cause a problem if emitted.
+        test(
+            "This is a string \"\"\" with triple quotes in the middle.",
+            "\"\"\"" + "This is a string \\\"\\\"\\\" with triple quotes in the middle." + "\"\"\"",
+        )
+    }
+
+    @Test
+    fun emitStringLiteral() {
+        val test = { arg: String, expected: String ->
+            val literal = Expr.StringLiteral(arg)
+            assertEquals(expected, literal.emit())
+        }
+        // Surrounded with quotes for a normal variable.
+        test("""COLNAME""", """"COLNAME"""")
+        // Literal escape should be escaped itself.
+        test("""\""", """"\\"""")
+        // Double quotes should also be escaped and surrounded by quotes.
+        test(""""""", """"\""""")
+        // Special characters like newlines should be output with their correct escape sequence.
+        test("\n\r\t\b\u000c", """"\n\r\t\b\f"""")
+        // TODO(jsternberg): Test octal and hex escape sequences and ensure those are supported.
+    }
+
+    @Test
+    fun emitBooleanLiteral() {
+        assertEquals("True", Expr.BooleanLiteral(true).emit())
+        assertEquals("False", Expr.BooleanLiteral(false).emit())
+    }
+
+    @Test
+    fun emitIntegerLiteral() {
+        assertEquals("0", Expr.IntegerLiteral(0).emit())
+        assertEquals("1", Expr.IntegerLiteral(1).emit())
+        assertEquals("-1", Expr.IntegerLiteral(-1).emit())
+    }
+
+    @Test
+    fun emitDoubleLiteral() {
+        assertEquals("0.0", Expr.DoubleLiteral(0.0).emit())
+        assertEquals("1.23", Expr.DoubleLiteral(1.23).emit())
+        assertEquals("-1.00001", Expr.DoubleLiteral(-1.00001).emit())
+    }
+
+    @Test
+    fun emitNone() {
+        assertEquals("None", Expr.None.emit())
+    }
+
+    @Test
+    fun emitSlice() {
+        // Slice with no parameters should just be a colon.
+        val slice1 = Expr.Slice()
+        assertEquals(":", slice1.emit())
+
+        // Slice with only a start or end parameter.
+        val slice2 = Expr.Slice(start = Expr.IntegerLiteral(1))
+        assertEquals("1:", slice2.emit())
+
+        val slice3 = Expr.Slice(stop = Expr.IntegerLiteral(2))
+        assertEquals(":2", slice3.emit())
+
+        // Now both.
+        val slice4 =
+            Expr.Slice(
+                Expr.IntegerLiteral(1),
+                Expr.IntegerLiteral(2),
+            )
+        assertEquals("1:2", slice4.emit())
+
+        // Include the step value.
+        val slice5 =
+            Expr.Slice(
+                Expr.IntegerLiteral(1),
+                Expr.IntegerLiteral(2),
+                Expr.IntegerLiteral(3),
+            )
+        assertEquals("1:2:3", slice5.emit())
+
+        // Step with only start value.
+        val slice6 =
+            Expr.Slice(
+                start = Expr.IntegerLiteral(1),
+                step = Expr.IntegerLiteral(3),
+            )
+        assertEquals("1::3", slice6.emit())
+
+        // Only the stop value.
+        val slice7 =
+            Expr.Slice(
+                stop = Expr.IntegerLiteral(2),
+                step = Expr.IntegerLiteral(3),
+            )
+        assertEquals(":2:3", slice7.emit())
+
+        // Neither start nor stop.
+        val slice8 =
+            Expr.Slice(
+                step = Expr.IntegerLiteral(3),
+            )
+        assertEquals("::3", slice8.emit())
+    }
+
+    @Test
+    fun emitList() {
+        // Test for empty Python lists
+        val list1 = Expr.List(listOf())
+        assertEquals("[]", list1.emit())
+
+        // Test for 1 element Python lists
+        val list2 = Expr.List(listOf(Expr.Raw("1")))
+        assertEquals("[1]", list2.emit())
+
+        // Test for many element Python lists
+        val list3 = Expr.List(listOf(Expr.Raw("1"), Expr.Raw("2"), Expr.Raw("3")))
+        assertEquals("[1, 2, 3]", list3.emit())
+    }
+
+    @Test
+    fun emitDict() {
+        // Test emitting a dictionary
+
+        // Test an empty dictionary
+        val dict1 = Expr.Dict()
+        assertEquals("{}", dict1.emit())
+
+        // Test 1 element dictionaries
+        val dict2 =
+            Expr.Dict(
+                Expr.StringLiteral("A") to Variable("a"),
+            )
+        assertEquals("{\"A\": a}", dict2.emit())
+
+        // Test multi-element dictionaries
+        val dict3 =
+            Expr.Dict(
+                Expr.StringLiteral("A") to Variable("a"),
+                Expr.StringLiteral("B") to Expr.Raw("x + y"),
+            )
+        assertEquals("{\"A\": a, \"B\": x + y}", dict3.emit())
+    }
+
+    @Test
+    fun emitDecimalLiteral() {
+        // Test emitting a Decimal Literal
+
+        // Test with fractional component. Note this must be a value
+        // BigDecimal can represent exactly
+        val decimal1 = Expr.DecimalLiteral(BigDecimal(1.5))
+        assertEquals("1.5", decimal1.emit())
+
+        // Test no fraction
+        val decimal2 = Expr.DecimalLiteral(BigDecimal(-14))
+        assertEquals("-14", decimal2.emit())
+
+        // Test 0
+        val decimal3 = Expr.DecimalLiteral(BigDecimal(0))
+        assertEquals("0", decimal3.emit())
+    }
+
+    @Test
+    fun emitFrameTripleQuotedString() {
+        // Test emitting a triple quoted string whose body is a Frame
+
+        // Generate the frame
+        val f = CodegenFrame()
+        f.add(Op.Assign(Variable("x"), Expr.IntegerLiteral(7)))
+        f.add(Op.Assign(Variable("y"), Expr.Call("f", listOf(Variable("x")))))
+
+        // Test with nesting level 0
+        val str1 = Expr.FrameTripleQuotedString(f, 0)
+        val expected1 = "\"\"\"x = 7\ny = f(x)\n\"\"\""
+        assertEquals(expected1, str1.emit())
+
+        // Test with nesting level 1
+        val str2 = Expr.FrameTripleQuotedString(f, 1)
+        val expected2 = "\"\"\"  x = 7\n  y = f(x)\n\"\"\""
+        assertEquals(expected2, str2.emit())
+
+        // Test with nesting level 2
+        val str3 = Expr.FrameTripleQuotedString(f, 2)
+        val expected3 = "\"\"\"    x = 7\n    y = f(x)\n\"\"\""
+        assertEquals(expected3, str3.emit())
+    }
+
+    @Test
+    fun emitFrameTripleQuotedStringNested() {
+        // Test emitting a triple quoted string whose body is a Frame
+        // but contains nested frames via If/Else.
+        // Generate the frame
+        val mainFrame = CodegenFrame()
+        val ifFrame = CodegenFrame()
+        ifFrame.add(Op.Assign(Variable("x"), Expr.IntegerLiteral(7)))
+        val elseFrame = CodegenFrame()
+        elseFrame.add(Op.Assign(Variable("x"), Expr.Call("f", listOf(Expr.StringLiteral("abc")))))
+
+        val ifOp = Op.If(Variable("cond"), ifFrame, elseFrame)
+        mainFrame.add(ifOp)
+
+        // Test with nesting level 0
+        val str1 = Expr.FrameTripleQuotedString(mainFrame, 0)
+        val expected1 = "\"\"\"if cond:\n  x = 7\nelse:\n  x = f(\"abc\")\n\"\"\""
+        assertEquals(expected1, str1.emit())
+
+        // Test with nesting level 1
+        val str2 = Expr.FrameTripleQuotedString(mainFrame, 1)
+        val expected2 = "\"\"\"  if cond:\n    x = 7\n  else:\n    x = f(\"abc\")\n\"\"\""
+        assertEquals(expected2, str2.emit())
+
+        // Test with nesting level 2
+        val str3 = Expr.FrameTripleQuotedString(mainFrame, 2)
+        val expected3 = "\"\"\"    if cond:\n      x = 7\n    else:\n      x = f(\"abc\")\n\"\"\""
+        assertEquals(expected3, str3.emit())
+    }
+
+    @Test
+    fun emitDataFrameSlice() {
+        val dataframeExpr = Expr.Raw("df3")
+        val lowerBound = Expr.IntegerLiteral(1)
+        val upperBound = Expr.IntegerLiteral(10)
+        // Test with simple integers
+        val out1 = Expr.DataFrameSlice(dataframeExpr, lowerBound, upperBound)
+        val expected1 = "df3.iloc[1:10]"
+        assertEquals(expected1, out1.emit())
+
+        // Test with more complex expressions
+        val dataframeExpr2 = Expr.Raw("df3")
+        val lowerBound2 = Expr.Raw("10*3 + 1")
+        val upperBound2 = Expr.Raw("random.randint(1, 3)")
+        val out2 = Expr.DataFrameSlice(dataframeExpr2, lowerBound2, upperBound2)
+        val expected2 = "df3.iloc[10*3 + 1:random.randint(1, 3)]"
+        assertEquals(expected2, out2.emit())
+    }
+}

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/ModuleTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/ModuleTest.kt
@@ -1,0 +1,141 @@
+package com.bodosql.calcite.ir
+
+import com.bodosql.calcite.application.BodoSQLCodegenException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModuleTest {
+    @Test
+    fun emit() {
+        val frame = CodegenFrame()
+        frame.add(Op.Assign(Variable("v1"), Expr.Raw("1")))
+        frame.add(Op.Assign(Variable("v2"), Expr.Raw("v1 + 3")))
+        val module = Module(frame)
+        val actual = module.emit()
+        val expected =
+            """
+            v1 = 1
+            v2 = v1 + 3
+            
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun append() {
+        val module = Module.Builder()
+        // Single line.
+        module.append("a = 1\n")
+        // Chain append calls.
+        module
+            .append("b = [\n")
+            .append("  1,\n")
+        // Continuing the previous append from the module is fine.
+        module.append("  2,\n")
+        module.append("]\n")
+
+        val actual = module.build().emit()
+        val expected =
+            """
+            a = 1
+            b = [
+              1,
+              2,
+            ]
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun activeFrames() {
+        /**
+         * Test that generated code writes only to the active frame
+         * for a builder.
+         */
+        val builder = Module.Builder()
+        val assign1 = Op.Assign(Variable("v1"), Expr.Raw("1"))
+        val assign2 = Op.Assign(Variable("x"), Expr.Raw("27"))
+        val assign3 = Op.Assign(Variable("y"), Expr.Raw("x - 2"))
+        val assign4 = Op.Assign(Variable("v2"), Expr.Raw("v1 + 3"))
+        // Add to the default frame
+        builder.add(assign1)
+        // Create a new frame
+        builder.startCodegenFrame()
+        builder.add(assign2)
+        builder.add(assign3)
+        // Pop the frame
+        val otherFrame = builder.endFrame()
+        // Add to the original frame
+        builder.add(assign4)
+        // Check the other frame
+        val doc = Doc()
+        otherFrame.emit(doc)
+        val actualOtherFrame = doc.toString()
+        val expectedOtherFrame =
+            """
+            x = 27
+            y = x - 2
+
+            """.trimIndent()
+        assertEquals(expectedOtherFrame, actualOtherFrame)
+        // check what was built
+        val actual = builder.build().emit()
+        val expected =
+            """
+            v1 = 1
+            v2 = v1 + 3
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun startStreamingPipeline() {
+        /**
+         * Test that startStreamingPipeline returns a streaming pipeline frame.
+         */
+        val builder = Module.Builder()
+        builder.startStreamingPipelineFrame(Variable("a"), Variable("b"))
+        val frame = builder.endFrame()
+        assert(frame is StreamingPipelineFrame)
+    }
+
+    @Test
+    fun endCurrentStreamingPipeline() {
+        /**
+         * Test that endCurrentStreamingPipeline works in a streaming
+         * context but not otherwise.
+         */
+        val builder = Module.Builder()
+        builder.startStreamingPipelineFrame(Variable("a"), Variable("b"))
+        builder.endCurrentStreamingPipeline()
+        builder.startCodegenFrame()
+        try {
+            builder.endCurrentStreamingPipeline()
+            // This should trigger an exception
+            assert(false)
+        } catch (e: BodoSQLCodegenException) {
+        }
+    }
+
+    @Test
+    fun getCurrentStreamingPipeline() {
+        /**
+         * Test that getCurrentStreamingPipeline works in a streaming
+         * context but not otherwise.
+         */
+        val builder = Module.Builder()
+        builder.startStreamingPipelineFrame(Variable("a"), Variable("b"))
+        builder.getCurrentStreamingPipeline()
+        // We shouldn't alter the state
+        builder.getCurrentStreamingPipeline()
+        builder.endFrame()
+        try {
+            builder.getCurrentStreamingPipeline()
+            // This should trigger an exception
+            assert(false)
+        } catch (e: BodoSQLCodegenException) {
+        }
+    }
+}

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/OpTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/OpTest.kt
@@ -1,0 +1,262 @@
+package com.bodosql.calcite.ir
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OpTest {
+    @Test
+    fun testOpIfEmit() {
+        // Test If emit with 1 if and 1 else
+        val doc = Doc()
+        // Create IF
+        val ifFrame = CodegenFrame()
+        ifFrame.add(Op.Assign(Variable("y"), Expr.Raw("7")))
+        val elseFrame = CodegenFrame()
+        elseFrame.add(Op.Assign(Variable("y"), Expr.Raw("-1")))
+        val ifOp: Op.If = Op.If(Expr.Raw("x == 5"), ifFrame, elseFrame)
+        ifOp.emit(doc)
+
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            if x == 5:
+              y = 7
+            else:
+              y = -1
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOpIfNoElseEmit() {
+        val doc = Doc()
+        // Create IF
+        val ifFrame = CodegenFrame()
+        ifFrame.add(Op.Assign(Variable("y"), Expr.Raw("7")))
+        val ifOp = Op.If(Expr.Raw("x == 5"), ifFrame)
+        ifOp.emit(doc)
+
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            if x == 5:
+              y = 7
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOpMultiIfEmit() {
+        // Test If emits with several ifs and 1 else
+        val doc = Doc()
+        // Create the if statements in reverse order
+        // Innermost If
+        val ifFrame3 = CodegenFrame()
+        ifFrame3.add(Op.Assign(Variable("y"), Expr.Raw("0")))
+        val elseFrame3 = CodegenFrame()
+        elseFrame3.add(Op.Assign(Variable("y"), Expr.Raw("-2")))
+        val ifOp3 = Op.If(Expr.Raw("(x == 4) and (j > 0)"), ifFrame3, elseFrame3)
+        // Middle If
+        val ifFrame2 = CodegenFrame()
+        ifFrame2.add(Op.Assign(Variable("y"), Expr.Raw("21")))
+        val elseFrame2 = CodegenFrame()
+        elseFrame2.add(ifOp3)
+        val ifOp2 = Op.If(Expr.Raw("x != 4"), ifFrame2, elseFrame2)
+        // Outermost If
+        val ifFrame1 = CodegenFrame()
+        ifFrame1.add(Op.Assign(Variable("y"), Expr.Raw("14")))
+        val elseFrame1 = CodegenFrame()
+        elseFrame1.add(ifOp2)
+        val ifOp = Op.If(Expr.Raw("x == 5"), ifFrame1, elseFrame1)
+
+        // Emit the code
+        ifOp.emit(doc)
+
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            if x == 5:
+              y = 14
+            else:
+              if x != 4:
+                y = 21
+              else:
+                if (x == 4) and (j > 0):
+                  y = 0
+                else:
+                  y = -2
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOpCodeEmit() {
+        // Identical text should be the same.
+        assertOpEmit(
+            """def foo():
+            |  return 4
+            """.trimMargin(),
+            Op.Code(
+                """def foo():
+            |  return 4
+                """.trimMargin(),
+            ),
+        )
+
+        // With consistent indentation.
+        assertOpEmit(
+            """def foo():
+            |  return 4
+            """.trimMargin(),
+            Op.Code(
+                """  def foo():
+            |    return 4
+                """.trimMargin(),
+            ),
+        )
+
+        // Blank lines with random indentation.
+        assertOpEmit(
+            """def foo():
+            |  return 4
+            """.trimMargin(),
+            Op.Code(
+                """  def foo():
+            |
+            |
+            |    return 4
+                """.trimMargin(),
+            ),
+        )
+    }
+
+    @Test
+    fun testWhileEmit() {
+        val doc = Doc()
+        val frame = CodegenFrame()
+        frame.add(Op.Assign(Variable("x"), Expr.IntegerLiteral(1)))
+        frame.add(Op.Stmt(Expr.Call("f", listOf(Variable("x")))))
+        val whileOp = Op.While(Expr.Raw("y == 2"), frame)
+        whileOp.emit(doc)
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            while y == 2:
+              x = 1
+              f(x)
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testStreamingPipelineEmit() {
+        val frame = StreamingPipelineFrame(Variable("stop"), Variable("iter"), StreamingStateScope(), 1)
+        frame.add(Op.Assign(Variable("v1"), Expr.Raw("1")))
+        frame.add(Op.Assign(Variable("stop"), Expr.Raw("v1 > 1")))
+        val doc = Doc()
+        val streamingPipeline = Op.StreamingPipeline(frame)
+        streamingPipeline.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            stop = False
+            iter = 0
+            bodo.libs.query_profile_collector.start_pipeline(1)
+            while not(stop):
+              v1 = 1
+              stop = v1 > 1
+              iter = (iter + 1)
+            bodo.libs.query_profile_collector.end_pipeline(1, iter)
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    private fun assertOpEmit(
+        expected: String,
+        op: Op,
+    ) {
+        val doc = Doc()
+        op.emit(doc)
+
+        val actual = doc.toString().trimEnd()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testTupleAssign() {
+        val doc = Doc()
+
+        // Check empty edge case is handled (should be no-op)
+        Op.TupleAssign(listOf(), Expr.IntegerLiteral(1)).emit(doc)
+        // Check 1 element edge case is handled
+        Op
+            .TupleAssign(
+                listOf(Variable("A")),
+                Expr.Tuple(
+                    listOf(Expr.IntegerLiteral(1)),
+                ),
+            ).emit(doc)
+        // Check 1 element edge case is handled
+        Op
+            .TupleAssign(
+                listOf(Variable("X"), Variable("Y"), Variable("Z")),
+                Expr.Tuple(
+                    listOf(
+                        Expr.IntegerLiteral(-1),
+                        Expr.IntegerLiteral(-2),
+                        Expr.IntegerLiteral(-3),
+                    ),
+                ),
+            ).emit(doc)
+
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            (A, ) = (1,)
+            (X, Y, Z, ) = (-1, -2, -3)
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testReturn() {
+        val doc = Doc()
+        // Check null is handled
+        Op.ReturnStatement(null).emit(doc)
+        Op.ReturnStatement(Variable("df2")).emit(doc)
+
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            return
+            return df2
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testSetItem() {
+        val doc = Doc()
+        Op.SetItem(Variable("arr"), Variable("i"), Expr.IntegerLiteral(7)).emit(doc)
+
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            arr[i] = 7
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testContinue() {
+        val doc = Doc()
+        Op.Continue.emit(doc)
+        val actual = doc.toString().trimEnd()
+        val expected =
+            """
+            continue
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+}

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/StreamingPipelineFrameTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/StreamingPipelineFrameTest.kt
@@ -1,0 +1,150 @@
+package com.bodosql.calcite.ir
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StreamingPipelineFrameTest {
+    @Test
+    fun testEmit() {
+        val frame = StreamingPipelineFrame(Variable("stop"), Variable("iter"), StreamingStateScope(), 1)
+        frame.add(Op.Assign(Variable("v1"), Expr.Raw("1")))
+        frame.add(Op.Assign(Variable("stop"), Expr.Raw("v1 > 1")))
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            stop = False
+            iter = 0
+            bodo.libs.query_profile_collector.start_pipeline(1)
+            while not(stop):
+              v1 = 1
+              stop = v1 > 1
+              iter = (iter + 1)
+            bodo.libs.query_profile_collector.end_pipeline(1, iter)
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testAppend() {
+        val frame = StreamingPipelineFrame(Variable("stop"), Variable("iter"), StreamingStateScope(), 1)
+        // Single line.
+        frame.append("a = 1\n")
+        // Test multiple lines being explicitly appended
+        frame.append("b = [\n")
+        frame.append("  1,\n")
+        frame.append("  2,\n")
+        frame.append("]\n")
+
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            stop = False
+            iter = 0
+            bodo.libs.query_profile_collector.start_pipeline(1)
+            while not(stop):
+              a = 1
+              b = [
+                1,
+                2,
+              ]
+              iter = (iter + 1)
+            bodo.libs.query_profile_collector.end_pipeline(1, iter)
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testAddInitializationTermination() {
+        val frame = StreamingPipelineFrame(Variable("stop"), Variable("iter"), StreamingStateScope(), 1)
+        frame.add(Op.Assign(Variable("v1"), Expr.Raw("1")))
+        frame.addInitialization(Op.Assign(Variable("state"), Expr.Call("aggregate_state")))
+        frame.addTermination(Op.Stmt(Expr.Call("delete_state", listOf(Variable("state")))))
+        frame.add(Op.Assign(Variable("stop"), Expr.Call("f", listOf(Variable("v1"), Variable("state")))))
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            stop = False
+            iter = 0
+            state = aggregate_state()
+            bodo.libs.query_profile_collector.start_pipeline(1)
+            while not(stop):
+              v1 = 1
+              stop = f(v1, state)
+              iter = (iter + 1)
+            delete_state(state)
+            bodo.libs.query_profile_collector.end_pipeline(1, iter)
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testEndSection() {
+        val frame = StreamingPipelineFrame(Variable("stop"), Variable("iter"), StreamingStateScope(), 1)
+        frame.add(Op.Assign(Variable("v1"), Expr.Raw("1")))
+        frame.add(Op.Assign(Variable("stop"), Expr.Raw("v1 > 1")))
+        frame.endSection(Variable("stop2"))
+        frame.add(Op.Assign(Variable("stop2"), Expr.Call("g")))
+        val doc = Doc()
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            stop = False
+            iter = 0
+            stop2 = False
+            bodo.libs.query_profile_collector.start_pipeline(1)
+            while not(stop2):
+              v1 = 1
+              stop = v1 > 1
+              stop2 = g()
+              iter = (iter + 1)
+            bodo.libs.query_profile_collector.end_pipeline(1, iter)
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testGenerateIOFlags() {
+        val frame = StreamingPipelineFrame(Variable("stop"), Variable("iter"), StreamingStateScope(), 1)
+        frame.addOutputControl(Variable("OutputControl1"))
+        frame.addInputRequest(Variable("InputRequest1"))
+        frame.addOutputControl(Variable("OutputControl2"))
+        frame.addInputRequest(Variable("InputRequest2"))
+        frame.addOutputControl(Variable("OutputControl3"))
+        val doc = Doc()
+
+        // Append the frame result
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            stop = False
+            iter = 0
+            OutputControl1 = True
+            OutputControl2 = True
+            OutputControl3 = True
+            bodo.libs.query_profile_collector.start_pipeline(1)
+            while not(stop):
+              iter = (iter + 1)
+              OutputControl1 = (InputRequest2 and InputRequest1)
+              OutputControl2 = InputRequest2
+            bodo.libs.query_profile_collector.end_pipeline(1, iter)
+            
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+}

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/StreamingStateScopeTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/StreamingStateScopeTest.kt
@@ -1,0 +1,161 @@
+package com.bodosql.calcite.ir
+
+import java.lang.Exception
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class StreamingStateScopeTest {
+    @Test
+    fun testNoRegisteredOps() {
+        val scope = StreamingStateScope()
+        val ops = scope.genOpComptrollerInit()
+        assertEquals(2, ops.size)
+    }
+
+    @Test
+    fun testRegisterOneOp() {
+        val scope = StreamingStateScope()
+        val opID = OperatorID(0, true)
+        scope.startOperator(opID, 0, OperatorType.UNKNOWN)
+        scope.endOperator(opID, 0)
+
+        val ops = scope.genOpComptrollerInit()
+        assertEquals(3, ops.size)
+        when (val registerOp = ops[1]) {
+            is Op.Stmt -> assertTrue(registerOp.expr is Expr.Call)
+            else -> assertTrue(false, "Expected a Op.Stmt")
+        }
+    }
+
+    @Test
+    fun testRegisterOpWithNoEnd() {
+        val scope = StreamingStateScope()
+        scope.startOperator(OperatorID(0, true), 0, OperatorType.UNKNOWN)
+        var gotException = false
+        try {
+            scope.genOpComptrollerInit()
+        } catch (e: Exception) {
+            assertTrue(e.message!!.contains("StreamingStateScope"))
+            gotException = true
+        }
+        assertTrue(gotException)
+    }
+
+    @Test
+    fun testRegisterOpWithInvalidEndPipeline() {
+        val scope = StreamingStateScope()
+        val opID = OperatorID(0, true)
+        // Start at pipeline id 1
+        scope.startOperator(opID, 1, OperatorType.UNKNOWN)
+        var gotException = false
+        try {
+            // end at pipeline id 0
+            scope.endOperator(opID, 0)
+        } catch (e: Exception) {
+            assertTrue(e.message!!.contains("StreamingStateScope"))
+            gotException = true
+        }
+        assertTrue(gotException)
+    }
+
+    @Test
+    fun testRegisterOpTwice() {
+        val scope = StreamingStateScope()
+        val opID = OperatorID(0, true)
+        scope.startOperator(opID, 0, OperatorType.UNKNOWN)
+        var gotException = false
+        try {
+            scope.startOperator(opID, 1, OperatorType.UNKNOWN)
+        } catch (e: Exception) {
+            assertTrue(e.message!!.contains("StreamingStateScope"))
+            gotException = true
+        }
+        assertTrue(gotException)
+    }
+
+    @Test
+    fun testEndOpTwice() {
+        val scope = StreamingStateScope()
+        val opID = OperatorID(0, true)
+        scope.startOperator(opID, 0, OperatorType.UNKNOWN)
+        scope.endOperator(opID, 0)
+        var gotException = false
+        try {
+            scope.endOperator(opID, 1)
+        } catch (e: Exception) {
+            assertTrue(e.message!!.contains("StreamingStateScope"))
+            gotException = true
+        }
+        assertTrue(gotException)
+    }
+
+    @Test
+    fun testEndUnknownOp() {
+        val scope = StreamingStateScope()
+        var gotException = false
+        try {
+            scope.endOperator(OperatorID(0, true), 1)
+        } catch (e: Exception) {
+            assertTrue(e.message!!.contains("StreamingStateScope"))
+            gotException = true
+        }
+        assertTrue(gotException)
+    }
+
+    @Test
+    fun testAddToFrame() {
+        val frame = CodegenFrame()
+        val op1 = Op.Assign(Variable("first"), Expr.IntegerLiteral(1))
+        frame.add(op1)
+        val op2 = Op.Assign(Variable("second"), Expr.IntegerLiteral(2))
+        frame.add(op2)
+        val ret = Op.ReturnStatement(Variable("first"))
+        frame.add(ret)
+
+        val scope = StreamingStateScope()
+        val opID = OperatorID(0, false)
+        scope.startOperator(opID, 0, OperatorType.UNKNOWN)
+        scope.endOperator(opID, 0)
+        scope.addToFrame(frame)
+
+        val doc = Doc()
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            bodo.libs.memory_budget.init_operator_comptroller()
+            bodo.libs.memory_budget.register_operator(0, bodo.libs.memory_budget.OperatorType.UNKNOWN, 0, 0, -1)
+            bodo.libs.memory_budget.compute_satisfiable_budgets()
+            bodo.libs.query_profile_collector.init()
+            first = 1
+            second = 2
+            bodo.libs.query_profile_collector.finalize()
+            return first
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testAddToFrameNoOperations() {
+        val frame = CodegenFrame()
+        val op1 = Op.Assign(Variable("first"), Expr.IntegerLiteral(1))
+        frame.add(op1)
+        val op2 = Op.Assign(Variable("second"), Expr.IntegerLiteral(2))
+        frame.add(op2)
+
+        val scope = StreamingStateScope()
+        scope.addToFrame(frame)
+        val doc = Doc()
+        frame.emit(doc)
+        val actual = doc.toString()
+        val expected =
+            """
+            first = 1
+            second = 2
+
+            """.trimIndent()
+        assertEquals(expected, actual)
+    }
+}

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/SymbolTableTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/calcite/ir/SymbolTableTest.kt
@@ -1,0 +1,127 @@
+package com.bodosql.calcite.ir
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SymbolTableTest {
+    @Test
+    fun genDfVar() {
+        genTestHelper("df") { genDfVar() }
+    }
+
+    @Test
+    fun genTableVar() {
+        genTestHelper("T") { genTableVar() }
+    }
+
+    @Test
+    fun genSeriesVar() {
+        genTestHelper("S") { genSeriesVar() }
+    }
+
+    @Test
+    fun genGenericTempVar() {
+        genTestHelper("_temp") { genGenericTempVar() }
+    }
+
+    @Test
+    fun genTempColumnVar() {
+        genTestHelper("__bodo_generated_column__") { genTempColumnVar() }
+    }
+
+    @Test
+    fun genWindowedAggDf() {
+        genTestHelper("__bodo_windowfn_generated_df_") { genWindowedAggDf() }
+    }
+
+    @Test
+    fun genWindowedAggFnName() {
+        genTestHelper("__bodo_dummy___sql_windowed_apply_fn_") { genWindowedAggFnName() }
+    }
+
+    @Test
+    fun genGroupbyApplyAggFnName() {
+        genTestHelper("__bodo_dummy___sql_groupby_apply_fn_") { genGroupbyApplyAggFnName() }
+    }
+
+    @Test
+    fun genGlobalVar() {
+        genTestHelper("global_") { genGlobalVar() }
+    }
+
+    @Test
+    fun genIterVar() {
+        genTestHelper("_iter_") { genIterVar() }
+    }
+
+    @Test
+    fun genOutputControlVar() {
+        genTestHelper("_produce_output_") { genOutputControlVar() }
+    }
+
+    @Test
+    fun genInputRequestVar() {
+        genTestHelper("_input_request_") { genInputRequestVar() }
+    }
+
+    @Test
+    fun genNoConflicts() {
+        // Invoke the generation functions repeatedly
+        // and just ensure we never have a conflict.
+        // This should be impossible because every function uses
+        // a different prefix, but just being safe.
+        val symbolTable = SymbolTable()
+        val vars = mutableSetOf<String>()
+
+        // Create a lot of variables of mixed types and just keep doing that
+        // with some small variation. We should always create 200 different variables.
+        val count = 50 * 19
+        for (i in 0 until count) {
+            val v =
+                when (i % 19) {
+                    0, 7, 9 -> symbolTable.genDfVar()
+                    1, 8 -> symbolTable.genTableVar()
+                    2, 6, 13 -> symbolTable.genSeriesVar()
+                    3, 10 -> symbolTable.genGenericTempVar()
+                    4, 12 -> symbolTable.genTempColumnVar()
+                    5 -> symbolTable.genWindowedAggDf()
+                    11 -> symbolTable.genWindowedAggFnName()
+                    14 -> symbolTable.genGroupbyApplyAggFnName()
+                    15 -> symbolTable.genGlobalVar()
+                    16 -> symbolTable.genIterVar()
+                    17 -> symbolTable.genOutputControlVar()
+                    18 -> symbolTable.genInputRequestVar()
+                    else -> throw IllegalStateException("${i % 19}")
+                }
+            vars.add(v.name)
+        }
+        assertEquals(count, vars.size)
+    }
+
+    private fun genTestHelper(
+        prefix: String,
+        genVar: SymbolTable.() -> Variable,
+    ) {
+        val symbolTable = SymbolTable()
+
+        // Store the generated variables.
+        val vars = mutableSetOf<String>()
+
+        // First variable should be prefix1.
+        val v1 = symbolTable.genVar()
+        assertEquals("${prefix}1", v1.name)
+        vars.add(v1.name)
+
+        // Second variable should be prefix2.
+        val v2 = symbolTable.genVar()
+        assertEquals("${prefix}2", v2.name)
+        vars.add(v2.name)
+
+        // Generate 98 more variables and check that
+        // we have 100 unique variable names.
+        for (i in 1..98) {
+            vars.add(symbolTable.genVar().name)
+        }
+        assertEquals(100, vars.size)
+    }
+}


### PR DESCRIPTION
## Changes included in this PR
Add PR CI support for java tests and the first wave of java tests confirmed to be safe publicly.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Better feedback for java contributors, if someone doesn't have access to the customer sample code repo they can't see test erros.
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.