### PR TITLE
Fix s3 tables tests

### DIFF
--- a/BodoSQL/bodosql/tests/conftest.py
+++ b/BodoSQL/bodosql/tests/conftest.py
@@ -27,7 +27,7 @@ from bodo.tests.conftest import (  # noqa
     tabular_connection,
 )
 from bodo.tests.iceberg_database_helpers.utils import get_spark
-from bodo.tests.utils import gen_nonascii_list, temp_env_override
+from bodo.tests.utils import gen_nonascii_list
 
 # Patch to avoid PySpark's Py4j exception handler in testing.
 # See:
@@ -1980,8 +1980,7 @@ def s3_tables_catalog():
     """
 
     warehouse = "arn:aws:s3tables:us-east-2:427443013497:bucket/unittest-bucket"
-    with temp_env_override({"AWS_REGION": "us-east-2"}):
-        yield bodosql.S3TablesCatalog(warehouse=warehouse)
+    return bodosql.S3TablesCatalog(warehouse=warehouse)
 
 
 @pytest.fixture(

--- a/BodoSQL/bodosql/tests/test_types/test_s3_tables_iceberg_catalog.py
+++ b/BodoSQL/bodosql/tests/test_types/test_s3_tables_iceberg_catalog.py
@@ -8,6 +8,7 @@ from bodo.tests.utils import (
     gen_unique_table_id,
     pytest_s3_tables,
     run_rank0,
+    temp_env_override,
 )
 from bodosql.bodosql_types.s3_tables_catalog import S3TablesConnectionType
 
@@ -16,6 +17,7 @@ pytestmark = pytest_s3_tables
 
 # Refer to bodo/tests/test_s3_tables_iceberg.py for infrastructure
 # required to run these tests
+@temp_env_override({"AWS_REGION": "us-east-2"})
 def test_basic_read(memory_leak_check, s3_tables_catalog):
     """
     Test reading an entire Iceberg table from S3 Tables in SQL
@@ -43,6 +45,7 @@ def test_basic_read(memory_leak_check, s3_tables_catalog):
     )
 
 
+@temp_env_override({"AWS_REGION": "us-east-2"})
 def test_s3_tables_catalog_iceberg_write(s3_tables_catalog, memory_leak_check):
     """tests that writing tables works"""
     import bodo_iceberg_connector as bic


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Context managers in fixtures didn't work as I expected so the test wasn't looking in the correct region
for the table bucket.
## Testing strategy
Replicated and fixed locally
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
NA
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.