### PR TITLE
Fix int32 dtype issue on Windows [run ci]

### DIFF
--- a/bodo/tests/test_dataframe_part1.py
+++ b/bodo/tests/test_dataframe_part1.py
@@ -1480,7 +1480,7 @@ def test_df_abs3(memory_leak_check):
     df = pd.DataFrame(
         {
             "A": pd.Series(
-                np.random.randint(0, np.iinfo(np.int64).max, size=12)
+                np.random.randint(0, np.iinfo(np.int64).max, size=12, dtype=np.int64)
             ).astype("timedelta64[ns]")
         }
     )

--- a/bodo/utils/typing.py
+++ b/bodo/utils/typing.py
@@ -1103,6 +1103,11 @@ def parse_dtype(dtype, func_name=None):
             return bodo.libs.bool_arr_ext.boolean_dtype
         if d_str == "str":
             return bodo.string_type
+
+        # Handle separately since Numpy < 2 on Windows returns int32 in np.dtype
+        if d_str == "int":
+            return types.int64
+
         return numba.np.numpy_support.from_dtype(np.dtype(d_str))
     except Exception:
         pass


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Fixes a couple of places with int32/int64 inconsistencies on Windows.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing CI.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.