### PR TITLE
Update nightly error checking tests for constant getitem

### DIFF
--- a/bodo/tests/test_io_errorchecking.py
+++ b/bodo/tests/test_io_errorchecking.py
@@ -877,9 +877,14 @@ def test_csv_sample_nrows_size(memory_leak_check):
     def impl2(fname):
         return pd.read_csv(fname, sample_nrows="no thanks")
 
+    @bodo.jit
+    def g(ilist):
+        print(ilist)
+        return ilist[0]
+
     # nonconstant
     def impl3(fname, ilist):
-        return pd.read_csv(fname, sample_nrows=ilist[0])
+        return pd.read_csv(fname, sample_nrows=g(ilist))
 
     with pytest.raises(
         BodoError,

--- a/bodo/tests/test_io_errorchecking.py
+++ b/bodo/tests/test_io_errorchecking.py
@@ -378,9 +378,14 @@ def test_csv_skiprows_type_nonconstant(memory_leak_check):
     """
     fname = os.path.join("bodo", "tests", "data", "example.csv")
 
+    @bodo.jit
+    def g(skiprow_list):
+        print(skiprow_list)
+        return skiprow_list[0]
+
     def impl(skiprow_list):
         return pd.read_csv(
-            fname, skiprows=skiprow_list[0], names=["X", "Y", "Z", "MM", "AA"]
+            fname, skiprows=g(skiprow_list), names=["X", "Y", "Z", "MM", "AA"]
         )
 
     skiprow_list = ["abcd"]

--- a/bodo/tests/test_io_errorchecking.py
+++ b/bodo/tests/test_io_errorchecking.py
@@ -928,9 +928,14 @@ def test_json_sample_nrows_size(memory_leak_check):
     def impl2(fname):
         return pd.read_json(fname, sample_nrows="no thanks")
 
+    @bodo.jit
+    def g(ilist):
+        print(ilist)
+        return ilist
+
     # nonconstant
     def impl3(fname, ilist):
-        return pd.read_json(fname, sample_nrows=ilist[0])
+        return pd.read_json(fname, sample_nrows=g(ilist))
 
     with pytest.raises(
         BodoError,

--- a/bodo/tests/test_io_errorchecking.py
+++ b/bodo/tests/test_io_errorchecking.py
@@ -400,9 +400,14 @@ def test_csv_skiprows_nonconstant_incorrect_values():
     """
     fname = os.path.join("bodo", "tests", "data", "example.csv")
 
+    @bodo.jit
+    def g(skiprow_list):
+        print(skiprow_list)
+        return skiprow_list[0]
+
     def impl(skiprow_list):
         return pd.read_csv(
-            fname, skiprows=skiprow_list[0], names=["X", "Y", "Z", "MM", "AA"]
+            fname, skiprows=g(skiprow_list), names=["X", "Y", "Z", "MM", "AA"]
         )
 
     skiprow_list = [-2]
@@ -411,6 +416,7 @@ def test_csv_skiprows_nonconstant_incorrect_values():
 
     @bodo.jit
     def f2():
+        print("f2")
         return [1, -3, 0]
 
     def impl2():

--- a/bodo/tests/test_io_errorchecking.py
+++ b/bodo/tests/test_io_errorchecking.py
@@ -380,6 +380,7 @@ def test_csv_skiprows_type_nonconstant(memory_leak_check):
 
     @bodo.jit
     def g(skiprow_list):
+        # Add print to avoid constant inference to call the function at compile time
         print(skiprow_list)
         return skiprow_list[0]
 
@@ -407,6 +408,7 @@ def test_csv_skiprows_nonconstant_incorrect_values():
 
     @bodo.jit
     def g(skiprow_list):
+        # Add print to avoid constant inference to call the function at compile time
         print(skiprow_list)
         return skiprow_list[0]
 
@@ -421,6 +423,7 @@ def test_csv_skiprows_nonconstant_incorrect_values():
 
     @bodo.jit
     def f2():
+        # Add print to avoid constant inference to call the function at compile time
         print("f2")
         return [1, -3, 0]
 
@@ -884,6 +887,7 @@ def test_csv_sample_nrows_size(memory_leak_check):
 
     @bodo.jit
     def g(ilist):
+        # Add print to avoid constant inference to call the function at compile time
         print(ilist)
         return ilist[0]
 
@@ -930,6 +934,7 @@ def test_json_sample_nrows_size(memory_leak_check):
 
     @bodo.jit
     def g(ilist):
+        # Add print to avoid constant inference to call the function at compile time
         print(ilist)
         return ilist
 

--- a/bodo/tests/test_series_errorchecking.py
+++ b/bodo/tests/test_series_errorchecking.py
@@ -405,8 +405,14 @@ def test_astype_non_constant_string(memory_leak_check):
     is not a compile time constant will produce a reasonable BodoError.
     """
 
+    @bodo.jit
+    def g(s):
+        # Add print to avoid constant inference to call the function at compile time
+        print(s)
+        return s[0]
+
     def impl(S, type_str):
-        return S.astype(type_str[0])
+        return S.astype(g(type_str))
 
     S = pd.Series([1, 2, 3, 4] * 10)
     type_str = ["uint64"]


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Updates error checking tests that check for non-constant since this PR allows getitem inference:
https://github.com/bodo-ai/Bodo/pull/176

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

Ran the tests locally since very simple.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.