### PR TITLE
Fix spawn hang on Windows CI

### DIFF
--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -303,7 +303,8 @@ class Spawner:
         if sys.platform == "win32":
             # Signals work differently on Windows, so use an async MPI barrier
             # instead
-            poll_for_barrier(self.worker_intercomm)
+            # NOTE: polling req.Test() manually seems to hang on Windows with Intel MPI
+            poll_for_barrier(self.worker_intercomm, None)
         else:
             # Wait for execution to finish
             while not signaled:


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

This fixes occasional spawn test hangs on Windows. Looks like `req.Test()` doesn't work properly sometimes (could be an Intel MPI bug?). Tested this locally with the pi example and didn't see major performance problems.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.