### PR TITLE
[BSE-4558] Remove Azure Read Support through HDFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ bodo/io/csv_json_reader.h
 bodo/io/csv_json_reader.cpp
 bodo/io/arrow_ext.h
 bodo/io/arrow_ext.cpp
-bodo/io/_hdfs.cpp
 bodo/utils/tracing.c
 bodo/libs/memory.cpp
 bodo/io/pyarrow_wrappers.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,23 +426,6 @@ target_compile_definitions(pyarrow_wrappers PRIVATE ARROW_PYTHON_EXPORTING)
 target_link_libraries(pyarrow_wrappers PRIVATE arrow arrow_python arrow_dataset "${MPI_LIBRARIES}")
 install(TARGETS pyarrow_wrappers DESTINATION "bodo/io/")
 
-# ----------------------- Cython Target - bodo.io._hdfs -----------------------
-add_custom_command(
-  OUTPUT bodo/io/_hdfs.cpp
-  DEPENDS bodo/io/_hdfs.pyx
-  VERBATIM
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  COMMAND "${CYTHON_EXECUTABLE}" --cplus -3 --output-file "bodo/io/_hdfs.cpp" "bodo/io/_hdfs.pyx"
-  COMMAND "${CMAKE_COMMAND}" -E copy "bodo/io/_hdfs.cpp" "${CMAKE_CURRENT_BINARY_DIR}/bodo/io/_hdfs.cpp"
-  COMMENT "Cythonizing Source bodo/io/_hdfs.pyx into bodo/io/_hdfs.cpp"
-)
-
-python_add_library(_hdfs MODULE WITH_SOABI "bodo/io/_hdfs.cpp")
-target_include_directories(_hdfs PUBLIC ${BASE_INCLUDE_DIRS})
-target_link_directories(_hdfs PRIVATE ${PYARROW_LIB_DIR} ${CONDA_LIB_DIR})
-target_link_libraries(_hdfs PRIVATE arrow arrow_python)
-install(TARGETS _hdfs DESTINATION "bodo/io/")
-
 # ---------------------- Cython Target - bodo.io.tracing ----------------------
 if (NOT (CMAKE_BUILD_TYPE STREQUAL "Release"))
   set(BODO_DEV_BUILD "1")
@@ -814,5 +797,5 @@ else()
 endif()
 
 set_target_properties(ext PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
-add_dependencies(ext csv_json_reader _hdfs tracing pyarrow_wrappers datasketches)
+add_dependencies(ext csv_json_reader tracing pyarrow_wrappers datasketches)
 install(TARGETS ext DESTINATION "bodo/")

--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -169,9 +169,6 @@ def get_sql_config_str() -> str:
     return conf_str
 
 
-# Should Bodo use the new Arrow Azure FileSystem implementation instead of
-# the old HDFS implementation.
-enable_azure_fs = os.environ.get("BODO_USE_AZURE_FS", "1") != "0"
 check_parquet_schema = os.environ.get("BODO_CHECK_PARQUET_SCHEMA", "0") != "0"
 
 # --------------------------- End Streaming Config ---------------------------

--- a/bodo/io/__init__.py
+++ b/bodo/io/__init__.py
@@ -1,6 +1,3 @@
-import pyarrow._hdfs
-import pyarrow.fs
-
 from bodo.ext import (  # noqa
     arrow_cpp,
     csv_cpp,
@@ -8,13 +5,3 @@ from bodo.ext import (  # noqa
     json_cpp,
     s3_reader,
 )
-
-from ._hdfs import HadoopFileSystem
-
-# HadoopFileSystem is a class defined by Arrow in a Cython file (_hdfs.pyx).
-# We need to monkey-patch it for now because it doesn't recognize "abfs://" and
-# "abfss://" prefixes and incorrectly modifies URIs with those prefixes. The
-# implementation of HadoopFileSystem where this change is required needs to be
-# in Cython, so we have a modified copy of Arrow's _hdfs.pyx in bodo/io
-pyarrow._hdfs.HadoopFileSystem = HadoopFileSystem
-pyarrow.fs.HadoopFileSystem = HadoopFileSystem

--- a/bodo/io/fs_io.py
+++ b/bodo/io/fs_io.py
@@ -572,7 +572,7 @@ def getfs(
         import fsspec
 
         return PyFileSystem(FSSpecHandler(fsspec.filesystem("http")))
-    elif protocol in {"abfs", "abfss"} and bodo.enable_azure_fs:  # pragma: no cover
+    elif protocol in {"abfs", "abfss"}:  # pragma: no cover
         if not storage_options:
             storage_options = {}
         if "account_name" not in storage_options:
@@ -584,7 +584,7 @@ def getfs(
                 storage_options["account_name"] = account_name
 
         return abfs_get_fs(storage_options)
-    elif protocol in {"hdfs", "abfs", "abfss"}:  # pragma: no cover
+    elif protocol == "hdfs":  # pragma: no cover
         return (
             get_hdfs_fs(fpath) if not isinstance(fpath, list) else get_hdfs_fs(fpath[0])
         )

--- a/bodo/io/parquet_pio.py
+++ b/bodo/io/parquet_pio.py
@@ -427,7 +427,7 @@ def get_fpath_without_protocol_prefix(
         tuple[str | list[str], str]: Filepath(s) without the prefix
             and the prefix itself.
     """
-    if protocol in {"abfs", "abfss"} and bodo.enable_azure_fs:  # pragma: no cover
+    if protocol in {"abfs", "abfss"}:
         # PyArrow AzureBlobFileSystem is initialized with account_name only
         # so the host / container name should be included in the files
         prefix = f"{protocol}://"
@@ -450,7 +450,7 @@ def get_fpath_without_protocol_prefix(
     prefix = ""
     if protocol == "s3":
         prefix = "s3://"
-    elif protocol in {"hdfs", "abfs", "abfss"}:
+    elif protocol == "hdfs":
         # HDFS filesystem is initialized with host:port info. Once
         # initialized, the filesystem needs the <protocol>://<host><port>
         # prefix removed to query and access files

--- a/buildscripts/clean.sh
+++ b/buildscripts/clean.sh
@@ -5,7 +5,5 @@ echo "Removing the build directory"
 rm -rf build
 echo "Removing bodo/io/csv_json_reader.cpp"
 find . -name "csv_json_reader.cpp" | xargs rm -f
-echo "Removing bodo/io/_hdfs.cpp"
-find . -name "_hdfs.cpp" | xargs rm -f
 echo "Removing mpi4py"
 rm -rf bodo/mpi4py


### PR DESCRIPTION
## Changes included in this PR

Right now, Bodo supports reading from Azure storage through the Arrow AzureFileSystem or through the HDFS interface. The Azure interface is generally preferred, so we should just remove the HDFS one entirely.

## Testing strategy

- [x] Run PR CI
- [ ] Run Nightly on Iceberg and Snowflake Tests: https://dev.azure.com/bodo-inc/Bodo/_build/results?buildId=25558&view=results

## User facing changes

No option for using HDFS.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.