### PR TITLE
BSE-4502: Fix default str args

### DIFF
--- a/bodo/utils/typing.py
+++ b/bodo/utils/typing.py
@@ -2,6 +2,7 @@
 Helper functions to enable typing.
 """
 
+import builtins
 import copy
 import itertools
 import operator
@@ -2273,6 +2274,14 @@ def _gen_objmode_overload(
 
         # Matplotlib specifies some arguments as `<deprecated parameter>`.
         # We can't support them, and it breaks our infrastructure, so omit them.
+        #
+        def get_default(default_val):
+            default_val_type = type(default_val)
+            match default_val_type:
+                case builtins.str:
+                    return "'" + default_val + "'"
+                case _:
+                    return str(default_val)
 
         args = func_spec.args[1:] if attr_name else func_spec.args[:]
         arg_strs = []
@@ -2280,7 +2289,7 @@ def _gen_objmode_overload(
             if i < n_pos_args:
                 arg_strs.append(arg)
             elif str(defaults[i - n_pos_args]) != "<deprecated parameter>":
-                arg_strs.append(arg + "=" + str(defaults[i - n_pos_args]))
+                arg_strs.append(arg + "=" + get_default(defaults[i - n_pos_args]))
             else:
                 args.remove(arg)
 

--- a/bodo/utils/typing.py
+++ b/bodo/utils/typing.py
@@ -2,7 +2,6 @@
 Helper functions to enable typing.
 """
 
-import builtins
 import copy
 import itertools
 import operator
@@ -2276,9 +2275,8 @@ def _gen_objmode_overload(
         # We can't support them, and it breaks our infrastructure, so omit them.
         #
         def get_default(default_val):
-            default_val_type = type(default_val)
-            match default_val_type:
-                case builtins.str:
+            match default_val:
+                case str():
                     return "'" + default_val + "'"
                 case _:
                     return str(default_val)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Scipy upgrade added string default arg to factorial which broke object mode overload
## Testing strategy
PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Scipy factorial usable in jit functions
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.