### PR TITLE
Force sf write to use put

### DIFF
--- a/bodo/io/snowflake.py
+++ b/bodo/io/snowflake.py
@@ -418,7 +418,7 @@ SF_WRITE_ASYNC_QUERY_FREQ = 0.5
 # If False, `to_sql` directly uploads Parquet files to S3/ADLS/GCS using Bodo's
 #     internal filesystem-write infrastructure. This method is faster but does
 #     not support Azure and GCS-backed Snowflake accounts.
-SF_WRITE_UPLOAD_USING_PUT = False
+SF_WRITE_UPLOAD_USING_PUT = True
 
 # Content to put in core-site.xml for Snowflake write. For ADLS backed stages,
 # Snowflake gives us a SAS token for access to the stage. Unfortunately,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Snowflake write will use put, I'll include this in the release notes
## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.