### PR TITLE
Add as_null=None to other signatures

### DIFF
--- a/BodoSQL/bodosql/kernels/special_handling_array_kernels.py
+++ b/BodoSQL/bodosql/kernels/special_handling_array_kernels.py
@@ -57,7 +57,7 @@ def is_in(
 
 
 def is_in_util(
-    arr_to_check, arr_search_vals, null_as, is_parallel=False
+    arr_to_check, arr_search_vals, null_as=None, is_parallel=False
 ):  # pragma: no cover
     pass
 
@@ -94,9 +94,9 @@ def is_in_overload(arr_to_check, arr_search_vals, null_as=None, is_parallel=Fals
         if isinstance(args[i], types.optional):  # pragma: no cover
             return unopt_argument(
                 "bodosql.kernels.is_in",
-                ["arr_to_check", "arr_search_vals", "is_parallel"],
+                ["arr_to_check", "arr_search_vals", "null_as", "is_parallel"],
                 i,
-                default_map={"is_parallel": False},
+                default_map={"null_as": None, "is_parallel": False},
             )
 
     def impl(
@@ -108,7 +108,7 @@ def is_in_overload(arr_to_check, arr_search_vals, null_as=None, is_parallel=Fals
 
 
 @overload(is_in_util)
-def is_in_util_overload(arr_to_check, arr_search_vals, null_as, is_parallel=False):
+def is_in_util_overload(arr_to_check, arr_search_vals, null_as=None, is_parallel=False):
     """
     Helper function for is_in. See is_in for information on arguments
     """
@@ -120,7 +120,7 @@ def is_in_util_overload(arr_to_check, arr_search_vals, null_as, is_parallel=Fals
     if arr_to_check == types.none:
 
         def impl(
-            arr_to_check, arr_search_vals, null_as, is_parallel=False
+            arr_to_check, arr_search_vals, null_as=None, is_parallel=False
         ):  # pragma: no cover
             return None
 
@@ -130,7 +130,7 @@ def is_in_util_overload(arr_to_check, arr_search_vals, null_as, is_parallel=Fals
         """If the types match, we don't have to do any casting, we can just use the array isin kernel"""
 
         def impl(
-            arr_to_check, arr_search_vals, null_as, is_parallel=False
+            arr_to_check, arr_search_vals, null_as=None, is_parallel=False
         ):  # pragma: no cover
             # code modified from overload_series_isin
             n = len(arr_to_check)
@@ -162,7 +162,7 @@ def is_in_util_overload(arr_to_check, arr_search_vals, null_as, is_parallel=Fals
         ), "Internal error: arr_to_check is dict encoded, but arr_search_vals does not have string dtype"
 
         def impl(
-            arr_to_check, arr_search_vals, null_as, is_parallel=False
+            arr_to_check, arr_search_vals, null_as=None, is_parallel=False
         ):  # pragma: no cover
             # code modified from overload_series_isin
             n = len(arr_to_check)
@@ -211,7 +211,7 @@ def is_in_util_overload(arr_to_check, arr_search_vals, null_as, is_parallel=Fals
     if is_array_typ(arr_to_check):
 
         def impl(
-            arr_to_check, arr_search_vals, null_as, is_parallel=False
+            arr_to_check, arr_search_vals, null_as=None, is_parallel=False
         ):  # pragma: no cover
             # code modified from overload_series_isin
             n = len(arr_to_check)
@@ -237,7 +237,7 @@ def is_in_util_overload(arr_to_check, arr_search_vals, null_as, is_parallel=Fals
     elif is_scalar_type(arr_to_check):
 
         def impl(
-            arr_to_check, arr_search_vals, null_as, is_parallel=False
+            arr_to_check, arr_search_vals, null_as=None, is_parallel=False
         ):  # pragma: no cover
             # convert scalar to array, do the operation, and then return the scalar value
             arr_to_check = bodo.utils.conversion.fix_arr_dtype(


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As Title
## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Tested locally. 
Original error fixed
```
E                            numba.core.errors.InternalError: Typing and implementation arguments differ in keyword argument names.
E                            Typing signature:         (arr_to_check, arr_search_vals, null_as=None, is_parallel=False)
E                            Implementation signature: (arr_to_check, arr_search_vals, is_parallel=False)
```
Tests still fails with error related to `AttributeError: 'PythonAPI' object has no attribute 'import_module'`. To be fixed in another PR.
## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.