### PR TITLE
Skip no-put snowflake write tests nightly

### DIFF
--- a/BodoSQL/bodosql/tests/test_types/test_snowflake_iceberg_catalog.py
+++ b/BodoSQL/bodosql/tests/test_types/test_snowflake_iceberg_catalog.py
@@ -512,6 +512,9 @@ def test_azure_basic_read(memory_leak_check):
     )
 
 
+@pytest.mark.skip(
+    "[BSE-4601] Snowflake Azure Write temporarily broken. Unskip after Arrow 19 upgrade."
+)
 def test_azure_basic_write(memory_leak_check):
     """
     Test writing an Iceberg table from Snowflake in SQL with

--- a/bodo/tests/test_snowflake_write.py
+++ b/bodo/tests/test_snowflake_write.py
@@ -781,7 +781,16 @@ def test_to_sql_table_name(table_names):
 @pytest.mark.parametrize("df_size", [17000 * 3, 2, 0])
 @pytest.mark.parametrize(
     "sf_write_use_put",
-    [pytest.param(True, id="with-put"), pytest.param(False, id="no-put")],
+    [
+        pytest.param(True, id="with-put"),
+        pytest.param(
+            False,
+            id="no-put",
+            marks=pytest.mark.skip(
+                "[BSE-4601] Snowflake Azure Write temporarily broken. Unskip after Arrow 19 upgrade."
+            ),
+        ),
+    ],
 )
 @pytest.mark.parametrize(
     "snowflake_user",
@@ -1559,7 +1568,13 @@ def test_snowflake_write_column_name_special_chars(memory_leak_check):
     "sf_write_use_put",
     [
         pytest.param(True, id="with-put"),
-        pytest.param(False, id="no-put"),
+        pytest.param(
+            False,
+            id="no-put",
+            marks=pytest.mark.skip(
+                "[BSE-4601] Snowflake Azure Write temporarily broken. Unskip after Arrow 19 upgrade."
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes included in this PR

As titled, this will just make things easier for us by making nightly green. Until we upgrade to Arrow 19. When we upgrade then we can unskip.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.