### PR TITLE
Create custom MPI ops for argmin/argmax reductions

### DIFF
--- a/bodo/libs/_distributed.cpp
+++ b/bodo/libs/_distributed.cpp
@@ -587,6 +587,152 @@ array_info *gather_array_py_entry(array_info *in_array, bool all_gather,
     }
 }
 
+// Corresponds to Numba's IndexValueType, used for MPI ArgMin/ArgMax.
+// https://github.com/numba/numba/blob/bced43d44b405a9db443b70171eb0125216770b6/numba/core/typing/new_builtins.py#L1152
+#pragma pack(1)
+template <typename T>
+struct IndexValuePair {
+    int64_t index;
+    T value;
+};
+
+/**
+ * @brief Create a pair MPI datatype (index & value) for the given MPI value
+ * type
+ *
+ * @param mpi_typ value type
+ * @return MPI_Datatype output pair MPI data type
+ */
+MPI_Datatype createPairDatatype(MPI_Datatype mpi_typ) {
+    MPI_Datatype newType;
+
+    // Each field is length 1 (1 index & 1 value)
+    int blocklengths[2] = {1, 1};
+
+    // The offsets for index/value members in IndexValuePair
+    MPI_Aint offsets[2] = {0, sizeof(int64_t)};
+
+    // Index/Value MPI data types
+    MPI_Datatype types[2] = {MPI_INT64_T, mpi_typ};
+
+    // Create and commit the custom datatype.
+    CHECK_MPI(MPI_Type_create_struct(2, blocklengths, offsets, types, &newType),
+              "dist_reduce: MPI error on MPI_Type_create_struct:");
+    CHECK_MPI(MPI_Type_commit(&newType),
+              "dist_reduce: MPI error on MPI_Type_commit:");
+
+    return newType;
+}
+
+/**
+ * @brief Custom MPI_Op function for ArgMin
+ *
+ * @tparam T value type
+ * @param invec input index/value
+ * @param inoutvec input/output index/value
+ * @param len number of elements (1 in our case but the op has to be general)
+ * @param datatype MPI data type of input (not used since templated)
+ */
+template <typename T>
+void ArgMinFunction(void *invec, void *inoutvec, int *len,
+                    MPI_Datatype *datatype) {
+    IndexValuePair<T> *in = static_cast<IndexValuePair<T> *>(invec);
+    IndexValuePair<T> *inout = static_cast<IndexValuePair<T> *>(inoutvec);
+
+    for (int i = 0; i < *len; i++) {
+        // If incoming value is smaller, take it
+        if (in[i].value < inout[i].value) {
+            inout[i].value = in[i].value;
+            inout[i].index = in[i].index;
+        }
+        // If tie, pick the smaller index
+        else if (in[i].value == inout[i].value) {
+            if (in[i].index < inout[i].index) {
+                inout[i].index = in[i].index;
+            }
+        }
+    }
+}
+
+/**
+ * @brief Custom MPI_Op function for ArgMax
+ *
+ * @tparam T value type
+ * @param invec input index/value
+ * @param inoutvec input/output index/value
+ * @param len number of elements (1 in our case but the op has to be general)
+ * @param datatype MPI data type of input (not used since templated)
+ */
+template <typename T>
+void ArgMaxFunction(void *invec, void *inoutvec, int *len,
+                    MPI_Datatype *datatype) {
+    IndexValuePair<T> *in = static_cast<IndexValuePair<T> *>(invec);
+    IndexValuePair<T> *inout = static_cast<IndexValuePair<T> *>(inoutvec);
+
+    for (int i = 0; i < *len; i++) {
+        // If incoming value is larger, take it
+        if (in[i].value > inout[i].value) {
+            inout[i].value = in[i].value;
+            inout[i].index = in[i].index;
+        }
+        // If tie, pick the smaller index
+        else if (in[i].value == inout[i].value) {
+            if (in[i].index < inout[i].index) {
+                inout[i].index = in[i].index;
+            }
+        }
+    }
+}
+
+template <typename T>
+MPI_Op createArgMinOp() {
+    MPI_Op op;
+    CHECK_MPI(MPI_Op_create(&ArgMinFunction<T>, /*commute=*/true, &op),
+              "dist_reduce: MPI error on MPI_Op_create:");
+    return op;
+}
+
+template <typename T>
+MPI_Op createArgMaxOp() {
+    MPI_Op op;
+    CHECK_MPI(MPI_Op_create(&ArgMaxFunction<T>, /*commute=*/true, &op),
+              "dist_reduce: MPI error on MPI_Op_create:");
+    return op;
+}
+
+#define EXPAND_ARGMINMAX(mpi_dtype, ctype)  \
+    if (mpi_typ == (mpi_dtype)) {           \
+        if (mpi_op == MPI_MINLOC) {         \
+            return createArgMinOp<ctype>(); \
+        } else if (mpi_op == MPI_MAXLOC) {  \
+            return createArgMaxOp<ctype>(); \
+        }                                   \
+    }
+
+/**
+ * @brief Create a custom MPI_Op for argmin/argmax for provided MPI data type
+ *
+ * @param mpi_typ value type
+ * @param mpi_op MPI_MINLOC or MPI_MAXLOC, specifying which operation to use
+ * @return MPI_Op custom MPI operator for reduction
+ */
+MPI_Op createArgMinMaxOp(MPI_Datatype mpi_typ, MPI_Op mpi_op) {
+    // Instantiate templates for argmin/argmax data types (should match relevant
+    // types in get_MPI_typ)
+    EXPAND_ARGMINMAX(MPI_UNSIGNED_CHAR, unsigned char)
+    EXPAND_ARGMINMAX(MPI_CHAR, char)
+    EXPAND_ARGMINMAX(MPI_INT, int)
+    EXPAND_ARGMINMAX(MPI_UNSIGNED, uint32_t)
+    EXPAND_ARGMINMAX(MPI_LONG_LONG_INT, int64_t)
+    EXPAND_ARGMINMAX(MPI_UNSIGNED_LONG_LONG, uint64_t)
+    EXPAND_ARGMINMAX(MPI_FLOAT, float)
+    EXPAND_ARGMINMAX(MPI_DOUBLE, double)
+    EXPAND_ARGMINMAX(MPI_SHORT, int16_t)
+    EXPAND_ARGMINMAX(MPI_UNSIGNED_SHORT, uint16_t)
+
+    throw std::runtime_error("Unsupported MPI operation for ArgMin/ArgMax");
+}
+
 void dist_reduce(char *in_ptr, char *out_ptr, int op_enum, int type_enum,
                  int64_t comm_ptr) {
     MPI_Datatype mpi_typ = get_MPI_typ(type_enum);
@@ -598,92 +744,18 @@ void dist_reduce(char *in_ptr, char *out_ptr, int op_enum, int type_enum,
 
     // argmax and argmin need special handling
     if (mpi_op == MPI_MAXLOC || mpi_op == MPI_MINLOC) {
-        // TODO: support intercomm in minloc/maxloc
-        assert(comm_ptr == 0);
-        // since MPI's indexed types use 32 bit integers, we workaround by
-        // using rank as index, then broadcasting the actual values from the
-        // target rank.
-        // TODO: generate user-defined reduce operation to avoid this workaround
-        int rank;
-        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Datatype pairMPIType = createPairDatatype(mpi_typ);
+        MPI_Op argMPIOp = createArgMinMaxOp(mpi_typ, mpi_op);
 
-        // allreduce struct is value + integer
-        int value_size;
-        CHECK_MPI(MPI_Type_size(mpi_typ, &value_size),
-                  "dist_reduce: MPI error on MPI_Type_size:");
-        // TODO: support int64_int value on Windows
-        MPI_Datatype val_rank_mpi_typ = get_val_rank_MPI_typ(type_enum);
-        // copy input index_value to output
-        memcpy(out_ptr, in_ptr, value_size + sizeof(int64_t));
+        CHECK_MPI(
+            MPI_Allreduce(in_ptr, out_ptr, 1, pairMPIType, argMPIOp, comm),
+            "_distributed.h::dist_reduce: MPI error on MPI_Allreduce "
+            "(argmin/argmax):");
 
-        // Determine the size of the pointer to allocate.
-        // argmin/argmax in MPI communicates a struct of 2 values:
-        // the actual value and a 32-bit index.
-        int val_idx_struct_size;
-        CHECK_MPI(MPI_Type_size(val_rank_mpi_typ, &val_idx_struct_size),
-                  "dist_reduce: MPI error on MPI_Type_size:");
-
-        // format: value + int (input format is int64+value)
-        char *in_val_rank = (char *)malloc(val_idx_struct_size);
-        if (in_val_rank == nullptr) {
-            return;
-        }
-        char *out_val_rank = (char *)malloc(val_idx_struct_size);
-        if (out_val_rank == nullptr) {
-            free(in_val_rank);
-            return;
-        }
-
-        char *in_val_ptr = in_ptr + sizeof(int64_t);
-
-        // MPI doesn't support values smaller than int and unsigned values, so
-        // cast values when they don't fit originally.
-        // TODO: Add support value_size > struct_val_size (int64 and long on
-        // Windows) and equal size but unsigned uint64 and long on Linux
-        int struct_val_size = val_idx_struct_size - sizeof(MPI_INT);
-        if (struct_val_size > value_size) {
-            // Case 1: uint32 and long on Linux
-            if (struct_val_size == sizeof(int64_t)) {
-                uint32_t orig_val = *((uint32_t *)in_val_ptr);
-                int64_t value = (int64_t)orig_val;
-                memcpy(in_val_rank, (char *)&value, struct_val_size);
-                // Case 2: Values smaller than int32_t (int8, uint8, int16,
-                // uint16)
-                // TODO: Can int be smaller on Windows?
-            } else if (struct_val_size == sizeof(int32_t)) {
-                int32_t value = 0;
-                switch (type_enum) {
-                    case Bodo_CTypes::_BOOL:
-                    case Bodo_CTypes::INT8:
-                        value = (int32_t)*((int8_t *)in_val_ptr);
-                        break;
-                    case Bodo_CTypes::UINT8:
-                        value = (int32_t)*((uint8_t *)in_val_ptr);
-                        break;
-                    case Bodo_CTypes::INT16:
-                        value = (int32_t)*((int16_t *)in_val_ptr);
-                        break;
-                    case Bodo_CTypes::UINT16:
-                        value = (int32_t)*((uint16_t *)in_val_ptr);
-                        break;
-                }
-                memcpy(in_val_rank, &value, struct_val_size);
-            }
-        } else {
-            memcpy(in_val_rank, in_val_ptr, struct_val_size);
-        }
-        memcpy(in_val_rank + struct_val_size, &rank, sizeof(int));
-        CHECK_MPI(MPI_Allreduce(in_val_rank, out_val_rank, 1, val_rank_mpi_typ,
-                                mpi_op, MPI_COMM_WORLD),
-                  "_distributed.h::dist_reduce: MPI error on MPI_Allreduce:");
-
-        int target_rank = *((int *)(out_val_rank + struct_val_size));
-
-        CHECK_MPI(MPI_Bcast(out_ptr, value_size + sizeof(int64_t), MPI_BYTE,
-                            target_rank, MPI_COMM_WORLD),
-                  "_distributed.h::dist_reduce: MPI error on MPI_Bcast:");
-        free(in_val_rank);
-        free(out_val_rank);
+        CHECK_MPI(MPI_Op_free(&argMPIOp),
+                  "_distributed.h::dist_reduce: MPI error on MPI_Op_free:");
+        CHECK_MPI(MPI_Type_free(&pairMPIType),
+                  "_distributed.h::dist_reduce: MPI error on MPI_Type_free:");
         return;
     }
 

--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -691,15 +691,13 @@ def dist_reduce_impl(value, reduce_op, comm):
             types.int32,
             types.float32,
             types.float64,
+            types.int64,
+            bodo.datetime64ns,
+            bodo.timedelta64ns,
+            bodo.datetime_date_type,
+            bodo.TimeType,
         ]
-        # TODO: Support uint64
-        if not sys.platform.startswith("win"):
-            # long is 4 byte on Windows
-            supported_typs.append(types.int64)
-            supported_typs.append(bodo.datetime64ns)
-            supported_typs.append(bodo.timedelta64ns)
-            supported_typs.append(bodo.datetime_date_type)
-            supported_typs.append(bodo.TimeType)
+
         if target_typ not in supported_typs and not isinstance(
             target_typ, (bodo.Decimal128Type, bodo.PandasTimestampType)
         ):  # pragma: no cover

--- a/bodo/tests/test_basic.py
+++ b/bodo/tests/test_basic.py
@@ -289,51 +289,37 @@ def test_funcs_input(request, memory_leak_check):
 
 @pytest.mark.smoke
 def test_reduce(test_dtypes_input, test_funcs_input, memory_leak_check):
-    import sys
-
     # loc allreduce doesn't support int64 on windows
     dtype = test_dtypes_input
     func = test_funcs_input
-    if not (
-        sys.platform.startswith("win")
-        and dtype == "int64"
-        and func in ["argmin", "argmax"]
-    ):
-        func_text = f"""def f(n):
-            A = np.arange(0, n, 1, np.{dtype})
-            return A.{func}()
-        """
-        loc_vars = {}
-        exec(func_text, {"np": np, "bodo": bodo}, loc_vars)
-        test_impl = loc_vars["f"]
-        n = 21  # XXX arange() on float32 has overflow issues on large n
-        check_func(test_impl, (n,))
+
+    func_text = f"""def f(n):
+        A = np.arange(0, n, 1, np.{dtype})
+        return A.{func}()
+    """
+    loc_vars = {}
+    exec(func_text, {"np": np, "bodo": bodo}, loc_vars)
+    test_impl = loc_vars["f"]
+    n = 21  # XXX arange() on float32 has overflow issues on large n
+    check_func(test_impl, (n,))
 
 
 @pytest.mark.slow
 def test_reduce2(test_dtypes_input, test_funcs_input, memory_leak_check):
-    import sys
-
     dtype = test_dtypes_input
     func = test_funcs_input
 
-    # loc allreduce doesn't support int64 on windows
-    if not (
-        sys.platform.startswith("win")
-        and dtype == "int64"
-        and func in ["argmin", "argmax"]
-    ):
-        func_text = f"""def f(A):
-            return A.{func}()
-        """
-        loc_vars = {}
-        exec(func_text, {"np": np}, loc_vars)
-        test_impl = loc_vars["f"]
+    func_text = f"""def f(A):
+        return A.{func}()
+    """
+    loc_vars = {}
+    exec(func_text, {"np": np}, loc_vars)
+    test_impl = loc_vars["f"]
 
-        n = 21
-        np.random.seed(0)
-        A = np.random.randint(0, 10, n).astype(dtype)
-        check_func(test_impl, (A,), convert_to_nullable_float=False)
+    n = 21
+    np.random.seed(0)
+    A = np.random.randint(0, 10, n).astype(dtype)
+    check_func(test_impl, (A,), convert_to_nullable_float=False)
 
 
 @pytest.mark.slow
@@ -353,27 +339,20 @@ def test_reduce_init_val(memory_leak_check):
 
 @pytest.mark.smoke
 def test_reduce_filter1(test_dtypes_input, test_funcs_input, memory_leak_check):
-    import sys
-
     dtype = test_dtypes_input
     func = test_funcs_input
-    # loc allreduce doesn't support int64 on windows
-    if not (
-        sys.platform.startswith("win")
-        and dtype == "int64"
-        and func in ["argmin", "argmax"]
-    ):
-        func_text = f"""def f(A):
-            A = A[A>5]
-            return A.{func}()
-        """
-        loc_vars = {}
-        exec(func_text, {"np": np}, loc_vars)
-        test_impl = loc_vars["f"]
-        n = 21
-        np.random.seed(0)
-        A = np.random.randint(0, 10, n).astype(dtype)
-        check_func(test_impl, (A,), convert_to_nullable_float=False)
+
+    func_text = f"""def f(A):
+        A = A[A>5]
+        return A.{func}()
+    """
+    loc_vars = {}
+    exec(func_text, {"np": np}, loc_vars)
+    test_impl = loc_vars["f"]
+    n = 21
+    np.random.seed(0)
+    A = np.random.randint(0, 10, n).astype(dtype)
+    check_func(test_impl, (A,), convert_to_nullable_float=False)
 
 
 def test_array_reduce(memory_leak_check):

--- a/bodo/tests/test_dataframe_part1.py
+++ b/bodo/tests/test_dataframe_part1.py
@@ -5,7 +5,6 @@ Unittests for DataFrames
 import datetime
 import operator
 import random
-import sys
 
 import numba
 import numpy as np
@@ -2003,11 +2002,13 @@ def test_df_nunique(df_value, memory_leak_check):
 
 def _is_supported_argminmax_typ(d):
     # distributed argmax types, see distributed_api.py
-    supported_typs = [np.int32, np.float32, np.float64]
-    if not sys.platform.startswith("win"):
-        # long is 4 byte on Windows
-        supported_typs.append(np.int64)
-        supported_typs.append(np.dtype("datetime64[ns]"))
+    supported_typs = [
+        np.int32,
+        np.float32,
+        np.float64,
+        np.int64,
+        np.dtype("datetime64[ns]"),
+    ]
     return d in supported_typs
 
 

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -129,12 +129,12 @@ def dist_IR_count(f_ir, func_name):
     return f_ir_text.count(func_name)
 
 
-@bodo.jit
+@numba.njit
 def get_rank():
     return bodo.libs.distributed_api.get_rank()
 
 
-@bodo.jit(cache=True)
+@numba.njit(cache=True)
 def get_start_end(n):
     rank = bodo.libs.distributed_api.get_rank()
     n_pes = bodo.libs.distributed_api.get_size()
@@ -951,6 +951,7 @@ def _get_dist_arg(
     l = len(a) if isinstance(a, pa.Array) else a.shape[0]
 
     start, end = get_start_end(l)
+
     # for var length case to be different than regular 1D in chunk sizes, add
     # one extra element to the second processor
     if var_length and bodo.get_size() >= 2 and l > bodo.get_size():
@@ -966,6 +967,7 @@ def _get_dist_arg(
 
     if check_typing_issues:
         _check_typing_issues(out_val)
+
     return out_val
 
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

This PR creates customer MPI operators for argmin/argmax reductions to avoid the builtin operator limitations. MPI provides `MPI_MINLOC` and `MPI_MAXLOC` operations for argmin/argmax reductions, but the provided pair data types are limited. In particular, MPI has MPI_LONG_INT which works for int64 on Linux/Mac but not Windows. The previous code is too complex due to working around int32 index limitations also,

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.