### PR TITLE
Support BodoDataFrame.map_partitions

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -375,6 +375,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
     def map_partitions(self, func, *args, **kwargs):
         """
         Apply a function to each partition of the dataframe.
+        NOTE: this pickles the function and sends it to the workers, so globals are
+        pickled. The use of lazy data structures as globals causes issues.
         """
         return bodo.spawn.spawner.submit_func_to_workers(
             func, [], self, *args, **kwargs

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -371,3 +371,11 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             storage_options=storage_options,
             mode=mode,
         )
+
+    def map_partitions(self, func, *args, **kwargs):
+        """
+        Apply a function to each partition of the dataframe.
+        """
+        return bodo.spawn.spawner.submit_func_to_workers(
+            func, [], self, *args, **kwargs
+        )

--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -269,7 +269,11 @@ class Spawner:
         self.worker_intercomm.bcast(propagate_env, bcast_root)
 
     def submit_func_to_workers(
-        self, dispatcher: "SpawnDispatcher", propagate_env, *args, **kwargs
+        self,
+        func_to_execute: "SpawnDispatcher" | pt.Callable,
+        propagate_env,
+        *args,
+        **kwargs,
     ):
         """Send func to be compiled and executed on spawned process"""
         assert not self._is_running, "submit_func_to_workers: already running"
@@ -296,11 +300,11 @@ class Spawner:
 
         # Send arguments and update dispatcher distributed flags for arguments
         args_meta, kwargs_meta = self._send_args_update_dist_flags(
-            dispatcher, args, kwargs
+            func_to_execute, args, kwargs
         )
 
-        # Send dispatcher
-        pickled_func = cloudpickle.dumps(dispatcher)
+        # Send function
+        pickled_func = cloudpickle.dumps(func_to_execute)
         self.worker_intercomm.bcast(pickled_func, root=self.bcast_root)
         debug_msg(self.logger, "submit_func_to_workers - wait for results")
 
@@ -533,7 +537,7 @@ class Spawner:
                 self._send_arg_meta(val, out_val)
 
     def _send_args_update_dist_flags(
-        self, dispatcher: "SpawnDispatcher", args, kwargs
+        self, func_to_execute: "SpawnDispatcher" | pt.Callable, args, kwargs
     ) -> tuple[tuple[ArgMetadata | None, ...], dict[str, ArgMetadata | None]]:
         """Send function arguments from spawner to workers. DataFrame/Series/Index/array
         arguments are sent separately using broadcast or scatter (depending on flags).
@@ -542,12 +546,21 @@ class Spawner:
         compilation on the worker.
 
         Args:
-            dispatcher (SpawnDispatcher): dispatcher to run on workers
+            func_to_execute (SpawnDispatcher | callable): function to run on workers
             args (tuple[Any]): positional arguments
             kwargs (dict[str, Any]): keyword arguments
         """
-        param_names = list(numba.core.utils.pysignature(dispatcher.py_func).parameters)
-        replicated = set(dispatcher.decorator_args.get("replicated", ()))
+        is_dispatcher = isinstance(func_to_execute, SpawnDispatcher)
+        param_names = list(
+            numba.core.utils.pysignature(
+                func_to_execute.py_func if is_dispatcher else func_to_execute
+            ).parameters
+        )
+        replicated = set(
+            func_to_execute.decorator_args.get("replicated", ())
+            if is_dispatcher
+            else ()
+        )
         dist_flags = []
         args_meta = tuple(
             self._get_arg_metadata(
@@ -585,9 +598,10 @@ class Spawner:
         # See bodo/tests/test_series_part2.py::test_series_map_func_cases1
         pickled_args = cloudpickle.dumps((args_to_send, kwargs_to_send))
         self.worker_intercomm.bcast(pickled_args, root=self.bcast_root)
-        dispatcher.decorator_args["distributed_block"] = (
-            dispatcher.decorator_args.get("distributed_block", []) + dist_flags
-        )
+        if is_dispatcher:
+            func_to_execute.decorator_args["distributed_block"] = (
+                func_to_execute.decorator_args.get("distributed_block", []) + dist_flags
+            )
         # Send DataFrame/Series/Index/array arguments (others are already sent)
         for arg, arg_meta in itertools.chain(
             zip(args, args_meta), zip(kwargs.values(), kwargs_meta.values())
@@ -739,11 +753,13 @@ atexit.register(destroy_spawner)
 
 
 def submit_func_to_workers(
-    dispatcher: "SpawnDispatcher", propagate_env, *args, **kwargs
+    func_to_execute: "SpawnDispatcher" | pt.Callable, propagate_env, *args, **kwargs
 ):
-    """Get the global spawner and submit `func` for execution"""
+    """Get the global spawner and submit `func_to_execute` for execution"""
     spawner = get_spawner()
-    return spawner.submit_func_to_workers(dispatcher, propagate_env, *args, **kwargs)
+    return spawner.submit_func_to_workers(
+        func_to_execute, propagate_env, *args, **kwargs
+    )
 
 
 class SpawnDispatcher:

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -447,7 +447,9 @@ def exec_func_handler(
         # Extract return value distribution from metadata
         is_distributed = func.overloads[sig].metadata["is_return_distributed"]
 
-    # TODO: handle other types
+    # TODO(ehsan): handle other types like scalars. The challenge is that scalars may
+    # not be replicated in the non-JIT cases like map_partitions, so we have to define
+    # the semantics (e.g. gather all values across ranks in a list?).
     if not is_dispatcher:
         assert is_distributable_typ(bodo.typeof(res))
         is_distributed = True

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -449,7 +449,7 @@ def exec_func_handler(
 
     # TODO: handle other types
     if not is_dispatcher:
-        assert is_distributable_typ(res)
+        assert is_distributable_typ(bodo.typeof(res))
         is_distributed = True
 
     debug_worker_msg(logger, f"Function result {is_distributed=}")

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -624,3 +624,26 @@ def test_json(collect_func):
         df,
         check_dtype=False,
     )
+
+
+@pytest_mark_spawn_mode
+def test_map_partitions():
+    """Test map_partitions on BodoDataFrame"""
+
+    @bodo.jit(spawn=True)
+    def _get_bodo_df(df):
+        return df
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    bodo_df = _get_bodo_df(df)
+
+    def f(df, a, b=3):
+        return df + a + 2 * b
+
+    out = bodo_df.map_partitions(f, 2, b=4)
+    assert out._lazy
+    pd.testing.assert_frame_equal(
+        out,
+        f(df, 2, b=4),
+        check_dtype=False,
+    )


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds a basic `BodoDataFrame.map_partitions` function to test our current AI use cases. Just a basic internal function (no user docs) for now until we develop the new dataframe library and data-parallel APIs.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Basic `map_partition` function is available for testing.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.