### PR TITLE
BSE-4525: Fix calcite upgrade

### DIFF
--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1940,10 +1940,9 @@ public class SqlToRelConverter {
       if (leftKeys.size() == 1) {
         SqlCall sqlCall =
             comparisonOp.createCall(rightVals.getParserPosition(), leftKeys.get(0), rightVals);
-        // Bodo Change: Derive the type of sql call so
+        // Bodo Change: Register the sql call so it has a type and
         // any calls to addAlias will work correctly
-        validator.deriveType(bb.scope, sqlCall);
-        rexComparison = bb.convertExpression(sqlCall);
+        rexComparison = bb.convertExpression(reg(bb.scope, sqlCall));
       } else {
         assert rightVals instanceof SqlCall;
         final SqlBasicCall call = (SqlBasicCall) rightVals;

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1940,6 +1940,9 @@ public class SqlToRelConverter {
       if (leftKeys.size() == 1) {
         SqlCall sqlCall =
             comparisonOp.createCall(rightVals.getParserPosition(), leftKeys.get(0), rightVals);
+        // Bodo Change: Derive the type of sql call so
+        // any calls to addAlias will work correctly
+        validator.deriveType(bb.scope, sqlCall);
         rexComparison = bb.convertExpression(sqlCall);
       } else {
         assert rightVals instanceof SqlCall;


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Registers a constructed sqlCalls type so null equals aliases don't error out
## Testing strategy
PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.