### PR TITLE
Fix iceberg_merge_cow_py function handling

### DIFF
--- a/BodoSQL/bodosql/tests/test_iceberg_merge_into_dict_encoding.py
+++ b/BodoSQL/bodosql/tests/test_iceberg_merge_into_dict_encoding.py
@@ -146,7 +146,7 @@ def test_merge_into_dict_encoding_inserts(
     )
 
     verify_dict_encoding_in_columns(
-        ("iceberg_merge_cow_py", "bodo.io.iceberg"),
+        ("iceberg_merge_cow_py", "bodo.io.iceberg.merge_into"),
         (bodo.typeof(bc),),
         bodo.jit(parallel=True)(impl),
         dict_col_names,
@@ -193,7 +193,7 @@ def test_merge_into_dict_encoding_updates(
     )
 
     verify_dict_encoding_in_columns(
-        ("iceberg_merge_cow_py", "bodo.io.iceberg"),
+        ("iceberg_merge_cow_py", "bodo.io.iceberg.merge_into"),
         (bodo.typeof(bc),),
         bodo.jit(parallel=True)(impl),
         dict_col_names,
@@ -237,7 +237,7 @@ def test_merge_into_dict_encoding_deletes(bodosql_dict_context):
     )
 
     verify_dict_encoding_in_columns(
-        ("iceberg_merge_cow_py", "bodo.io.iceberg"),
+        ("iceberg_merge_cow_py", "bodo.io.iceberg.merge_into"),
         (bodo.typeof(bc),),
         bodo.jit(parallel=True)(impl),
         dict_col_names,
@@ -287,7 +287,7 @@ def test_merge_into_dict_encoding_all(bodosql_dict_context):
     )
 
     verify_dict_encoding_in_columns(
-        ("iceberg_merge_cow_py", "bodo.io.iceberg"),
+        ("iceberg_merge_cow_py", "bodo.io.iceberg.merge_into"),
         (bodo.typeof(bc),),
         bodo.jit(parallel=True)(impl),
         dict_col_names,
@@ -355,7 +355,7 @@ def test_merge_into_dict_encoding_no_merge(iceberg_database, iceberg_table_conn)
     )
 
     args = (bodo.typeof(bc),)
-    func_name = ("iceberg_merge_cow_py", "bodo.io.iceberg")
+    func_name = ("iceberg_merge_cow_py", "bodo.io.iceberg.merge_into")
     dict_encoded_column_names = ["A"]
 
     # TODO: Fix dict encoding?

--- a/bodo/transforms/distributed_analysis_call_registry.py
+++ b/bodo/transforms/distributed_analysis_call_registry.py
@@ -489,7 +489,7 @@ class DistributedAnalysisCallRegistry:
             ("set_bit_to_arr", "bodo.libs.int_arr_ext"): no_op_analysis,
             # iceberg_merge_cow_py doesn't have a return value
             # or alter the distribution of any input.
-            ("iceberg_merge_cow_py", "bodo.io.iceberg"): no_op_analysis,
+            ("iceberg_merge_cow_py", "bodo.io.iceberg.merge_into"): no_op_analysis,
             ("decode_if_dict_array", "bodo.utils.typing"): meet_out_first_arg_analysis,
             (
                 "np_to_nullable_array",

--- a/bodo/transforms/distributed_pass.py
+++ b/bodo/transforms/distributed_pass.py
@@ -2360,7 +2360,7 @@ class DistributedPass:
             )
 
         # Iceberg Merge Into
-        if fdef == ("iceberg_merge_cow_py", "bodo.io.iceberg"):
+        if fdef == ("iceberg_merge_cow_py", "bodo.io.iceberg.merge_into"):
             # Dataframe is the 3rd argument (counting from 0)
             df_arg = rhs.args[3].name
             if not self._is_1D_or_1D_Var_arr(df_arg):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
The path to `iceberg_merge_cow_py` changed in a previous PR here https://github.com/bodo-ai/Bodo/pull/130
which needs updated. This should fix a bunch of nightly issues.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
CI tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.