### PR TITLE
Fix df.sample on Windows

### DIFF
--- a/bodo/libs/_array_operations.cpp
+++ b/bodo/libs/_array_operations.cpp
@@ -1970,8 +1970,8 @@ std::shared_ptr<table_info> sample_table_inner_parallel(
 
     // Gather how many rows are on each rank
     std::vector<int64_t> ListSizes(n_pes);
-    CHECK_MPI(MPI_Allgather(&n_local, 1, MPI_LONG, ListSizes.data(), 1,
-                            MPI_LONG, MPI_COMM_WORLD),
+    CHECK_MPI(MPI_Allgather(&n_local, 1, MPI_LONG_LONG, ListSizes.data(), 1,
+                            MPI_LONG_LONG, MPI_COMM_WORLD),
               "sample_table_inner_parallel: MPI error on MPI_Allgather:");
 
     // Total number of rows across all ranks
@@ -2106,10 +2106,11 @@ std::shared_ptr<table_info> sample_table_inner_parallel(
                   "sample_table_inner_parallel: MPI error on MPI_Scatter:");
 
         ListIdxChosen.resize(n_samp_out);
-        CHECK_MPI(MPI_Scatterv(ListIdxSampledExport.data(), ListCounts.data(),
-                               ListDisps.data(), MPI_LONG, ListIdxChosen.data(),
-                               n_samp_out, MPI_LONG, 0, MPI_COMM_WORLD),
-                  "sample_table_inner_parallel: MPI error on MPI_Scatterv:");
+        CHECK_MPI(
+            MPI_Scatterv(ListIdxSampledExport.data(), ListCounts.data(),
+                         ListDisps.data(), MPI_LONG_LONG, ListIdxChosen.data(),
+                         n_samp_out, MPI_LONG_LONG, 0, MPI_COMM_WORLD),
+            "sample_table_inner_parallel: MPI error on MPI_Scatterv:");
 
         ListIdxSampledExport.clear();
         ListCounts.clear();

--- a/bodo/tests/test_index.py
+++ b/bodo/tests/test_index.py
@@ -348,13 +348,13 @@ def test_binary_infer(memory_leak_check):
     "data,dtype",
     [
         (np.ones(3, dtype=np.int32), np.float64),
-        (np.arange(10), np.dtype("datetime64[ns]")),
+        (np.arange(10, dtype=np.int64), np.dtype("datetime64[ns]")),
         (
             pd.Series(["2020-9-1", "2019-10-11", "2018-1-4", "2015-8-3", "1990-11-21"]),
             np.dtype("datetime64[ns]"),
         ),
-        (np.arange(10), np.dtype("timedelta64[ns]")),
-        (pd.Series(np.arange(10)), np.dtype("timedelta64[ns]")),
+        (np.arange(10, dtype=np.int64), np.dtype("timedelta64[ns]")),
+        (pd.Series(np.arange(10, dtype=np.int64)), np.dtype("timedelta64[ns]")),
     ],
 )
 def test_generic_index_constructor_with_dtype(data, dtype):

--- a/bodo/tests/test_series_old.py
+++ b/bodo/tests/test_series_old.py
@@ -389,7 +389,7 @@ class TestSeries(unittest.TestCase):
             return A + i
 
         n = 11
-        df = pd.DataFrame({"A": np.arange(n)})
+        df = pd.DataFrame({"A": np.arange(n, dtype=np.int64)})
         bodo_func = bodo.jit(test_impl)
         pd.testing.assert_series_equal(
             bodo_func(df.A, 1), test_impl(df.A, 1), check_names=False


### PR DESCRIPTION
Replaces MPI_LONG which is not portable on Windows and fixes a couple of dtype issues in tests.