### PR TITLE
[BSE-3986] Improve Unclear Join Code for NA Checks

### DIFF
--- a/bodo/hiframes/dataframe_impl.py
+++ b/bodo/hiframes/dataframe_impl.py
@@ -3278,11 +3278,14 @@ def _insert_NA_cond(expr_node, left_columns, left_data, right_columns, right_dat
             )
         return binop
 
-    def _insert_NA_cond_body(expr_node, null_set):
+    def _insert_NA_cond_body(expr_node, null_set) -> None:
         """
-        Returns an updated version of the sub expr and a set
-        of all column checks (i.e. right.A) that need a null value
-        inserted.
+        Scans through expr_node and inserts names for all
+        columns that have a column checks (i.e. right.A) and need a
+        null value inserted.
+
+        Also modified expr_node in-place to add null checks,
+        but only for the OR case.
         """
         if isinstance(expr_node, pandas.core.computation.ops.BinOp):
             if expr_node.op == "|":
@@ -3325,7 +3328,6 @@ def _insert_NA_cond(expr_node, left_columns, left_data, right_columns, right_dat
             arr_type = data[cols.index(col_name)]
             if bodo.utils.typing.is_nullable(arr_type):
                 null_set.add(expr_node.name)
-        return expr_node
 
     null_set = set()
     _insert_NA_cond_body(expr_node, null_set)

--- a/bodo/hiframes/dataframe_impl.py
+++ b/bodo/hiframes/dataframe_impl.py
@@ -3281,7 +3281,7 @@ def _insert_NA_cond(expr_node, left_columns, left_data, right_columns, right_dat
     def _insert_NA_cond_body(expr_node, null_set) -> None:
         """
         Scans through expr_node and inserts names for all
-        columns that have a column checks (i.e. right.A) and need a
+        columns that have a column check (i.e. right.A) and need a
         null value inserted.
 
         Also modified expr_node in-place to add null checks,


### PR DESCRIPTION
## Changes included in this PR

Clarified a helper function that adds NA checks to a general join condition that it modifies the expression in-place. Was originally unclear if we were performing the right behavior.

## Testing strategy

Verified locally on general condition Join tests, particularly with `|` / ORs in them. Checked if the input was modified in-place and if the return value was equal. Once behavior was confirmed, I cleaned up the section.

## User facing changes

N/A

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.