### PR TITLE
BSE-4525: Update int -> decimal type coercion

### DIFF
--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/validate/implicit/BodoTypeCoercionImpl.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/validate/implicit/BodoTypeCoercionImpl.java
@@ -185,13 +185,13 @@ public class BodoTypeCoercionImpl extends TypeCoercionImpl {
 
     // Fix new precision and scale for integer - decimal and decimal - decimal comparisons
     if ((SqlTypeUtil.isDecimal(type1) || SqlTypeUtil.isDecimal(type2)) && (SqlTypeUtil.isExactNumeric(type1) && SqlTypeUtil.isExactNumeric(type2))) {
-      int l1 = type1.getPrecision() - type1.getScale();
-      int l2 = type2.getPrecision() - type2.getScale();
+      final RelDataType type1AsDecimal = factory.decimalOf(type1);
+      final RelDataType type2AsDecimal = factory.decimalOf(type2);
+      int l1 = type1AsDecimal.getPrecision() - type1AsDecimal.getScale();
+      int l2 = type2AsDecimal.getPrecision() - type2AsDecimal.getScale();
       int newLeading = Math.max(l1, l2);
-      int newScale = Math.max(type1.getScale(), type2.getScale());
-      int maxPrecision = factory.getTypeSystem().getMaxPrecision(SqlTypeName.DECIMAL);
-      int newPrecision = Math.min(newLeading + newScale, maxPrecision);
-      newScale = Math.min(newScale, maxPrecision - newLeading);
+      final int newScale = Math.min(Math.max(type1AsDecimal.getScale(), type2AsDecimal.getScale()), factory.getTypeSystem().getMaxScale(SqlTypeName.DECIMAL));
+      final int newPrecision = Math.min(newLeading + newScale, factory.getTypeSystem().getMaxPrecision(SqlTypeName.DECIMAL));
       return factory.createSqlType(SqlTypeName.DECIMAL, newPrecision, newScale);
     }
 

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/validate/implicit/BodoTypeCoercionImpl.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql/validate/implicit/BodoTypeCoercionImpl.java
@@ -185,12 +185,19 @@ public class BodoTypeCoercionImpl extends TypeCoercionImpl {
 
     // Fix new precision and scale for integer - decimal and decimal - decimal comparisons
     if ((SqlTypeUtil.isDecimal(type1) || SqlTypeUtil.isDecimal(type2)) && (SqlTypeUtil.isExactNumeric(type1) && SqlTypeUtil.isExactNumeric(type2))) {
+      // Convert all types to decimal so we can get an accurate precision and scale
+      // Integer types return defaultMaxPrecision and defaultMaxScale which creates
+      // an incorrect precision and scale for the resulting decimal type.
       final RelDataType type1AsDecimal = factory.decimalOf(type1);
       final RelDataType type2AsDecimal = factory.decimalOf(type2);
+      // Get the number of leading digits for each type
       int l1 = type1AsDecimal.getPrecision() - type1AsDecimal.getScale();
       int l2 = type2AsDecimal.getPrecision() - type2AsDecimal.getScale();
+      // New leading digits is the max of the two types to ensure we don't lose any information
       int newLeading = Math.max(l1, l2);
+      // New scale is the max of the two types clamped to the max scale to ensure we don't lose any information when possible
       final int newScale = Math.min(Math.max(type1AsDecimal.getScale(), type2AsDecimal.getScale()), factory.getTypeSystem().getMaxScale(SqlTypeName.DECIMAL));
+      // New precision is the sum of the new leading and new scale clamped to the max precision to ensure we don't lose any information when possible
       final int newPrecision = Math.min(newLeading + newScale, factory.getTypeSystem().getMaxPrecision(SqlTypeName.DECIMAL));
       return factory.createSqlType(SqlTypeName.DECIMAL, newPrecision, newScale);
     }


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes a bug where we call getMaxPrecision and getMaxScale on integer types, this always returns 38, 0 due to the way we've defined our type system. Fixed this by converting to decimal first

## Testing strategy
Running tests locally
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.