### PR TITLE
BSE-4590: Use disassembler in _replace_load_deref_code

### DIFF
--- a/bodo/tests/test_bytecode.py
+++ b/bodo/tests/test_bytecode.py
@@ -40,22 +40,18 @@ def test_very_large_tuple(memory_leak_check):
     )
 
 
+def get_bc_stream(code):
+    import dis
+
+    for inst in dis.get_instructions(code):
+        yield inst.offset, inst.opcode, inst.arg
+
+
 @pytest_mark_one_rank
 def test_bc_stream_to_bytecode():
     """
     Tests that _bc_stream_bytecode correctly reverses disassembled bytecode.
     """
-    import dis
-
-    def get_bc_stream(code):
-        for inst in dis.get_instructions(code):
-            (
-                offset,
-                op,
-                arg,
-            ) = inst.offset, inst.opcode, inst.arg
-            yield (offset, op, arg)
-
     test_code = _bc_stream_to_bytecode.__code__
     assert (
         _bc_stream_to_bytecode(get_bc_stream(test_code), len(test_code.co_code))
@@ -68,20 +64,9 @@ def test_bc_stream_to_bytecode_all_typing_pass():
     """
     Tests that _bc_stream_bytecode correctly reverses disassembled bytecode for all typing pass functions.
     """
-    import dis
-
-    def get_bc_stream(code):
-        for inst in dis.get_instructions(code):
-            (
-                offset,
-                op,
-                arg,
-            ) = inst.offset, inst.opcode, inst.arg
-            yield (offset, op, arg)
-
     import bodo.transforms.typing_pass
 
-    for _, obj in vars(bodo.transforms.typing_pass).items():
+    for obj in vars(bodo.transforms.typing_pass).values():
         if callable(obj) and hasattr(obj, "__code__"):
             test_code = obj.__code__
             assert (

--- a/bodo/tests/test_bytecode.py
+++ b/bodo/tests/test_bytecode.py
@@ -54,8 +54,7 @@ def test_bc_stream_to_bytecode():
     """
     test_code = _bc_stream_to_bytecode.__code__
     assert (
-        _bc_stream_to_bytecode(get_bc_stream(test_code), len(test_code.co_code))
-        == test_code.co_code
+        _bc_stream_to_bytecode(get_bc_stream(test_code), test_code) == test_code.co_code
     )
 
 
@@ -70,6 +69,6 @@ def test_bc_stream_to_bytecode_all_typing_pass():
         if callable(obj) and hasattr(obj, "__code__"):
             test_code = obj.__code__
             assert (
-                _bc_stream_to_bytecode(get_bc_stream(test_code), len(test_code.co_code))
+                _bc_stream_to_bytecode(get_bc_stream(test_code), test_code)
                 == test_code.co_code
             )

--- a/bodo/tests/test_bytecode.py
+++ b/bodo/tests/test_bytecode.py
@@ -3,7 +3,8 @@
 import numba
 from numba.core import ir
 
-from bodo.tests.utils import DeadcodeTestPipeline, check_func
+from bodo.tests.utils import DeadcodeTestPipeline, check_func, pytest_mark_one_rank
+from bodo.transforms.typing_pass import _bc_stream_to_bytecode
 
 
 def test_very_large_tuple(memory_leak_check):
@@ -37,3 +38,53 @@ def test_very_large_tuple(memory_leak_check):
     assert num_build_tuples == 1, (
         "After DCE the IR should only contain a single build tuple"
     )
+
+
+@pytest_mark_one_rank
+def test_bc_stream_to_bytecode():
+    """
+    Tests that _bc_stream_bytecode correctly reverses disassembled bytecode.
+    """
+    import dis
+
+    def get_bc_stream(code):
+        for inst in dis.get_instructions(code):
+            (
+                offset,
+                op,
+                arg,
+            ) = inst.offset, inst.opcode, inst.arg
+            yield (offset, op, arg)
+
+    test_code = _bc_stream_to_bytecode.__code__
+    assert (
+        _bc_stream_to_bytecode(get_bc_stream(test_code), len(test_code.co_code))
+        == test_code.co_code
+    )
+
+
+@pytest_mark_one_rank
+def test_bc_stream_to_bytecode_all_typing_pass():
+    """
+    Tests that _bc_stream_bytecode correctly reverses disassembled bytecode for all typing pass functions.
+    """
+    import dis
+
+    def get_bc_stream(code):
+        for inst in dis.get_instructions(code):
+            (
+                offset,
+                op,
+                arg,
+            ) = inst.offset, inst.opcode, inst.arg
+            yield (offset, op, arg)
+
+    import bodo.transforms.typing_pass
+
+    for _, obj in vars(bodo.transforms.typing_pass).items():
+        if callable(obj) and hasattr(obj, "__code__"):
+            test_code = obj.__code__
+            assert (
+                _bc_stream_to_bytecode(get_bc_stream(test_code), len(test_code.co_code))
+                == test_code.co_code
+            )

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -6383,7 +6383,7 @@ def _bc_stream_to_bytecode(bc_stream, out_size):
                 arg >>= 8
 
         else:
-            assert arg == None
+            assert arg is None
     return out
 
 

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -6401,6 +6401,11 @@ def _replace_load_deref_code(code, freevar_arg_map):
     prev_n_locals = code.co_nlocals
 
     def _patch_opargs(code, freevar_arg_map, prev_argcount, prev_n_locals):
+        """
+        Patch the code object to replace the free variable load with an argument load.
+        Returns a stream of the updated bytecode.
+        """
+
         # cannot handle cases that write to free variables
         banned_ops = (dis.opmap["STORE_DEREF"], dis.opmap["LOAD_CLOSURE"])
         # local variable access to be adjusted

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -6364,13 +6364,13 @@ def _set_updated_container(varname, update_func, updated_containers, equiv_vars)
         updated_containers[w] = update_func
 
 
-def _bc_stream_to_bytecode(bc_stream, out_size):
+def _bc_stream_to_bytecode(bc_stream, original_code):
     """convert a stream of unpacked bytecode to a bytearray, reverses disassembly"""
     import dis
 
     from numba.core.bytecode import ARG_LEN, CODE_LEN
 
-    out = bytearray(out_size)
+    out = bytearray(original_code.co_code)
     for (
         offset,
         op,
@@ -6445,7 +6445,7 @@ def _replace_load_deref_code(code, freevar_arg_map):
     return bytes(
         _bc_stream_to_bytecode(
             _patch_opargs(code, freevar_arg_map, prev_argcount, prev_n_locals),
-            len(code.co_code),
+            code,
         )
     )
 

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -14,6 +14,7 @@ import numba
 import numpy as np
 import pandas as pd
 from numba.core import event, ir, ir_utils, types
+from numba.core.bytecode import _unpack_opargs
 from numba.core.compiler_machinery import register_pass
 from numba.core.extending import register_jitable
 from numba.core.inline_closurecall import inline_closure_call
@@ -6363,6 +6364,25 @@ def _set_updated_container(varname, update_func, updated_containers, equiv_vars)
         updated_containers[w] = update_func
 
 
+def _bc_stream_to_bytecode(bc_stream, out_size):
+    """convert a stream of unpacked bytecode to a bytearray, reverses _unpack_opargs"""
+    import dis
+
+    from numba.core.bytecode import ARG_LEN, CODE_LEN
+
+    out = bytearray(out_size)
+    for offset, op, arg, _ in bc_stream:
+        out[offset] = op
+        if op >= dis.HAVE_ARGUMENT:
+            for i in range(ARG_LEN):
+                out[offset + CODE_LEN + i] = arg & 0xFF
+                arg >>= 8
+
+        else:
+            assert arg is None
+    return out
+
+
 def _replace_load_deref_code(code, freevar_arg_map, prev_argcount, prev_n_locals):
     """replace load of free variables in byte code with load of new arguments and
     adjust local variable indices due to new arguments in co_varnames.
@@ -6373,51 +6393,44 @@ def _replace_load_deref_code(code, freevar_arg_map, prev_argcount, prev_n_locals
     """
     import dis
 
-    from numba.core.bytecode import ARG_LEN, CODE_LEN, NO_ARG_LEN
+    def _patch_opargs(code, freevar_arg_map, prev_argcount, prev_n_locals):
+        # cannot handle cases that write to free variables
+        banned_ops = (dis.opmap["STORE_DEREF"], dis.opmap["LOAD_CLOSURE"])
+        # local variable access to be adjusted
+        local_varname_ops = (
+            dis.opmap["LOAD_FAST"],
+            dis.opmap["STORE_FAST"],
+            dis.opmap["DELETE_FAST"],
+        )
+        n_new_args = len(freevar_arg_map)
+        for offset, op, arg, nextoffset in _unpack_opargs(code):
+            require(op not in banned_ops)
 
-    # assuming these constants are 1 to simplify the code, very unlikely to change
-    assert CODE_LEN == 1 and ARG_LEN == 1 and NO_ARG_LEN == 1, (
-        "invalid bytecode version"
+            # adjust local variable access since index includes arguments
+            if op in local_varname_ops and arg >= prev_argcount:
+                arg += n_new_args
+
+            # Python 3.11 copies free vars into local variables in the beginning of the
+            # function. We need to update LOAD_DEREF indices accordingly. See:
+            # https://docs.python.org/3.11/library/dis.html#opcode-COPY_FREE_VARS
+            # https://github.com/python/cpython/blob/cce6ba91b3a0111110d7e1db828bd6311d58a0a7/Python/ceval.c#L3206
+            if "COPY_FREE_VARS" in dis.opmap and op == dis.opmap["COPY_FREE_VARS"]:
+                freevar_arg_map = {
+                    k + prev_n_locals: v for k, v in freevar_arg_map.items()
+                }
+
+            # replace free variable load
+            if op == dis.opmap["LOAD_DEREF"] and arg in freevar_arg_map:
+                op = dis.opmap["LOAD_FAST"]
+                arg = freevar_arg_map[arg]
+            yield offset, op, arg, nextoffset
+
+    return bytes(
+        _bc_stream_to_bytecode(
+            _patch_opargs(code, freevar_arg_map, prev_argcount, prev_n_locals),
+            len(code),
+        )
     )
-    # cannot handle cases that write to free variables
-    banned_ops = (dis.opmap["STORE_DEREF"], dis.opmap["LOAD_CLOSURE"])
-    # local variable access to be adjusted
-    local_varname_ops = (
-        dis.opmap["LOAD_FAST"],
-        dis.opmap["STORE_FAST"],
-        dis.opmap["DELETE_FAST"],
-    )
-    n_new_args = len(freevar_arg_map)
-
-    new_code = np.empty(len(code), np.int8)
-    n = len(code)
-    i = 0
-    while i < n:
-        op = code[i]
-        arg = code[i + 1]
-        require(op not in banned_ops)
-
-        # adjust local variable access since index includes arguments
-        if op in local_varname_ops and arg >= prev_argcount:
-            arg += n_new_args
-
-        # Python 3.11 copies free vars into local variables in the beginning of the
-        # function. We need to update LOAD_DEREF indices accordingly. See:
-        # https://docs.python.org/3.11/library/dis.html#opcode-COPY_FREE_VARS
-        # https://github.com/python/cpython/blob/cce6ba91b3a0111110d7e1db828bd6311d58a0a7/Python/ceval.c#L3206
-        if "COPY_FREE_VARS" in dis.opmap and op == dis.opmap["COPY_FREE_VARS"]:
-            freevar_arg_map = {k + prev_n_locals: v for k, v in freevar_arg_map.items()}
-
-        # replace free variable load
-        if op == dis.opmap["LOAD_DEREF"] and arg in freevar_arg_map:
-            op = dis.opmap["LOAD_FAST"]
-            arg = freevar_arg_map[arg]
-
-        new_code[i] = op
-        new_code[i + 1] = arg
-        i += 2
-
-    return bytes(new_code)
 
 
 def _get_state_defining_call(func_ir, state, fn):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Use the builtin disassembler to modify the applied functions bytecode. Adds a function to reverse the process as well.

## Testing strategy
Ran existing freevar tests locally and added unittest for helper function.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
More safe applied functions with non const free variables.
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.