### PR TITLE
Fix stream join crash on Windows

### DIFF
--- a/bodo/libs/_pinnable.h
+++ b/bodo/libs/_pinnable.h
@@ -107,14 +107,6 @@ struct pinnable_ptr {
     using difference_type = typename std::iterator_traits<T *>::difference_type;
     using iterator_category = std::random_access_iterator_tag;
 
-#ifdef _WIN32
-    /// @brief Needed for MSVC compatibility
-    static pinnable_ptr pointer_to(element_type &obj) {
-        throw std::runtime_error(
-            "pinnable_ptr: pointer_to not implemeneted yet.");
-    }
-#endif
-
     /// @brief  Construct a null pinnable_ptr
     pinnable_ptr() : base_(nullptr), offset_(0) {}
 

--- a/bodo/libs/streaming/_join.cpp
+++ b/bodo/libs/streaming/_join.cpp
@@ -455,7 +455,8 @@ void JoinPartition::FinalizeGroups() {
                          num_rows_in_group_->cend(),
                          groups_offsets_->begin() + 1);
 #else
-        // std::partial_sum crashes on Windows for some reason. Use a loop
+        // std::partial_sum requires pointer_to method in pinnable_ptr on
+        // Windows, which seems difficult to implement correctly. Use a loop
         // instead.
         size_t sum = num_rows_in_group_->at(0);
         for (size_t i = 1; i < num_groups; ++i) {

--- a/bodo/libs/streaming/_join.cpp
+++ b/bodo/libs/streaming/_join.cpp
@@ -450,9 +450,20 @@ void JoinPartition::FinalizeGroups() {
     (*groups_offsets_)[0] = 0;
     // Do a cumulative sum and fill the rest of groups_offsets:
     if (num_groups > 0) {
+#ifndef _WIN32
         std::partial_sum(num_rows_in_group_->cbegin(),
                          num_rows_in_group_->cend(),
                          groups_offsets_->begin() + 1);
+#else
+        // std::partial_sum crashes on Windows for some reason. Use a loop
+        // instead.
+        size_t sum = num_rows_in_group_->at(0);
+        for (size_t i = 1; i < num_groups; ++i) {
+            (*groups_offsets_)[i] = sum;
+            sum += num_rows_in_group_->at(i);
+        }
+        (*groups_offsets_)[num_groups] = sum;
+#endif
     }
 
     // Release the pin guard


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Avoids `std::partial_sum` in streaming join code on Windows since it requires pointer_to method in pinnable_ptr which is difficult to implement looks like.


## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.