### PR TITLE
Fix BodoSQL to respect non-streaming configuration

### DIFF
--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/RelationalAlgebraGenerator.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/RelationalAlgebraGenerator.java
@@ -95,6 +95,9 @@ public class RelationalAlgebraGenerator {
   /** Store the type system being used to access timezone info during Bodo codegen */
   private final RelDataTypeSystem typeSystem;
 
+  /** Should the planner output streaming code. */
+  private final boolean isStreaming;
+
   /** The Bodo verbose level. This is used to control code generated and/or compilation info. */
   private final int verboseLevel;
 
@@ -160,7 +163,8 @@ public class RelationalAlgebraGenerator {
    * the Planner member variables.
    */
   private void setupPlanner(List<SchemaPlus> defaultSchemas, RelDataTypeSystem typeSystem) {
-    PlannerImpl.Config config = new PlannerImpl.Config(defaultSchemas, typeSystem, sqlStyle);
+    PlannerImpl.Config config =
+        new PlannerImpl.Config(defaultSchemas, typeSystem, sqlStyle, isStreaming);
     try {
       this.planner = new PlannerImpl(config);
     } catch (Exception e) {
@@ -193,6 +197,7 @@ public class RelationalAlgebraGenerator {
       @NonNull boolean coveringExpressionCaching,
       @NonNull boolean prefetchSFIceberg,
       @Nullable String defaultTz) {
+    this.isStreaming = isStreaming;
     this.catalog = catalog;
     this.verboseLevel = verboseLevel;
     this.tracingLevel = tracingLevel;

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/PlannerImpl.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/PlannerImpl.kt
@@ -157,13 +157,21 @@ class PlannerImpl(
          * only provide traits for streaming.
          * @return The list of trait definitions for our planner.
          */
-        private fun getTraitDefs(): List<RelTraitDef<out RelTrait>> = listOf(ConventionTraitDef.INSTANCE, BatchingPropertyTraitDef.INSTANCE)
+        @JvmStatic
+        private fun getTraitDefs(isStreaming: Boolean): List<RelTraitDef<out RelTrait>> =
+            if (isStreaming) {
+                // Only include BatchingPropertyTraitDef with streaming.
+                listOf(ConventionTraitDef.INSTANCE, BatchingPropertyTraitDef.INSTANCE)
+            } else {
+                listOf(ConventionTraitDef.INSTANCE)
+            }
 
         /**
          * Get the programs that are defined for our planner. We currently
          * only provide programs for streaming.
          * @return The list of programs for our planner.
          */
+        @JvmStatic
         private fun getPrograms(): List<Program> =
             listOf(
                 BodoPrograms.preprocessor(),
@@ -184,7 +192,7 @@ class PlannerImpl(
                 .convertletTable(convertletTable)
                 .sqlValidatorConfig(validatorConfig)
                 .costFactory(CostFactory())
-                .traitDefs(getTraitDefs())
+                .traitDefs(getTraitDefs(isStreaming = config.isStreaming))
                 .programs(getPrograms())
                 .build()
         }
@@ -251,5 +259,6 @@ class PlannerImpl(
         val defaultSchemas: List<SchemaPlus>,
         val typeSystem: RelDataTypeSystem,
         val sqlStyle: String,
+        val isStreaming: Boolean,
     )
 }


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Non-streaming was disabled in the code refactoring. This correctly disables streaming by removing the treat when configured from Python. This was determined by dead code inspection in the IDE.

## Testing strategy

This depends on PR CI.

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.