### PR TITLE
Update Numba and Numpy versions in other places after Numba 0.61.0 upgrade

### DIFF
--- a/buildscripts/bodo/conda-recipe/meta.yaml
+++ b/buildscripts/bodo/conda-recipe/meta.yaml
@@ -39,10 +39,10 @@ requirements:
     - ninja
     - mpi4py =3.1.5
 
-    - numba =0.60.0
+    - numba =0.61.0
     # Compatible with Numba requirements.
     # Resolves build issues on nightly
-    - numpy >=1.24,<1.27
+    - numpy >=1.24,<2.2
     - pandas >=2.2,<2.3
     - fsspec >=2021.09
     - libarrow =18.1.0
@@ -67,7 +67,7 @@ requirements:
     - pandas >=2.2,<2.3
     - fsspec >=2021.09
     - pyarrow =18.1.0
-    - numba 0.60.0
+    - numba 0.61.0
     - mpich *=h* # [not win]
     - msmpi # [win]
     - vs2015_runtime # [win]
@@ -82,7 +82,7 @@ requirements:
   # but will restrict them if they are present in the conda env.
   run_constrained:
     - matplotlib <= 3.8.2
-    - numpy >=1.24,<1.27
+    - numpy >=1.24,<2.2
     - scikit-learn =1.4.*
     - s3fs >=2022.1.0
     - adlfs >=2022.1.0

--- a/iceberg/pyproject.toml
+++ b/iceberg/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "py4j==0.10.9.7",
     "pyarrow==18.1.0",
-    "numpy>=1.24,<1.27",
+    "numpy>=1.24,<2.2",
     "pandas>=2.2,<2.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "scikit-build-core[pyproject]",
     "cython>=3.0,<3.1",
     # Build Libraries
-    "numpy>=1.24,<1.27",
+    "numpy>=1.24,<2.2",
     "pyarrow==18.1.0",
     "mpi4py>=3.1,<3.2",
     "pip"
@@ -35,10 +35,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "numba==0.60.0",
+    "numba==0.61.0",
     "pyarrow==18.1.0",
     "pandas>=2.2,<2.3",
-    "numpy>=1.24,<1.27",
+    "numpy>=1.24,<2.2",
     # fsspec >= 2021.09 because it includes Arrow filesystem wrappers (useful for fs.glob() for example)
     "fsspec>=2021.09",
     "requests",


### PR DESCRIPTION
Follow up on Numba 0.61 upgrade: https://github.com/bodo-ai/Bodo/pull/98