### PR TITLE
Add Update Before Installing docker.io

### DIFF
--- a/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
@@ -91,6 +91,7 @@ jobs:
 
   - bash: |
       set -exo pipefail
+      sudo apt-get update
       sudo apt-get install -y docker.io
       sudo service docker start
       sudo chmod 666 /var/run/docker.sock

--- a/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
@@ -75,6 +75,7 @@ jobs:
 
   - bash: |
       set -exo pipefail
+      sudo apt-get update
       sudo apt-get install -y docker.io
       sudo service docker start
       sudo chmod 666 /var/run/docker.sock


### PR DESCRIPTION
## Changes included in this PR
Different jobs on Azure nightly has been failing with following error even with automatic retrying and manual retrying of job.
```
E: Unable to locate package docker.io
E: Couldn't find any package by glob 'docker.io'
E: Couldn't find any package by regex 'docker.io'
```
According to online search, adding `sudo apt-get update` would fix that.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
N/A. It's inconsistent error on different jobs. Will monitor following nightly runs.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
No
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [N/A] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.