### PR TITLE
Switch to Using GitHub's Linux ARM Instances

### DIFF
--- a/.github/workflows/_build_bodo_conda_linux_comm.yml
+++ b/.github/workflows/_build_bodo_conda_linux_comm.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-bodo:
-    runs-on: ${{ inputs.arm && 'self-arm-medium' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.arm && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     container: ${{ inputs.arm && 'condaforge/linux-anvil-aarch64:alma8' || 'condaforge/linux-anvil-x86_64:alma8' }}
     permissions:
       id-token: write

--- a/.github/workflows/_build_bodo_pip.yml
+++ b/.github/workflows/_build_bodo_pip.yml
@@ -59,13 +59,6 @@ jobs:
         if: contains(inputs.os, 'macos')
         run: |
           pixi global install sccache
-      # TODO: Remove once the self-hosted runners use Ubuntu
-      - name: Install Pipx on Self-Hosted Runner
-        if: inputs.name == 'linux-arm'
-        run: |
-          sudo dnf install -y python3-pip
-          python3 -m pip install --user pipx
-          python3 -m pipx ensurepath 
 
       - name: Build Wheels
         run: ${{ contains(inputs.os, 'macos') && 'pipx' || 'python3 -m pipx' }} run cibuildwheel==2.22.0

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,7 +52,7 @@ jobs:
             name: macos-x86
           - os: macos-latest
             name: macos-arm
-          - os: self-arm-medium
+          - os: ubuntu-24.04-arm
             name: linux-arm
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
## Changes included in this PR

Use GitHubs new Linux ARM instances instead of our self-hosted ones. https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

## Testing strategy

Run the build CIs.

## User facing changes

None

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.