### PR TITLE
Reduce cache path length for string generated functions

### DIFF
--- a/bodo/numba_compat.py
+++ b/bodo/numba_compat.py
@@ -1915,6 +1915,8 @@ def CacheImpl__init__(self, py_func):
     )
 
     conf_str_hash = hashlib.md5(get_sql_config_str().encode()).hexdigest()
+    # Remove unnecessary prefix to make path shorter (important on Windows)
+    fullname = fullname.removeprefix("<string>.")
     self._filename_base = f"{self.get_filename_base(fullname, abiflags)}bodo{bodo_version}-{conf_str_hash}"
 
 
@@ -6842,7 +6844,7 @@ class BodoCacheLocator(numba.core.caching._CacheLocator):
         cache_path = numba.config.CACHE_DIR
     else:
         appdirs = AppDirs(appname="bodo", appauthor=False)
-        cache_path = os.path.join(appdirs.user_cache_dir, ".bodo_strfunc_cache")
+        cache_path = os.path.join(appdirs.user_cache_dir, ".strfunc_cache")
 
     def __init__(self, py_func, py_file):
         source = BodoCacheLocator.registered_funcs[py_func.__qualname__]

--- a/bodo/utils/utils.py
+++ b/bodo/utils/utils.py
@@ -1853,7 +1853,7 @@ def create_arg_hash(*args, **kwargs):
     concat_str_args = "".join(map(str, args)) + "".join(
         f"{k}={v}" for k, v in kwargs.items()
     )
-    arg_hash = hashlib.sha256(concat_str_args.encode("utf-8"))
+    arg_hash = hashlib.md5(concat_str_args.encode("utf-8"))
     return arg_hash.hexdigest()
 
 
@@ -1868,7 +1868,9 @@ def bodo_exec(func_text, glbls, loc_vars, real_globals):
         real_globals: should be passed globals() from the calling scope
     """
     # Get hash of function text.
-    text_hash = hashlib.sha256(func_text.encode("utf-8")).hexdigest()
+    # Using shorter md5 hash vs sha256 to reduce chances of hitting 260 character limit
+    # on Windows.
+    text_hash = hashlib.md5(func_text.encode("utf-8")).hexdigest()
     # Use a regular expression to find and add hash to the function name.
     pattern = r"(^def\s+)(\w+)(\s*\()"
     found_pattern = re.search(pattern, func_text)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. This reduces the chances of hitting the 260 character limit in Windows paths. Fixes some of our unit tests.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests on Windows. Just applicable to internal functions so our CI should catch issues.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.