### PR TITLE
Fix decimal add/sub/mul/div/mod on Windows

### DIFF
--- a/bodo/libs/_decimal_ext.cpp
+++ b/bodo/libs/_decimal_ext.cpp
@@ -854,16 +854,22 @@ arrow::Decimal128 multiply_decimal_scalars_util(
 /**
  * @brief Python entry point to multiply two decimal scalars.
  */
-arrow::Decimal128 multiply_decimal_scalars_py_entry(
-    arrow::Decimal128 v1, int64_t p1, int64_t s1, arrow::Decimal128 v2,
-    int64_t p2, int64_t s2, int64_t out_precision, int64_t out_scale,
-    bool* overflow) noexcept {
+void multiply_decimal_scalars_py_entry(uint64_t v1_low, int64_t v1_high,
+                                       int64_t p1, int64_t s1, uint64_t v2_low,
+                                       int64_t v2_high, int64_t p2, int64_t s2,
+                                       int64_t out_precision, int64_t out_scale,
+                                       uint64_t* out_low_ptr,
+                                       uint64_t* out_high_ptr,
+                                       bool* overflow) noexcept {
     try {
-        return multiply_decimal_scalars_util(
+        arrow::Decimal128 v1(v1_high, v1_low);
+        arrow::Decimal128 v2(v2_high, v2_low);
+        arrow::Decimal128 res = multiply_decimal_scalars_util(
             v1, p1, s1, v2, p2, s2, out_precision, out_scale, overflow);
+        *out_low_ptr = res.low_bits();
+        *out_high_ptr = res.high_bits();
     } catch (const std::exception& e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
-        return arrow::Decimal128(0);
     }
 }
 

--- a/bodo/libs/_decimal_ext.cpp
+++ b/bodo/libs/_decimal_ext.cpp
@@ -606,17 +606,21 @@ arrow::Decimal128 add_or_subtract_decimal_scalars_util(
 /**
  * @brief Python entrypoint for addition and subtraction of decimal scalars.
  */
-arrow::Decimal128 add_or_subtract_decimal_scalars_py_entry(
-    arrow::Decimal128 v1, int64_t p1, int64_t s1, arrow::Decimal128 v2,
-    int64_t p2, int64_t s2, int64_t out_precision, int64_t out_scale,
+void add_or_subtract_decimal_scalars_py_entry(
+    uint64_t v1_low, int64_t v1_high, int64_t p1, int64_t s1, uint64_t v2_low,
+    int64_t v2_high, int64_t p2, int64_t s2, int64_t out_precision,
+    int64_t out_scale, uint64_t* out_low_ptr, uint64_t* out_high_ptr,
     bool do_addition, bool* overflow) noexcept {
     try {
-        return add_or_subtract_decimal_scalars_util(v1, p1, s1, v2, p2, s2,
-                                                    out_precision, out_scale,
-                                                    do_addition, overflow);
+        arrow::Decimal128 v1(v1_high, v1_low);
+        arrow::Decimal128 v2(v2_high, v2_low);
+        arrow::Decimal128 res = add_or_subtract_decimal_scalars_util(
+            v1, p1, s1, v2, p2, s2, out_precision, out_scale, do_addition,
+            overflow);
+        *out_low_ptr = res.low_bits();
+        *out_high_ptr = res.high_bits();
     } catch (const std::exception& e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
-        return arrow::Decimal128(0);
     }
 }
 

--- a/bodo/libs/decimal_arr_ext.py
+++ b/bodo/libs/decimal_arr_ext.py
@@ -1702,7 +1702,7 @@ def _add_or_subtract_decimal_scalars(
     def codegen(context, builder, signature, args):
         d1, d2, output_precision, output_scale, do_addition = args
         fnty = lir.FunctionType(
-            lir.IntType(128),
+            lir.VoidType(),
             [
                 lir.IntType(64),
                 lir.IntType(64),
@@ -1939,7 +1939,7 @@ def _multiply_decimal_scalars(typingctx, d1_t, d2_t, precision_t, scale_t):
     def codegen(context, builder, signature, args):
         d1, d2, output_precision, output_scale = args
         fnty = lir.FunctionType(
-            lir.IntType(128),
+            lir.VoidType(),
             [
                 lir.IntType(64),
                 lir.IntType(64),
@@ -2335,16 +2335,20 @@ def _divide_decimal_scalars(typingctx, d1_t, d2_t, precision_t, scale_t, do_div0
     def codegen(context, builder, signature, args):
         d1, d2, output_precision, output_scale, do_div0 = args
         fnty = lir.FunctionType(
-            lir.IntType(128),
+            lir.VoidType(),
             [
-                lir.IntType(128),
-                lir.IntType(64),
-                lir.IntType(64),
-                lir.IntType(128),
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64).as_pointer(),  # out_low_ptr
+                lir.IntType(64).as_pointer(),  # out_high_ptr
                 lir.IntType(1).as_pointer(),
                 lir.IntType(1),
             ],
@@ -2357,24 +2361,33 @@ def _divide_decimal_scalars(typingctx, d1_t, d2_t, precision_t, scale_t, do_div0
             builder.module, fnty, name="divide_decimal_scalars"
         )
         overflow_pointer = cgutils.alloca_once(builder, lir.IntType(1))
-        ret = builder.call(
+        d1_low, d1_high = _ll_get_int128_low_high(builder, d1)
+        d2_low, d2_high = _ll_get_int128_low_high(builder, d2)
+        out_low_ptr = cgutils.alloca_once(builder, lir.IntType(64))
+        out_high_ptr = cgutils.alloca_once(builder, lir.IntType(64))
+        builder.call(
             fn,
             [
-                d1,
+                d1_low,
+                d1_high,
                 d1_precision_const,
                 d1_scale_const,
-                d2,
+                d2_low,
+                d2_high,
                 d2_precision_const,
                 d2_scale_const,
                 output_precision,
                 output_scale,
+                out_low_ptr,
+                out_high_ptr,
                 overflow_pointer,
                 do_div0,
             ],
         )
         bodo.utils.utils.inlined_check_and_propagate_cpp_exception(context, builder)
+        res = _ll_int128_from_low_high(builder, out_low_ptr, out_high_ptr)
         overflow = builder.load(overflow_pointer)
-        return context.make_tuple(builder, signature.return_type, [ret, overflow])
+        return context.make_tuple(builder, signature.return_type, [res, overflow])
 
     output_decimal_type = Decimal128Type(output_precision, output_scale)
     ret_type = types.Tuple([output_decimal_type, types.bool_])

--- a/bodo/libs/decimal_arr_ext.py
+++ b/bodo/libs/decimal_arr_ext.py
@@ -1704,14 +1704,18 @@ def _add_or_subtract_decimal_scalars(
         fnty = lir.FunctionType(
             lir.IntType(128),
             [
-                lir.IntType(128),
-                lir.IntType(64),
-                lir.IntType(64),
-                lir.IntType(128),
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(64),
                 lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64),
+                lir.IntType(64).as_pointer(),  # out_low_ptr
+                lir.IntType(64).as_pointer(),  # out_high_ptr
                 lir.IntType(1),
                 lir.IntType(1).as_pointer(),
             ],
@@ -1724,24 +1728,33 @@ def _add_or_subtract_decimal_scalars(
             builder.module, fnty, name="add_or_subtract_decimal_scalars"
         )
         overflow_pointer = cgutils.alloca_once(builder, lir.IntType(1))
-        ret = builder.call(
+        d1_low, d1_high = _ll_get_int128_low_high(builder, d1)
+        d2_low, d2_high = _ll_get_int128_low_high(builder, d2)
+        out_low_ptr = cgutils.alloca_once(builder, lir.IntType(64))
+        out_high_ptr = cgutils.alloca_once(builder, lir.IntType(64))
+        builder.call(
             fn,
             [
-                d1,
+                d1_low,
+                d1_high,
                 d1_precision_const,
                 d1_scale_const,
-                d2,
+                d2_low,
+                d2_high,
                 d2_precision_const,
                 d2_scale_const,
                 output_precision,
                 output_scale,
+                out_low_ptr,
+                out_high_ptr,
                 do_addition,
                 overflow_pointer,
             ],
         )
         bodo.utils.utils.inlined_check_and_propagate_cpp_exception(context, builder)
+        res = _ll_int128_from_low_high(builder, out_low_ptr, out_high_ptr)
         overflow = builder.load(overflow_pointer)
-        return context.make_tuple(builder, signature.return_type, [ret, overflow])
+        return context.make_tuple(builder, signature.return_type, [res, overflow])
 
     output_decimal_type = Decimal128Type(output_precision, output_scale)
     ret_type = types.Tuple([output_decimal_type, types.bool_])


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Avoids int128 in C function signature for LLVM/Windows compatibility.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.