### PR TITLE
Fix test_pivot_to_parquet on Windows

### DIFF
--- a/bodo/tests/test_pivot_crosstab.py
+++ b/bodo/tests/test_pivot_crosstab.py
@@ -1589,15 +1589,15 @@ def test_pivot_table_index_none(memory_leak_check):
         # Integer values
         pd.DataFrame(
             {
-                "A": np.arange(10),
+                "A": np.arange(10, dtype=np.int64),
                 "B": ["teq", "b", "ce", "32", "re2"] * 2,
-                "C": np.arange(10),
+                "C": np.arange(10, dtype=np.int64),
             }
         ),
         # String values
         pd.DataFrame(
             {
-                "A": np.arange(10),
+                "A": np.arange(10, dtype=np.int64),
                 "B": ["teq", "b", "ce", "32", "re2"] * 2,
                 "C": [str(i) for i in range(10)],
             }


### PR DESCRIPTION
Just int32/int64 mismatch issue.