### PR TITLE
Fix file compression in IO tests for Windows

### DIFF
--- a/bodo/tests/test_io.py
+++ b/bodo/tests/test_io.py
@@ -1,7 +1,9 @@
 """Tests I/O for CSV, NP IO, etc."""
 
+import gzip
 import io
 import os
+import shutil
 import subprocess
 import unittest
 
@@ -61,16 +63,25 @@ def compress_dir(dir_name):
         for fname in [
             f
             for f in os.listdir(dir_name)
-            if f.endswith(".csv") and os.path.getsize(dir_name + "/" + f) > 0
+            if f.endswith(".csv") and os.path.getsize(os.path.join(dir_name, f)) > 0
         ]:
-            subprocess.run(["gzip", "-f", fname], cwd=dir_name)
+            full_fname = os.path.join(dir_name, fname)
+            out_fname = full_fname + ".gz"
+            with open(full_fname, "rb") as f_in:
+                with gzip.open(out_fname, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            os.remove(full_fname)
     bodo.barrier()
 
 
 def uncompress_dir(dir_name):
     if bodo.get_rank() == 0:
         for fname in [f for f in os.listdir(dir_name) if f.endswith(".gz")]:
-            subprocess.run(["gunzip", fname], cwd=dir_name)
+            full_fname = os.path.join(dir_name, fname)
+            with gzip.open(full_fname, "rb") as f_in:
+                with open(full_fname.removesuffix(".gz"), "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            os.remove(full_fname)
     bodo.barrier()
 
 

--- a/bodo/tests/test_io.py
+++ b/bodo/tests/test_io.py
@@ -1,9 +1,7 @@
 """Tests I/O for CSV, NP IO, etc."""
 
-import gzip
 import io
 import os
-import shutil
 import subprocess
 import unittest
 
@@ -22,12 +20,14 @@ from bodo.tests.utils import (
     _get_dist_arg,
     _test_equal_guard,
     check_func,
+    compress_dir,
     count_array_REPs,
     count_parfor_REPs,
     get_rank,
     get_start_end,
     pytest_mark_one_rank,
     reduce_sum,
+    uncompress_dir,
 )
 from bodo.utils.testing import ensure_clean
 from bodo.utils.typing import BodoError
@@ -55,33 +55,6 @@ def remove_files(file_names):
     if bodo.get_rank() == 0:
         for fname in file_names:
             os.remove(fname)
-    bodo.barrier()
-
-
-def compress_dir(dir_name):
-    if bodo.get_rank() == 0:
-        for fname in [
-            f
-            for f in os.listdir(dir_name)
-            if f.endswith(".csv") and os.path.getsize(os.path.join(dir_name, f)) > 0
-        ]:
-            full_fname = os.path.join(dir_name, fname)
-            out_fname = full_fname + ".gz"
-            with open(full_fname, "rb") as f_in:
-                with gzip.open(out_fname, "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-            os.remove(full_fname)
-    bodo.barrier()
-
-
-def uncompress_dir(dir_name):
-    if bodo.get_rank() == 0:
-        for fname in [f for f in os.listdir(dir_name) if f.endswith(".gz")]:
-            full_fname = os.path.join(dir_name, fname)
-            with gzip.open(full_fname, "rb") as f_in:
-                with open(full_fname.removesuffix(".gz"), "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-            os.remove(full_fname)
     bodo.barrier()
 
 

--- a/bodo/tests/test_json.py
+++ b/bodo/tests/test_json.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 import bodo
-from bodo.tests.utils import _get_dist_arg, check_func
+from bodo.tests.utils import _get_dist_arg, check_func, compress_dir, uncompress_dir
 from bodo.utils.testing import ensure_clean, ensure_clean_dir
 from bodo.utils.typing import BodoError
 
@@ -32,24 +32,6 @@ def remove_files(file_names):
     if bodo.get_rank() == 0:
         for fname in file_names:
             os.remove(fname)
-    bodo.barrier()
-
-
-def compress_dir(dir_name):
-    if bodo.get_rank() == 0:
-        for fname in [
-            f
-            for f in os.listdir(dir_name)
-            if f.endswith(".json") and os.path.getsize(dir_name + "/" + f) > 0
-        ]:
-            subprocess.run(["gzip", "-f", fname], cwd=dir_name)
-    bodo.barrier()
-
-
-def uncompress_dir(dir_name):
-    if bodo.get_rank() == 0:
-        for fname in [f for f in os.listdir(dir_name) if f.endswith(".gz")]:
-            subprocess.run(["gunzip", fname], cwd=dir_name)
     bodo.barrier()
 
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Makes the compression code in IO tests portable to run on Windows.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.