### PR TITLE
[Windows compat] Install VC 2010 DLLs for Spark Iceberg setup

### DIFF
--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -72,6 +72,9 @@ jobs:
               # Spark needs to verify HADOOP_HOME exists at initialization even if it is not used.
               export HADOOP_HOME="$(pwd)/buildscripts/local_utils/hadoop_dummy"
               export PATH=$HADOOP_HOME/bin:$PATH
+              # Visual Studio 2010 DLLs are needed for winutils.exe
+              curl -LO https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe
+              ./vcredist_x64.exe -passive
             fi
 
             # Bodo Tests: Coverage is collected

--- a/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
@@ -119,7 +119,7 @@ jobs:
         export PATH=$HADOOP_HOME/bin:$PATH
         # Visual Studio 2010 DLLs are needed for winutils.exe
         curl -LO https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe
-         ./vcredist_x64.exe -passive
+        ./vcredist_x64.exe -passive
       else
         echo "Skipping hadoop/arrow env var setup"
       fi

--- a/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
@@ -117,6 +117,9 @@ jobs:
         # Spark needs to verify HADOOP_HOME exists at initialization even if it is not used.
         export HADOOP_HOME="$(System.DefaultWorkingDirectory)/buildscripts/local_utils/hadoop_dummy"
         export PATH=$HADOOP_HOME/bin:$PATH
+        # Visual Studio 2010 DLLs are needed for winutils.exe
+        curl -LO https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe
+         ./vcredist_x64.exe -passive
       else
         echo "Skipping hadoop/arrow env var setup"
       fi

--- a/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
@@ -100,7 +100,7 @@ jobs:
         export PATH=$HADOOP_HOME/bin:$PATH
         # Visual Studio 2010 DLLs are needed for winutils.exe
         curl -LO https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe
-         ./vcredist_x64.exe -passive
+        ./vcredist_x64.exe -passive
       else
         echo "Skipping hadoop/arrow env var setup"
       fi

--- a/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
@@ -98,6 +98,9 @@ jobs:
         # Spark needs to verify HADOOP_HOME exists at initialization even if it is not used.
         export HADOOP_HOME="$(System.DefaultWorkingDirectory)/buildscripts/local_utils/hadoop_dummy"
         export PATH=$HADOOP_HOME/bin:$PATH
+        # Visual Studio 2010 DLLs are needed for winutils.exe
+        curl -LO https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe
+         ./vcredist_x64.exe -passive
       else
         echo "Skipping hadoop/arrow env var setup"
       fi


### PR DESCRIPTION
Spark's Hadoop requires `winutils.exe`, which requires VC 2010 DLLs to work. This adds VC 2010 C++ redistributable package installation.

Looks like this fixed a lot of Iceberg unit tests on nightly: https://dev.azure.com/bodo-inc/Bodo/_build/results?buildId=25581&view=logs&j=bbbeb651-3f8d-5af3-55c0-c39fb5dcb633