### PR TITLE
Skip repartitioning tests on Windows since buffer pool is off

### DIFF
--- a/bodo/tests/test_streaming/test_groupby_repartitioning.py
+++ b/bodo/tests/test_streaming/test_groupby_repartitioning.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 
 import numpy as np
 import pandas as pd
@@ -26,7 +27,13 @@ from bodo.tests.utils import (
     temp_env_override,
 )
 
-# NOTE: Once we're no longer actively working on Groupby Spill Support, most of these tests can be marked as "slow".
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform == "win32", reason="TODO[BSE-4556]: enable buffer pool on Windows"
+    ),
+    pytest.mark.slow,
+]
+
 
 ##################### COMMON HELPERS #####################
 

--- a/bodo/tests/test_streaming/test_hash_join_repartitioning.py
+++ b/bodo/tests/test_streaming/test_hash_join_repartitioning.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -17,6 +19,13 @@ from bodo.libs.streaming.join import (
 )
 from bodo.mpi4py import MPI
 from bodo.tests.utils import pytest_mark_one_rank, set_broadcast_join, temp_env_override
+
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform == "win32", reason="TODO[BSE-4556]: enable buffer pool on Windows"
+    ),
+    pytest.mark.slow,
+]
 
 
 @pytest.fixture(params=[True, False])

--- a/bodo/tests/test_streaming/test_mrnf_repartitioning.py
+++ b/bodo/tests/test_streaming/test_mrnf_repartitioning.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -15,6 +17,14 @@ from bodo.libs.streaming.groupby import (
 from bodo.mpi4py import MPI
 from bodo.tests.utils import _get_dist_arg, pytest_mark_one_rank, temp_env_override
 from bodo.utils.typing import ColNamesMetaType, MetaType
+
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform == "win32", reason="TODO[BSE-4556]: enable buffer pool on Windows"
+    ),
+    pytest.mark.slow,
+]
+
 
 ##################### COMMON HELPERS #####################
 


### PR DESCRIPTION
As title. Also marks them as slow as previously intended.