### PR TITLE
Update runtests to reflect the change in the cache dir name.

### DIFF
--- a/bodo/runtests_caching.py
+++ b/bodo/runtests_caching.py
@@ -107,9 +107,9 @@ use_run_name = "AGENT_NAME" in os.environ
 
 # String-generated bodo functions are cached in the directory
 # as defined in Numba (which is currently ~/.cache/bodo) with
-# .bodo_strfunc_cache appended.
+# .strfunc_cache appended.
 appdirs = AppDirs(appname="bodo", appauthor=False)
-cache_path = os.path.join(appdirs.user_cache_dir, ".bodo_strfunc_cache")
+cache_path = os.path.join(appdirs.user_cache_dir, ".strfunc_cache")
 # Remove the string-generated cache directory to make sure the tests
 # recreate it.
 shutil.rmtree(cache_path, ignore_errors=True)


### PR DESCRIPTION
## Changes included in this PR

Fix problem relating to the name checked for the Bodo string generated function cache directory.

## Testing strategy

[run CI]

## User facing changes

None

## Checklist
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.