### PR TITLE
Use a task queue for delete tasks of lazy data structures in spawn

### DIFF
--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -18,6 +18,7 @@ import cloudpickle
 import numba
 import pandas as pd
 import psutil
+from numba.core import types
 from pandas.core.arrays.arrow.array import ArrowExtensionArray
 
 import bodo
@@ -566,6 +567,7 @@ class Spawner:
         return args_meta, kwargs_meta
 
     def _run_del_queue(self):
+        """Run delete tasks in the queue if no other tasks are running."""
         if not self._is_running and self._del_queue and not self.destroyed:
             self._is_running = True
             res_id = self._del_queue.popleft()
@@ -576,7 +578,8 @@ class Spawner:
             self._is_running = False
             self._run_del_queue()
 
-    def set_config(self, name, value):
+    def set_config(self, name: str, value: pt.Any):
+        """Set configuration value on workers"""
         assert not self._is_running, "set_config: already running"
         self._is_running = True
         spawner.worker_intercomm.bcast(CommandType.SET_CONFIG.value, self.bcast_root)
@@ -584,7 +587,8 @@ class Spawner:
         self._is_running = False
         self._run_del_queue()
 
-    def register_type(self, type_name, type_value):
+    def register_type(self, type_name: str, type_value: types.Type):
+        """Register a new type on workers"""
         assert not self._is_running, "register_type: already running"
         self._is_running = True
         spawner.worker_intercomm.bcast(CommandType.REGISTER_TYPE.value, self.bcast_root)

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -3287,12 +3287,9 @@ def set_config(name, val):
     set_global_config(name, val)
     if test_spawn_mode_enabled:
         import bodo.spawn.spawner
-        from bodo.spawn.spawner import CommandType
 
         spawner = bodo.spawn.spawner.get_spawner()
-        bcast_root = MPI.ROOT if bodo.get_rank() == 0 else MPI.PROC_NULL
-        spawner.worker_intercomm.bcast(CommandType.SET_CONFIG.value, bcast_root)
-        spawner.worker_intercomm.bcast((name, val), bcast_root)
+        spawner.set_config(name, val)
 
 
 @contextmanager

--- a/bodo/utils/typing.py
+++ b/bodo/utils/typing.py
@@ -2690,8 +2690,6 @@ def is_safe_arrow_cast(lhs_scalar_typ, rhs_scalar_typ):
 def register_type(type_name, type_value):
     """register a data type to be used in objmode blocks"""
     import bodo.spawn.spawner
-    from bodo.mpi4py import MPI
-    from bodo.spawn.spawner import CommandType
 
     # check input
     if not isinstance(type_name, str):
@@ -2714,9 +2712,7 @@ def register_type(type_name, type_value):
     # TODO[BSE-4170]: simplify test flags
     if bodo.spawn_mode or bodo.tests.utils.test_spawn_mode_enabled:
         spawner = bodo.spawn.spawner.get_spawner()
-        bcast_root = MPI.ROOT if bodo.get_rank() == 0 else MPI.PROC_NULL
-        spawner.worker_intercomm.bcast(CommandType.REGISTER_TYPE.value, bcast_root)
-        spawner.worker_intercomm.bcast((type_name, type_value), bcast_root)
+        spawner.register_type(type_name, type_value)
 
 
 # boxing TypeRef is necessary for passing type to objmode calls


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Garbage collection can trigger a lazy data structure's delete tasks during execution of a spawn function. This can lead to unexpected data being broadcast to workers, resulting in failures (often MPI broadcast error). Spawn tests fail on current main branch on M1 Macs because of this issue since pytest seems to trigger garbage collection at certain times.

This PR adds a queue for delete tasks and runs them only if other tasks are not running. This at least handles the more common case of garbage collection during function execution which can be long.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

Spawn tests on CI seem enough.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None (just reliability improvement).

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.