### PR TITLE
Fix JSON lines read in parallel

### DIFF
--- a/bodo/io/_csv_json_reader.cpp
+++ b/bodo/io/_csv_json_reader.cpp
@@ -2192,7 +2192,7 @@ extern "C" PyObject *file_chunk_reader(
         // seem like something that should worry us right now
 
         char row_separator = '\n';
-        if (strcmp(suffix, "json") == 0) {
+        if ((strcmp(suffix, "json") == 0) && !json_lines) {
             row_separator = '}';
         }
 

--- a/bodo/tests/test_io_hf.py
+++ b/bodo/tests/test_io_hf.py
@@ -17,6 +17,18 @@ def test_read_csv_hf(datapath, memory_leak_check):
 
 
 @pytest.mark.slow
+def test_read_json_hf(datapath, memory_leak_check):
+    """Test read_json from Hugging Face"""
+
+    def test_impl():
+        return pd.read_json(
+            "hf://datasets/HuggingFaceH4/MATH-500/test.jsonl", lines=True
+        )
+
+    check_func(test_impl, ())
+
+
+@pytest.mark.slow
 def test_read_parquet_hf(datapath, memory_leak_check):
     """Test read_parquet from Hugging Face"""
 

--- a/docs/docs/file_io.md
+++ b/docs/docs/file_io.md
@@ -657,7 +657,7 @@ read and write of data on GCS.
 
 ### Hugging Face Datasets
 
-Bodo supports reading CSV and Parquet data from Hugging Face datasets using the [huggingface_hub](https://huggingface.co/docs/huggingface_hub) library
+Bodo supports reading CSV, JSON and Parquet data from Hugging Face datasets using the [huggingface_hub](https://huggingface.co/docs/huggingface_hub) library
 (which can be installed using pip or Conda).
 The data path should start with `hf://`. For example:
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Fixes a JSON read bug that was exposed during HuggingFace effort. Using `}` separator for this dataset is problematic since the data itself has `}`. We should discuss not accepting JSON altogether if `lines=False` because of potential similar issues.

Looks like this bug was introduced 5 years ago! Previous version checked lines when setting the separator.
https://github.com/bodo-ai/Bodo/commit/b3d9e7182beab0d893ccd9985ee54f1907312318

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added a unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

Bug fix and minor doc change.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.