### PR TITLE
BSE-4505: Fix oracle error check test

### DIFF
--- a/bodo/tests/test_sql_errorchecking.py
+++ b/bodo/tests/test_sql_errorchecking.py
@@ -1,9 +1,7 @@
 """Tests I/O error checking for SQL"""
 # TODO: Move error checking tests from test_sql to here.
 
-import random
 import re
-import string
 
 import numpy as np
 import pandas as pd
@@ -64,16 +62,10 @@ def test_to_sql_oracle():
     def test_impl_write_sql(df, table_name, conn):
         df.to_sql(table_name, conn, index=False, if_exists="replace")
 
-    np.random.seed(5)
-    random.seed(5)
-    len_list = 1
-    letters = string.ascii_letters
-    list_string = [
-        "".join(random.choice(letters) for i in range(4002)) for _ in range(len_list)
-    ]
+    list_int = [np.iinfo(np.int64).max + 1]
     df_in = pd.DataFrame(
         {
-            "AB": list_string,
+            "AB": list_int,
         }
     )
     table_name = "to_sql_table"


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
The string column started being typed as CLOB instead of varchar which has max size of 2GB. This uses a large int instead to trigger an invalid operation.

## Testing strategy
Local
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
NA
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.