### PR TITLE
Skip query profile collector tests on Windows

### DIFF
--- a/bodo/tests/test_query_profile_collector.py
+++ b/bodo/tests/test_query_profile_collector.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 import numpy as np
 import pandas as pd
@@ -30,6 +31,10 @@ from bodo.tests.utils import (
     temp_env_override,
 )
 from bodo.utils.typing import ColNamesMetaType, MetaType
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="TODO[BSE-4580]: fix nightly test hangs on Windows"
+)
 
 
 def test_query_profile_collection_compiles(memory_leak_check):


### PR DESCRIPTION
Skip query profile collector tests hang on Windows nightly for some reason, which is not reproducible locally. Skipping them for now since not high priority.