### PR TITLE
Add extra arg to is_in test helper

### DIFF
--- a/BodoSQL/bodosql/tests/test_kernels/test_special_handling_array_kernels.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_special_handling_array_kernels.py
@@ -36,7 +36,10 @@ def verify_dict_encoded_in_impl(impl, args):
 
     # Note: infrastructure doesn't handle defaults, so we need to manually add this to
     # the signature
-    used_sig = used_sig + (bodo.bool_,)
+    used_sig = used_sig + (
+        bodo.none,
+        bodo.bool_,
+    )
     # Find the is_in_util dispatcher in the IR
     dispatcher, used_sig = find_nested_dispatcher_and_args(
         dispatcher,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Nightly (BodoSQL only) This eliminates around half of the issues but there are still a few more. https://dev.azure.com/bodo-inc/Bodo/_build/results?buildId=25476&view=results 
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.