### PR TITLE
Skip Tabular Tests

### DIFF
--- a/BodoSQL/bodosql/tests/test_types/tabular_test_harness.py
+++ b/BodoSQL/bodosql/tests/test_types/tabular_test_harness.py
@@ -1,13 +1,13 @@
 from ddltest_harness import DDLTestHarness
 
 import bodosql
-from bodo.tests.iceberg_database_helpers.utils import get_spark_tabular
+from bodo.tests.iceberg_database_helpers.utils import get_spark
 from bodo.utils.utils import run_rank0
 
 
 class TabularTestHarness(DDLTestHarness):
     def __init__(self, tabular_catalog, tabular_connection, tmppath):
-        self.spark = get_spark_tabular(tabular_connection, tmppath)
+        self.spark = get_spark(tabular_connection, tmppath)
         self.bc = bodosql.BodoSQLContext(catalog=tabular_catalog)
 
     def run_bodo_query(self, query):

--- a/BodoSQL/bodosql/tests/test_types/test_tabular_iceberg_catalog.py
+++ b/BodoSQL/bodosql/tests/test_types/test_tabular_iceberg_catalog.py
@@ -9,7 +9,7 @@ import pytest
 import bodo
 import bodosql
 from bodo.tests.iceberg_database_helpers.utils import (
-    get_spark_tabular,
+    get_spark,
 )
 from bodo.tests.user_logging_utils import (
     check_logger_msg,
@@ -219,7 +219,7 @@ def check_table_comment(
     if bodo.get_rank() != 0:
         return
 
-    spark = get_spark_tabular(tabular_connection)
+    spark = get_spark(tabular_connection)
     table_cmt = (
         spark.sql(f"DESCRIBE TABLE EXTENDED {schema}.{table_name}")
         .filter("col_name = 'Comment'")

--- a/bodo/tests/iceberg_database_helpers/utils.py
+++ b/bodo/tests/iceberg_database_helpers/utils.py
@@ -5,8 +5,6 @@ from typing import NamedTuple
 import pandas as pd
 from pyspark.sql import SparkSession
 
-import bodo
-
 DATABASE_NAME = "iceberg_db"
 
 
@@ -61,7 +59,9 @@ def get_spark(path: str = ".") -> SparkSession:
         # Note that we need to have all catalogs registered on the same instance
         # because otherwise spark will cache the instance, and not pick up new
         # configuration changes.
-        if "TABULAR_CREDENTIAL" in os.environ:
+        # Tabular's platform seems to be dead but we will reuse this for general
+        # rest catalog testing.
+        if "TABULAR_CREDENTIAL" in os.environ and False:
             # TODO(aneesh) this is mildly sketchy - ideally a tabular spark
             # instance should be provided as pytest fixture
             from bodo.tests.conftest import get_tabular_connection
@@ -104,14 +104,6 @@ def get_spark(path: str = ".") -> SparkSession:
         shutil.rmtree("/root/.ivy2", ignore_errors=True)
         shutil.rmtree("/root/.m2/repository", ignore_errors=True)
     return do_get_spark()
-
-
-def get_spark_tabular(tabular_connection, path="."):
-    if bodo.get_rank() != 0:
-        return None
-    spark = get_spark(path=path)
-    spark.sql("use default;")
-    return spark
 
 
 def transform_str(col_name: str, transform: str, val: int) -> str:

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -3114,8 +3114,8 @@ pytest_one_rank = [
 tabular_markers = (
     pytest.mark.tabular,
     pytest.mark.iceberg,
-    pytest.mark.skipif(
-        "TABULAR_CREDENTIAL" not in os.environ, reason="requires tabular credentials"
+    pytest.mark.skip(
+        "Tabular's platform is deactivated, we will replace these with Polaris"
     ),
 )
 

--- a/docs/docs/api_docs/sql/database_catalogs.md
+++ b/docs/docs/api_docs/sql/database_catalogs.md
@@ -223,60 +223,6 @@ To access S3 BodoSQL uses the following environment variables to connect to S3:
 If you encounter any issues connecting to s3 or accessing a table, please ensure that these environment variables are set.
 For more information please refer to the [AWS documentation.](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
 
-
-## TabularCatalog {#tabular-catalog-api}
-
-The `TabularCatalog` allows users to read and write tables using the REST Iceberg Catalog provided by Tabular.
-To use this catalog, you will have to select a warehouse and provide a method of authentication.
-
-```py
-catalog = bodosql.TabularCatalog(
-    warehouse="warehouse_name",
-    credential="clientid:clientsecret"
-)
-bc = bodosql.BodoSQLContext(catalog=catalog)
-
-@bodo.jit
-def run_query(bc):
-    return bc.sql("SELECT * FROM MY_SCHEMA.MY_TABLE")
-
-run_query(bc)
-```
-
-When constructing a query you must follow the BodoSQL rules for [identifier case sensitivity][identifier-case-sensitivity].
-
-
-### API Reference
-
-- `bodosql.TabularCatalog(warehouse: str, credential: str, token: str)`
-<br><br>
-
-    Constructor for `TabularCatalog`. This allows users to use a Tabular Iceberg Warehouse as a database for querying
-    or writing tables with a `BodoSQLContext`. Either `credential` or `token` must be provided.
-
-    ***Arguments***
-
-    - `warehouse`: Name of the Tabular Iceberg Warehouse to query.
-
-    - `rest_uri`: The REST URI for Tabular's REST Iceberg catalog, defaults to `https://api.tabular.io/ws`.
-
-    - `credential`: The [Tabular credential](https://docs.tabular.io/en/creating-and-modifying-credentials.html) to use for authentication. This should be in the form of `clientid:clientsecret`.
-
-    - `token`: A [temporary OAuth2 token](https://docs.tabular.io/en/data-access-flow-in-tabular.html) to use for authentication. This token should be a valid token for the Tabular Warehouse.
-
-#### Supported Query Types
-
-The `TabularCatalog` currently supports the following types of SQL queries:
-
-  * `#!sql SELECT`
-  * `#!sql CREATE TABLE AS`
-
-
-#### S3 Support
-
-The `TabularCatalog` supports reading and writing tables stored on S3.
-S3 access is provided by the Tabular Warehouse and does not require any additional configuration.
-
 ## GlueCatalog {#glue-catalog-api}
 
 The `GlueCatalog` allows users to read and write tables using AWS Glue.

--- a/docs/docs/iceberg/intro.md
+++ b/docs/docs/iceberg/intro.md
@@ -36,7 +36,6 @@ These are the Iceberg catalogs supported in Bodo Python and SQL:
 |--------------|---------------------|-----------------|------------------|
 | HadoopCatalog | Yes | Yes, via the FileSystemCatalog | Local and S3 Support |
 | Snowflake's Managed Iceberg Catalog | Yes | Yes, via the SnowflakeCatalog | Integrated into BodoSQL's Snowflake support |
-| Tabular's RESTCatalog | Yes | Yes, via the TabularCatalog | Only tested on S3 |
 | GlueCatalog | Yes | Yes, via the GlueCatalog |  |
 | HiveCatalog | Yes | Yes, via TablePath |  |
 | S3 Tables | Yes | Yes, via the S3TablesCatalog |  |

--- a/docs/docs/iceberg/read_write.md
+++ b/docs/docs/iceberg/read_write.md
@@ -7,7 +7,6 @@ Reading and Writing Iceberg in Bodo {#iceberg_read_write}
 BodoSQL can be used to read, create, or insert into an Iceberg table. Iceberg Tables are automatically detected by existing catalogs and are used during read:
 
 - Snowflake Iceberg Tables are automatically detected when using the [`SnowflakeCatalog`][snowflake-catalog-api].
-- Tables within the specified warehouse are automatically detected when using the [`TabularCatalog`][tabular-catalog-api].
 - Tables within the specified warehouse are automatically detected when using the [`GlueCatalog`][glue-catalog-api].
 - Tables within the specified warehouse are automatically detected when using the [`S3TablesCatalog`][s3-tables-catalog-api].
 - Hadoop Iceberg Catalogs and Tables are detected when using the [`FileSystemCatalog`][fs-catalog-api].

--- a/docs/docs/integrating_bodo/database_catalog.md
+++ b/docs/docs/integrating_bodo/database_catalog.md
@@ -18,8 +18,8 @@ Click on _CREATE CATALOG_ and fill up the form with the required values.
 ![Catalogs](../platform2-screenshots/catalogspage.png#center) 
 
 
-Currently, we support Snowflake Database Catalogs, Tabular Database Catalogs and AWS Glue Catalogs on the Bodo Platform.  
-See [`SnowflakeCatalog`][snowflake-catalog-api], [`TabularCatalog`][tabular-catalog-api] and [`GlueCatalog`][glue-catalog-api] for details on
+Currently, we support Snowflake Database Catalogs, and AWS Glue Catalogs on the Bodo Platform.  
+See [`SnowflakeCatalog`][snowflake-catalog-api] and [`GlueCatalog`][glue-catalog-api] for details on
 the required parameters.
 
 Upon submitting the form, you will see that your Catalog has been created and is now


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Our Tabular credentials finally died, I'm assuming the platform is just done, I can't login to the webui either.
I skipped all tests and removed references from docs, leaving the code since it'll be reusable by polaris/general rest catalog.

## Testing strategy
Going to re-run nightly once this is merged 5000 tests failed since creating spark connects to tabular
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Docs update
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.