### PR TITLE
Update benchmark/readme cluster config

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,7 +26,7 @@ We compared Bodo's performance on this workload to other systems including [Dask
 
 For cluster creation and configuration, we use the [Bodo SDK](https://docs.bodo.ai/2024.12/guides/using_bodo_platform/bodo_platform_sdk_guide/) for Bodo, Dask Cloud Provider for Dask, Ray for Modin, and AWS EMR for Spark. Scripts to configure and launch clusters for each system can be found in the same directory as the implementation.
 
-Each benchmark is collected on a cluster containing 4 worker instances and 128 physical cores. Dask, Modin, and Spark use 4 `r6i.16xlarge` instances, each consisting of 32 physical cores and 512 GiB of memory. Dask Cloud Provider also allocates an additional `c6i.xlarge` instance for the distributed scheduler which contains 2 cores.
+Each benchmark is collected on a cluster containing 4 worker instances and 128 physical cores. For the workers, we use `r6i.16xlarge` instances, each consisting of 32 physical cores and 512 GiB of memory. Dask Cloud Provider also allocates an additional `c6i.xlarge` instance for the distributed scheduler which contains 2 cores.
 
 ### Results
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,6 +17,7 @@ We compared Bodo's performance on this workload to other systems including [Dask
 | Package      | Version      |
 |----------------|----------------|
 | bodo   | 2024.10   |
+| bodosdk | 2.2.0 |
 | dask   | 2024.9.1  |
 | dask-cloudprovider  | 2024.9.1  |
 | modin   | 0.32.0   |
@@ -25,7 +26,7 @@ We compared Bodo's performance on this workload to other systems including [Dask
 
 For cluster creation and configuration, we use the [Bodo SDK](https://docs.bodo.ai/2024.12/guides/using_bodo_platform/bodo_platform_sdk_guide/) for Bodo, Dask Cloud Provider for Dask, Ray for Modin, and AWS EMR for Spark. Scripts to configure and launch clusters for each system can be found in the same directory as the implementation.
 
-Each benchmark is collected on a cluster containing 4 worker instances and 128 physical cores. Dask, Modin, and Spark use 4 `r6i.16xlarge` instances, each consisting of 32 physical cores and 256 GiB of memory. Dask Cloud Provider also allocates an additional `c6i.xlarge` instance for the distributed scheduler which contains 2 cores. Bodo is run on 4 `c6i.16xlarge` instances, each consisting of 32 physical cores and 64 GiB of memory.
+Each benchmark is collected on a cluster containing 4 worker instances and 128 physical cores. Dask, Modin, and Spark use 4 `r6i.16xlarge` instances, each consisting of 32 physical cores and 256 GiB of memory. Dask Cloud Provider also allocates an additional `c6i.xlarge` instance for the distributed scheduler which contains 2 cores.
 
 ### Results
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,7 +26,7 @@ We compared Bodo's performance on this workload to other systems including [Dask
 
 For cluster creation and configuration, we use the [Bodo SDK](https://docs.bodo.ai/2024.12/guides/using_bodo_platform/bodo_platform_sdk_guide/) for Bodo, Dask Cloud Provider for Dask, Ray for Modin, and AWS EMR for Spark. Scripts to configure and launch clusters for each system can be found in the same directory as the implementation.
 
-Each benchmark is collected on a cluster containing 4 worker instances and 128 physical cores. Dask, Modin, and Spark use 4 `r6i.16xlarge` instances, each consisting of 32 physical cores and 256 GiB of memory. Dask Cloud Provider also allocates an additional `c6i.xlarge` instance for the distributed scheduler which contains 2 cores.
+Each benchmark is collected on a cluster containing 4 worker instances and 128 physical cores. Dask, Modin, and Spark use 4 `r6i.16xlarge` instances, each consisting of 32 physical cores and 512 GiB of memory. Dask Cloud Provider also allocates an additional `c6i.xlarge` instance for the distributed scheduler which contains 2 cores.
 
 ### Results
 

--- a/benchmarks/nyc_taxi/bodo/run_bodo.py
+++ b/benchmarks/nyc_taxi/bodo/run_bodo.py
@@ -21,7 +21,7 @@ from bodosdk import BodoWorkspaceClient
 def run_bodo_benchmark():
     bodo_workspace = BodoWorkspaceClient()
     benchmark_cluster = bodo_workspace.ClusterClient.create(
-        name="Benchmark Bodo", instance_type="c6i.16xlarge", workers_quantity=4
+        name="Benchmark Bodo", instance_type="r6i.16xlarge", workers_quantity=4
     )
     benchmark_cluster.wait_for_status(["RUNNING"])
 


### PR DESCRIPTION
## Changes included in this PR

Results are the same, it was just a little confusing that we were using a different instance type for Bodo vs other systems.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

Reran and collected timings: 
```
  0: Reading Time:  7.757560914809176
  0: Monthly Taxi Travel Times Computation Time:  8.208836417048644
  0: Writing time: 0.23172555982387166

  0: Reading Time:  6.565165733819697
  0: Monthly Taxi Travel Times Computation Time:  8.06452604663184
  0: Writing time: 0.46552765083754366

  0: Reading Time:  7.54428860361196
  0: Monthly Taxi Travel Times Computation Time:  8.081353348460198
  0: Writing time: 0.8068051076614324
```

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
No
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.