### PR TITLE
[BSE-4295][BSE-3920][BSE-3853][BSE-3782] Add Various Missing Docs

### DIFF
--- a/docs/docs/api_docs/pandas/groupby/index.md
+++ b/docs/docs/api_docs/pandas/groupby/index.md
@@ -24,6 +24,7 @@ Bodo supports the following `groupby` methods:
 | [`pd.core.groupby.Groupby.median`][pdcoregroupbygroupbymedian]                         | Compute the median value of the group.                                    |
 | [`pd.core.groupby.Groupby.min`][pdcoregroupbygroupbymin]                               | Compute the minimum value of the group.                                   |
 | [`pd.core.groupby.DataFrameGroupby.nunique`][pdcoregroupbydataframegroupbynunique]     | Compute the number of unique values in the group.                         |
+| [`pd.core.groupby.DataFrameGroupby.ngroup`][pdcoregroupbydataframegroupbyngroup]     | Compute a unique index number for each group.                         |
 | [`pd.core.groupby.Groupby.pipe`][pdcoregroupbygroupbypipe]                             | Apply a function to each group.                                           |
 | [`pd.core.groupby.Groupby.prod`][pdcoregroupbygroupbyprod]                             | Compute the product of the group.                                         |
 | [`pd.core.groupby.Groupby.rolling`][pdcoregroupbygroupbyrolling]                       | Provide rolling window calculations.                                      |

--- a/docs/docs/api_docs/pandas/groupby/ngroup.md
+++ b/docs/docs/api_docs/pandas/groupby/ngroup.md
@@ -1,0 +1,32 @@
+# `pd.core.groupby.DataFrameGroupby.ngroup`
+
+`pandas.core.groupby.DataFrameGroupby.ngroup(ascending=True)`
+
+
+### Example Usage
+
+```py
+
+>>> @bodo.jit
+... def f(df):
+...     return df.groupby("A").ngroup()
+>>> df = pd.DataFrame({
+...     "A": [1, 2, 3, 4, 5, 1, 2, 3, 4, 1, 2, 1],
+...     "B": np.arange(12.0)
+... })
+>>> f(df)
+0     1
+1     0
+2     3
+3     2
+4     4
+5     1
+6     0
+7     3
+8     2
+9     1
+10    0
+11    1
+dtype: int64
+```
+  

--- a/docs/docs/api_docs/pandas/series/dt.is_leap_year.md
+++ b/docs/docs/api_docs/pandas/series/dt.is_leap_year.md
@@ -7,3 +7,17 @@
 !!! note
 	Input must be a Series of `datetime64` data.
 
+### Example Usage
+
+``` py
+>>> @bodo.jit
+... def f(S):
+...     return S.dt.is_leap_year
+>>> S = pd.Series([pd.Timestamp('2020-01-01'), pd.Timestamp('2021-01-01')])
+>>> f(S)
+0      True
+1     False
+dtype: bool
+```
+
+

--- a/docs/docs/api_docs/pandas/series/index.md
+++ b/docs/docs/api_docs/pandas/series/index.md
@@ -192,6 +192,7 @@ unless support is explicitly mentioned.
 - [`pd.Series.dt.is_quarter_end`][pdseriesdtis_quarter_end]              
 - [`pd.Series.dt.is_year_start`][pdseriesdtis_year_start]                
 - [`pd.Series.dt.is_year_end`][pdseriesdtis_year_end]                    
+- [`pd.Series.dt.is_leap_year`][pdseriesdtis_leap_year]                    
 - [`pd.Series.dt.daysinmonth`][pdseriesdtdaysinmonth]                    
 - [`pd.Series.dt.days_in_month`][pdseriesdtdays_in_month]                
 
@@ -247,7 +248,8 @@ unless support is explicitly mentioned.
 - [`pd.Series.str.isupper`][pdseriesstrisupper]                          
 - [`pd.Series.str.istitle`][pdseriesstristitle]                          
 - [`pd.Series.str.isnumeric`][pdseriesstrisnumeric]                      
-- [`pd.Series.str.isdecimal`][pdseriesstrisdecimal]                      
+- [`pd.Series.str.isdecimal`][pdseriesstrisdecimal]   
+- [`pd.Series.str.encode`][pdseriesstrencode]                   
 
 ### Categorical accessor
 

--- a/docs/docs/api_docs/pandas/series/str.encode.md
+++ b/docs/docs/api_docs/pandas/series/str.encode.md
@@ -5,8 +5,10 @@
 `pandas.Series.str.encode(encoding, errors='strict')`
 
 ### Argument Restrictions:
- * `encoding`: must be type `String`.
- * `errors`: must be type `String`.
+| argument 	  | datatypes   | other requirements  |
+|-------------|-------------|---------------------|
+| `encoding`  | String      | 					  |
+| `errors`    | String      | 					  |
 
 !!! note
 	Input must be a Series of `String` data.
@@ -25,5 +27,5 @@
 4       b'@'
 5     b'a n'
 6    b'^ Ef'
-dtype: object
+dtype: large_binary[pyarrow]
 ```

--- a/docs/docs/bodo_parallelism/advanced.md
+++ b/docs/docs/bodo_parallelism/advanced.md
@@ -92,7 +92,7 @@ Functions `create_params` and `load_data` have `distributed=False` set,
 which makes all of their data structures and computations replicated across processors.
 
 !!! seealso "See Also"
-        [`bodo.scatterv`][bodoscatterv], [`bodo.prange`][explicit-parallel-loops]
+    API Docs for [`bodo.scatterv`][bodoscatterv]
 
 ```py
 @bodo.jit(distributed=False)


### PR DESCRIPTION
## Changes included in this PR

Closes various oncall issues related to doc inconsistencies.
- Add Series.str.encode
- Add Series.dt.is_leap_year
- Add DataFrameGroupby.ngroup
- Fix broken scatterv/prange link in docs

## Testing strategy

Generated the docs locally and verified. Took screenshots if reviewers want to see.

## User facing changes

Fixes to various docs pages.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.