### PR TITLE
Fix Jupyter output cell on Windows

### DIFF
--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -647,6 +647,18 @@ class Spawner:
         def worker_output_thread_func():
             """Thread that receives all worker outputs and prints them."""
 
+            # ipykernel redirects the output of threads to the first cell using
+            # _thread_to_parent_header. We need to remove this thread to make sure
+            # prints apprear in the correct cell.
+            # https://github.com/ipython/ipykernel/blob/dab3b39e3f1e0258d99b189867d8f2e2d36c976e/ipykernel/ipkernel.py#L766
+            # https://github.com/ipython/ipykernel/blob/dab3b39e3f1e0258d99b189867d8f2e2d36c976e/ipykernel/iostream.py#L525
+            sys.stdout._thread_to_parent_header.pop(
+                threading.current_thread().ident, None
+            )
+            sys.stderr._thread_to_parent_header.pop(
+                threading.current_thread().ident, None
+            )
+
             while True:
                 message = out_socket.recv_string()
                 is_stderr = message.startswith("1")


### PR DESCRIPTION
`ipykernel` redirects the output of threads to the first cell. This makes sure our worker output thread's prints appear in the correct cell.