### PR TITLE
[Windows Int128 compat] Round, trunc, floor, ceil Decimal

### DIFF
--- a/bodo/libs/_decimal_ext.cpp
+++ b/bodo/libs/_decimal_ext.cpp
@@ -1575,16 +1575,16 @@ array_info* round_decimal_array_py_entry(array_info* arr_, int64_t round_scale,
  * @brief Python entrypoint for taking the ceil or floor of a given Decimal128
  * value.
  *
- * @param in_low The Decimal128 value
- * @param in_high The Decimal128 value
- * @param input_p The precision of the input decimal value.
- * @param input_s The scale of the input decimal value.
- * @param round_scale The scale to which the value should be rounded. Negative
- * scales indicate rounding to the left of the decimal point.
- * @param is_ceil A boolean indicating whether to apply the ceiling (true) or
- * floor (false) operation.
- * @param out_low_ptr The Decimal128 value
- * @param out_high_ptr The Decimal128 value
+ * @param[in] in_low The low 64 bits of the input Decimal128 value.
+ * @param[in] in_high The high 64 bits of the input Decimal128 value.
+ * @param[in] input_p The precision of the input decimal value.
+ * @param[in] input_s The scale of the input decimal value.
+ * @param[in] round_scale The scale to which the value should be rounded.
+ * Negative scales indicate rounding to the left of the decimal point.
+ * @param[in] is_ceil A boolean indicating whether to apply the ceiling (true)
+ * or floor (false) operation.
+ * @param[out] out_low_ptr A pointer to the low 64 bits of the result.
+ * @param[out] out_high_ptr A pointer to the high 64 bits of the result.
  */
 void ceil_floor_decimal_scalar_py_entry(uint64_t in_low, int64_t in_high,
                                         int32_t input_p, int32_t input_s,

--- a/bodo/libs/_decimal_ext.cpp
+++ b/bodo/libs/_decimal_ext.cpp
@@ -1575,23 +1575,27 @@ array_info* round_decimal_array_py_entry(array_info* arr_, int64_t round_scale,
  * @brief Python entrypoint for taking the ceil or floor of a given Decimal128
  * value.
  *
- * @param value The Decimal128 value
+ * @param in_low The Decimal128 value
+ * @param in_high The Decimal128 value
  * @param input_p The precision of the input decimal value.
  * @param input_s The scale of the input decimal value.
  * @param round_scale The scale to which the value should be rounded. Negative
  * scales indicate rounding to the left of the decimal point.
  * @param is_ceil A boolean indicating whether to apply the ceiling (true) or
  * floor (false) operation.
- * @return The resulting Decimal128 value.
+ * @param out_low_ptr The Decimal128 value
+ * @param out_high_ptr The Decimal128 value
  */
-arrow::Decimal128 ceil_floor_decimal_scalar_py_entry(arrow::Decimal128 value,
-                                                     int32_t input_p,
-                                                     int32_t input_s,
-                                                     int32_t round_scale,
-                                                     bool is_ceil) {
+void ceil_floor_decimal_scalar_py_entry(uint64_t in_low, int64_t in_high,
+                                        int32_t input_p, int32_t input_s,
+                                        int32_t round_scale, bool is_ceil,
+                                        uint64_t* out_low_ptr,
+                                        int64_t* out_high_ptr) {
     arrow::Decimal128 result;
     try {
         bool overflow = false;
+        arrow::Decimal128 value = arrow::Decimal128(in_high, in_low);
+
         if (is_ceil) {
             if (round_scale < 0) {
                 result = decimalops::Ceil<true>(value, input_p, input_s,
@@ -1612,10 +1616,10 @@ arrow::Decimal128 ceil_floor_decimal_scalar_py_entry(arrow::Decimal128 value,
         if (overflow) {
             throw std::runtime_error("Number out of representable range");
         }
-        return result;
+        *out_low_ptr = result.low_bits();
+        *out_high_ptr = result.high_bits();
     } catch (const std::exception& e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
-        return arrow::Decimal128(0);
     }
 }
 

--- a/bodo/libs/decimal_arr_ext.py
+++ b/bodo/libs/decimal_arr_ext.py
@@ -2608,27 +2608,43 @@ def _round_decimal_scalar(
 
     def codegen(context, builder, signature, args):
         val, round_scale, input_p, input_s, output_p, output_s = args
+        in_low, in_high = _ll_get_int128_low_high(builder, val)
+        out_low_ptr = cgutils.alloca_once(builder, lir.IntType(64))
+        out_high_ptr = cgutils.alloca_once(builder, lir.IntType(64))
         fnty = lir.FunctionType(
-            lir.IntType(128),
+            lir.VoidType(),
             [
-                lir.IntType(128),
+                lir.IntType(64),  # in_low
+                lir.IntType(64),  # in_high
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(1).as_pointer(),
+                lir.IntType(64).as_pointer(),  # out_low_ptr
+                lir.IntType(64).as_pointer(),  # out_high_ptr
             ],
         )
         fn = cgutils.get_or_insert_function(
             builder.module, fnty, name="round_decimal_scalar"
         )
         overflow_pointer = cgutils.alloca_once(builder, lir.IntType(1))
-        ret = builder.call(
+        builder.call(
             fn,
-            [val, round_scale, input_p, input_s, overflow_pointer],
+            [
+                in_low,
+                in_high,
+                round_scale,
+                input_p,
+                input_s,
+                overflow_pointer,
+                out_low_ptr,
+                out_high_ptr,
+            ],
         )
         bodo.utils.utils.inlined_check_and_propagate_cpp_exception(context, builder)
+        res = _ll_int128_from_low_high(builder, out_low_ptr, out_high_ptr)
         overflow = builder.load(overflow_pointer)
-        return context.make_tuple(builder, signature.return_type, [ret, overflow])
+        return context.make_tuple(builder, signature.return_type, [res, overflow])
 
     output_precision = get_overload_const_int(output_p_t)
     output_scale = get_overload_const_int(output_s_t)

--- a/bodo/libs/decimal_arr_ext.py
+++ b/bodo/libs/decimal_arr_ext.py
@@ -2698,25 +2698,41 @@ def _ceil_floor_decimal_scalar(
 
     def codegen(context, builder, signature, args):
         value, input_p, input_s, output_p, output_s, round_scale, is_ceil = args
+        in_low, in_high = _ll_get_int128_low_high(builder, value)
+        out_low_ptr = cgutils.alloca_once(builder, lir.IntType(64))
+        out_high_ptr = cgutils.alloca_once(builder, lir.IntType(64))
         fnty = lir.FunctionType(
-            lir.IntType(128),
+            lir.VoidType(),
             [
-                lir.IntType(128),
+                lir.IntType(64),  # in_low
+                lir.IntType(64),  # in_high
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(1),
+                lir.IntType(64).as_pointer(),  # out_low_ptr
+                lir.IntType(64).as_pointer(),  # out_high_ptr
             ],
         )
         fn = cgutils.get_or_insert_function(
             builder.module, fnty, name="ceil_floor_decimal_scalar"
         )
-        ret = builder.call(
+        builder.call(
             fn,
-            [value, input_p, input_s, round_scale, is_ceil],
+            [
+                in_low,
+                in_high,
+                input_p,
+                input_s,
+                round_scale,
+                is_ceil,
+                out_low_ptr,
+                out_high_ptr,
+            ],
         )
         bodo.utils.utils.inlined_check_and_propagate_cpp_exception(context, builder)
-        return ret
+        res = _ll_int128_from_low_high(builder, out_low_ptr, out_high_ptr)
+        return res
 
     output_precision = get_overload_const_int(output_p_t)
     output_scale = get_overload_const_int(output_s_t)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.