### PR TITLE
[Windows int128 compat] Cast Decimal

### DIFF
--- a/bodo/libs/_decimal_ext.cpp
+++ b/bodo/libs/_decimal_ext.cpp
@@ -1917,17 +1917,22 @@ arrow::Decimal128 factorial_decimal_scalar(arrow::Decimal128 val,
 /**
  * @brief Python entry point for taking the factorial of a decimal scalar.
  *
- * @param val Input decimal
- * @param input_s Scale of the input
- * @return arrow::Decimal128 Result of the factorial
+ * @param[in] in_low Low 64 bits of the input decimal.
+ * @param[in] in_high High 64 bits of the input decimal.
+ * @param[in] input_s Scale of the input
+ * @param[out] out_low_ptr Pointer to the low 64 bits of the result.
+ * @param[out] out_high_ptr Pointer to the high 64 bits of the result.
  */
-arrow::Decimal128 factorial_decimal_scalar_py_entry(arrow::Decimal128 val,
-                                                    int64_t input_s) {
+void factorial_decimal_scalar_py_entry(uint64_t in_low, int64_t in_high,
+                                       int64_t input_s, uint64_t* out_low,
+                                       int64_t* out_high) {
     try {
-        return factorial_decimal_scalar(val, input_s);
+        arrow::Decimal128 val = arrow::Decimal128(in_high, in_low);
+        arrow::Decimal128 out = factorial_decimal_scalar(val, input_s);
+        *out_low = out.low_bits();
+        *out_high = out.high_bits();
     } catch (const std::exception& e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
-        return arrow::Decimal128(0);
     }
 }
 


### PR DESCRIPTION
## Changes included in this PR

There are 40 references in `lir.Int128Type`. This PR addresses 4 of them so there are at least 36 remaining references to either input/outputs that need to be replaced.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Run tests locally.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.