### PR TITLE
Fix decimal scalar boxing on Windows

### DIFF
--- a/bodo/libs/_decimal_ext.cpp
+++ b/bodo/libs/_decimal_ext.cpp
@@ -2237,9 +2237,10 @@ decimal_value int64_to_decimal(int64_t value) {
 
 void unbox_decimal(PyObject* obj, uint8_t* data);
 
-PyObject* box_decimal(decimal_value val, int8_t precision, int8_t scale) {
+PyObject* box_decimal(uint64_t low, int64_t high, int8_t precision,
+                      int8_t scale) {
     // convert input to Arrow scalar
-    arrow::Decimal128 arrow_decimal(val.high, val.low);
+    arrow::Decimal128 arrow_decimal(high, low);
     std::shared_ptr<arrow::Decimal128Scalar> scalar =
         std::make_shared<arrow::Decimal128Scalar>(
             arrow_decimal, arrow::decimal128(precision, scale));


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

As title.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing CI.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.