### PR TITLE
Skip hanging E2E tests on CI

### DIFF
--- a/e2e-tests/iceberg/test_basic_table.py
+++ b/e2e-tests/iceberg/test_basic_table.py
@@ -2,9 +2,11 @@ import os
 import shutil
 from uuid import uuid4
 
+import pytest
 from utils.utils import run_cmd
 
 
+@pytest.mark.skip(reason="TODO [BSE-4605]: update Iceberg tests.")
 def test_iceberg_basic_df():
     num_processes = 4
     timeout = 300

--- a/e2e-tests/join/streaming_hash_join/test_stream_hash_join.py
+++ b/e2e-tests/join/streaming_hash_join/test_stream_hash_join.py
@@ -5,6 +5,7 @@ import pytest
 from utils.utils import run_cmd, temp_env_override
 
 
+@pytest.mark.skip(reason="TODO [BSE-4589]: Fix hanging tests on CI.")
 @pytest.mark.parametrize(
     "input_schema, expected_out_len, expected_checksum_lower, expected_checksum_upper, mem_size_mib, num_ranks",
     [


### PR DESCRIPTION
## Changes included in this PR
As titled, some are due to older tests that need to be updated and others are hanging on CI (but not locally)

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
https://github.com/bodo-ai/Bodo/actions/runs/13681064111
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.