### PR TITLE
#223: Support Parquet Writes Partitioned by an Index Column

### DIFF
--- a/BodoSQL/bodosql/context.py
+++ b/BodoSQL/bodosql/context.py
@@ -1133,7 +1133,7 @@ class BodoSQLContext:
 
     def generate_plan(
         self, sql, params_dict=None, dynamic_params_list=None, show_cost=False
-    ):
+    ) -> str:
         """
         Return the optimized plan for the SQL code as
         as a Python string.

--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -3630,7 +3630,12 @@ def pivot_impl(
     return impl
 
 
-@overload_method(DataFrameType, "to_parquet", no_unliteral=True)
+@overload_method(
+    DataFrameType,
+    "to_parquet",
+    no_unliteral=True,
+    # jit_options={"cache": True}
+)
 def to_parquet_overload(
     df,
     path,

--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -3694,18 +3694,31 @@ def to_parquet_overload(
     if not is_overload_none(partition_cols):
         assert_bodo_error(is_overload_constant_list(partition_cols))
         partition_cols = get_overload_const_list(partition_cols)
+        # Map column names to their dataframe location
+        column_to_idx = {col: idx for idx, col in enumerate(df.columns)}
+        # Include index columms as if appended to the end of the dataframe
+        if isinstance(df.index, SingleIndexType) and isinstance(
+            df.index.name_typ, types.StringLiteral
+        ):
+            column_to_idx[df.index.name_typ.literal_value] = len(df.columns)
+        else:
+            column_to_idx.update(
+                (name_type.literal_value, len(df.columns) + i)
+                for i, name_type in enumerate(df.index.names_typ)
+                if isinstance(name_type, types.StringLiteral)
+            )
+
         part_col_idxs = []
         for part_col_name in partition_cols:
-            try:
-                # TODO: Support index columns as partition columns
-                idx = df.columns.index(part_col_name)
-            except ValueError:
+            if part_col_name not in column_to_idx:
                 raise BodoError(
-                    f"Partition column `{part_col_name}` is not in dataframe"
+                    f"Partition column `{part_col_name}` is not in the DataFrame. "
+                    f"If `{part_col_name}` is an index column, make sure it has a compile-time known name."
                 )
-            part_col_idxs.append(idx)
+            part_col_idxs.append(column_to_idx[part_col_name])
     else:
         partition_cols = None
+        part_col_idxs = []
 
     if not is_overload_none(index) and not is_overload_constant_bool(index):
         raise BodoError("to_parquet(): index must be a constant bool or None")
@@ -3736,7 +3749,7 @@ def to_parquet_overload(
     # if index=None and parallel:
     #    write index to the parquet file and write non-dict to metadata regardless of index type
     is_range_index = isinstance(df.index, bodo.hiframes.pd_index_ext.RangeIndexType)
-    write_non_rangeindex = (df.index is not None) and (
+    (df.index is not None) and (
         is_overload_true(_is_parallel)
         or (not is_overload_true(_is_parallel) and not is_range_index)
     )
@@ -3753,16 +3766,39 @@ def to_parquet_overload(
         and not is_overload_true(_is_parallel)
     )
 
-    func_text = "def bodo_df_to_parquet(df, path, engine='auto', compression='snappy', index=None, partition_cols=None, storage_options=None, row_group_size=-1, _bodo_file_prefix='part-', _bodo_timestamp_tz=None, _is_parallel=False):\n"
-
+    func_text = (
+        "def bodo_df_to_parquet(\n"
+        "    df, path,\n"
+        "    engine='auto', compression='snappy',\n"
+        "    index=None, partition_cols=None,\n"
+        "    storage_options=None, row_group_size=-1,\n"
+        "    _bodo_file_prefix='part-', _bodo_timestamp_tz=None, _is_parallel=False\n"
+        "):\n"
+        "    if compression is None:\n"
+        "        compression = 'none'\n"
+        "    if _bodo_timestamp_tz is None:\n"
+        "        _bodo_timestamp_tz = ''\n"
+    )
+    # Parquet needs to include all columns, including index columns
+    if write_non_range_index_to_metadata:
+        func_text += (
+            "    append_arr_info_list_to_cpp_table(table,\n"
+            "        [array_to_info(arr) for arr in index_to_array_list(df.index)])\n"
+        )
     # Get all column names that will be written to parquet
-    # Note, index columns are added later for the non-partition case
-    # TODO: Extend for partitioned writes as well
+    # Note, index columns are added later
     if df.has_runtime_cols:
         func_text += "    columns_index = get_dataframe_column_names(df)\n"
         # Note: C++ assumes the array is always a string array.
         func_text += "    col_names_arr = index_to_array(columns_index)\n"
-    func_text += "    col_names = array_to_info(col_names_arr)\n"
+    # In the underlying Parquet file, for non-range index columns with no name,
+    # we use the name __index_level_{idx}__ to identify the column.
+    func_text += (
+        "    index_field_names_arr = pd.array(\n"
+        "        [f'__index_level_{idx}__' if name is None else name for idx, name in enumerate(index.names)])\n"
+        "    all_names_arr = np.concatenate((col_names_arr, index_field_names_arr))\n"
+        "    all_names = array_to_info(all_names_arr)\n"
+    )
 
     # Why we are calling drop_duplicates_local_dictionary on all dict encoded arrays?
     # Arrow doesn't support writing DictionaryArrays with nulls in the dictionary.
@@ -3791,18 +3827,10 @@ def to_parquet_overload(
         func_text += f"    info_list = [{data_args}]\n"
         func_text += "    table = arr_info_list_to_table(info_list)\n"
 
-    func_text += "    if compression is None:\n"
-    func_text += "        compression = 'none'\n"
-    func_text += "    if _bodo_timestamp_tz is None:\n"
-    func_text += "        _bodo_timestamp_tz = ''\n"
-
     # if it's an s3 url, get the region and pass it into the c++ code
     func_text += "    bucket_region = bodo.io.fs_io.get_s3_bucket_region_wrapper(path, parallel=_is_parallel)\n"
-    col_names_no_parts_arr = None
+
     if partition_cols:
-        col_names_no_parts_arr = pd.array(
-            [col_name for col_name in df.columns if col_name not in partition_cols]
-        )
         # We need the values of the categories for any partition columns that
         # are categorical arrays, because they are used to generate the
         # output directory name
@@ -3817,36 +3845,20 @@ def to_parquet_overload(
         else:
             func_text += "    cat_table = 0\n"
         func_text += (
-            "    col_names_no_partitions = array_to_info(col_names_no_parts_arr)\n"
-        )
-        func_text += f"    part_cols_idxs = np.array({part_col_idxs}, dtype=np.int32)\n"
-        func_text += "    parquet_write_table_partitioned_cpp(unicode_to_utf8(path),\n"
-        func_text += "                            table, col_names, col_names_no_partitions, cat_table,\n"
-        func_text += (
-            "                            part_cols_idxs.ctypes, len(part_cols_idxs),\n"
-        )
-        func_text += "                            unicode_to_utf8(compression),\n"
-        func_text += "                            _is_parallel,\n"
-        func_text += "                            unicode_to_utf8(bucket_region),\n"
-        func_text += "                            row_group_size,\n"
-        func_text += "                            unicode_to_utf8(_bodo_file_prefix),\n"
-        func_text += (
-            "                            unicode_to_utf8(_bodo_timestamp_tz))\n"
+            "    all_names_no_part_arr = pd.array([name for name in all_names_arr if name not in partition_cols])\n"
+            f"    part_cols_idxs = np.array({part_col_idxs}, dtype=np.int32)\n"
+            "    all_names_no_part = array_to_info(all_names_no_part_arr)\n"
+            "    parquet_write_table_partitioned_cpp(unicode_to_utf8(path),\n"
+            "        table, all_names, all_names_no_part, cat_table,\n"
+            "        part_cols_idxs.ctypes, len(part_cols_idxs),\n"
+            "        unicode_to_utf8(compression),\n"
+            "        _is_parallel,\n"
+            "        unicode_to_utf8(bucket_region),\n"
+            "        row_group_size,\n"
+            "        unicode_to_utf8(_bodo_file_prefix),\n"
+            "        unicode_to_utf8(_bodo_timestamp_tz))\n"
         )
     else:
-        # Parquet needs to include all columns, including index columns
-        if is_overload_true(index) or (
-            is_overload_none(index) and write_non_rangeindex
-        ):
-            func_text += "    index_arr_list = index_to_array_list(df.index)\n"
-            func_text += "    index_info_list = []\n"
-            for i in range(df.index.nlevels):
-                func_text += (
-                    f"    index_info_list.append(array_to_info(index_arr_list[{i}]))\n"
-                )
-            func_text += (
-                "    append_arr_info_list_to_cpp_table(table, index_info_list)\n"
-            )
         func_text += (
             # Generate Pandas metadata string to store in the Parquet schema.
             # It requires both compile-time type info and runtime index name info
@@ -3886,6 +3898,7 @@ def to_parquet_overload(
         col_names_arr = pd.array(df.columns)
 
     glbls = {
+        "pd": pd,
         "np": np,
         "bodo": bodo,
         "unicode_to_utf8": unicode_to_utf8,
@@ -3900,7 +3913,6 @@ def to_parquet_overload(
         "py_table_to_cpp_table": py_table_to_cpp_table,
         "py_table_typ": df.table_type,
         "get_dataframe_table": get_dataframe_table,
-        "col_names_no_parts_arr": col_names_no_parts_arr,
         "get_dataframe_column_names": get_dataframe_column_names,
         "fix_arr_dtype": fix_arr_dtype,
         "decode_if_dict_array": decode_if_dict_array,

--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -3736,6 +3736,7 @@ def to_parquet_overload(
 
     from bodo.io.parquet_write import (
         gen_pandas_parquet_metadata,
+        get_index_field_names,
         parquet_write_table_cpp,
         parquet_write_table_partitioned_cpp,
     )
@@ -3749,17 +3750,11 @@ def to_parquet_overload(
     # if index=None and parallel:
     #    write index to the parquet file and write non-dict to metadata regardless of index type
     is_range_index = isinstance(df.index, bodo.hiframes.pd_index_ext.RangeIndexType)
-    (df.index is not None) and (
-        is_overload_true(_is_parallel)
-        or (not is_overload_true(_is_parallel) and not is_range_index)
-    )
-
     # we write index to metadata always if index=True
     write_non_range_index_to_metadata = is_overload_true(index) or (
         is_overload_none(index)
         and (not is_range_index or is_overload_true(_is_parallel))
     )
-
     write_rangeindex_to_metadata = (
         is_overload_none(index)
         and is_range_index
@@ -3779,12 +3774,6 @@ def to_parquet_overload(
         "    if _bodo_timestamp_tz is None:\n"
         "        _bodo_timestamp_tz = ''\n"
     )
-    # Parquet needs to include all columns, including index columns
-    if write_non_range_index_to_metadata:
-        func_text += (
-            "    append_arr_info_list_to_cpp_table(table,\n"
-            "        [array_to_info(arr) for arr in index_to_array_list(df.index)])\n"
-        )
     # Get all column names that will be written to parquet
     # Note, index columns are added later
     if df.has_runtime_cols:
@@ -3794,9 +3783,8 @@ def to_parquet_overload(
     # In the underlying Parquet file, for non-range index columns with no name,
     # we use the name __index_level_{idx}__ to identify the column.
     func_text += (
-        "    index_field_names_arr = pd.array(\n"
-        "        [f'__index_level_{idx}__' if name is None else name for idx, name in enumerate(index.names)])\n"
-        "    all_names_arr = np.concatenate((col_names_arr, index_field_names_arr))\n"
+        "    index_field_names = get_index_field_names(df.index.names)\n"
+        "    all_names_arr = bodo.libs.array_kernels.concat((col_names_arr, index_field_names))\n"
         "    all_names = array_to_info(all_names_arr)\n"
     )
 
@@ -3826,6 +3814,12 @@ def to_parquet_overload(
         data_args = ", ".join(f"array_to_info(arr{i})" for i in range(len(df.columns)))
         func_text += f"    info_list = [{data_args}]\n"
         func_text += "    table = arr_info_list_to_table(info_list)\n"
+    # Parquet needs to include all columns, including index columns
+    if write_non_range_index_to_metadata:
+        func_text += (
+            "    append_arr_info_list_to_cpp_table(table,\n"
+            "        [array_to_info(arr) for arr in index_to_array_list(df.index)])\n"
+        )
 
     # if it's an s3 url, get the region and pass it into the c++ code
     func_text += "    bucket_region = bodo.io.fs_io.get_s3_bucket_region_wrapper(path, parallel=_is_parallel)\n"
@@ -3845,10 +3839,12 @@ def to_parquet_overload(
         else:
             func_text += "    cat_table = 0\n"
         func_text += (
-            "    all_names_no_part_arr = pd.array([name for name in all_names_arr if name not in partition_cols])\n"
+            "    with bodo.no_warning_objmode(all_names_no_part_arr=bodo.string_array_type):\n"
+            "        all_names_no_part_arr = pd.array([name for name in all_names_arr if name not in partition_cols])\n"
             f"    part_cols_idxs = np.array({part_col_idxs}, dtype=np.int32)\n"
             "    all_names_no_part = array_to_info(all_names_no_part_arr)\n"
-            "    parquet_write_table_partitioned_cpp(unicode_to_utf8(path),\n"
+            "    parquet_write_table_partitioned_cpp(\n"
+            "        unicode_to_utf8(path),\n"
             "        table, all_names, all_names_no_part, cat_table,\n"
             "        part_cols_idxs.ctypes, len(part_cols_idxs),\n"
             "        unicode_to_utf8(compression),\n"
@@ -3919,6 +3915,7 @@ def to_parquet_overload(
         "decode_if_dict_table": decode_if_dict_table,
         "index_to_array_list": index_to_array_list,
         "append_arr_info_list_to_cpp_table": append_arr_info_list_to_cpp_table,
+        "get_index_field_names": get_index_field_names,
     }
     glbls.update(extra_globals)
     return bodo_exec(

--- a/bodo/io/parquet_pio.py
+++ b/bodo/io/parquet_pio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import random
 import time
@@ -136,7 +137,7 @@ class ParquetFileInfo(FileInfo):
         self.use_hive = use_hive
         super().__init__()
 
-    def _get_schema(self, fname):
+    def _get_schema(self, fname) -> FileSchema:
         try:
             return parquet_file_schema(
                 fname,
@@ -1238,28 +1239,26 @@ def _add_categories_to_pq_dataset(pq_dataset):
     pq_dataset._category_info = category_info
 
 
-def get_pandas_metadata(schema, num_pieces):
+def get_pandas_metadata(schema) -> tuple[list[str | dict], dict[str, bool | None]]:
     # find pandas index column if any
     # TODO: other pandas metadata like dtypes needed?
     # https://pandas.pydata.org/pandas-docs/stable/development/developer.html
-    index_col = None
+    index_cols = []
     # column_name -> is_nullable (or None if unknown)
     nullable_from_metadata: defaultdict[str, bool | None] = defaultdict(lambda: None)
-    key = b"pandas"
-    if schema.metadata is not None and key in schema.metadata:
-        import json
-
-        pandas_metadata = json.loads(schema.metadata[key].decode("utf8"))
+    KEY = b"pandas"
+    if schema.metadata is not None and KEY in schema.metadata:
+        pandas_metadata = json.loads(schema.metadata[KEY].decode("utf8"))
         if pandas_metadata is None:
-            return index_col, nullable_from_metadata
+            return [], nullable_from_metadata
 
-        n_indices = len(pandas_metadata["index_columns"])
-        if n_indices > 1:
-            raise BodoError("read_parquet: MultiIndex not supported yet")
-        index_col = pandas_metadata["index_columns"][0] if n_indices else None
+        index_cols = pandas_metadata["index_columns"]
         # ignore non-str/dict index metadata
-        if not isinstance(index_col, str) and not isinstance(index_col, dict):
-            index_col = None
+        index_cols = [
+            index_col
+            for index_col in index_cols
+            if isinstance(index_col, str) or isinstance(index_col, dict)
+        ]
 
         for col_dict in pandas_metadata["columns"]:
             col_name = col_dict["name"]
@@ -1272,7 +1271,7 @@ def get_pandas_metadata(schema, num_pieces):
                     nullable_from_metadata[col_name] = True
                 else:
                     nullable_from_metadata[col_name] = False
-    return index_col, nullable_from_metadata
+    return index_cols, nullable_from_metadata
 
 
 def get_str_columns_from_pa_schema(pa_schema: pa.Schema) -> list[str]:
@@ -1410,7 +1409,6 @@ def parquet_file_schema(
 
     partition_names = pq_dataset.partition_names
     pa_schema = pq_dataset.schema
-    num_pieces = len(pq_dataset.pieces)
 
     # Get list of string columns
     str_columns = get_str_columns_from_pa_schema(pa_schema)
@@ -1444,10 +1442,11 @@ def parquet_file_schema(
     # NOTE: use arrow schema instead of the dataset schema to avoid issues with
     # names of list types columns (arrow 0.17.0)
     # col_names is an array that contains all the column's name and
-    # index's name if there is one, otherwise "__index__level_0"
+    # index's name if there is one, otherwise "__index__level_0__"
     # If there is no index at all, col_names will not include anything.
     col_names = pa_schema.names
-    index_col, nullable_from_metadata = get_pandas_metadata(pa_schema, num_pieces)
+    index_cols, nullable_from_metadata = get_pandas_metadata(pa_schema)
+    index_col_names: set[str] = {name for name in index_cols if isinstance(name, str)}
     col_types_total = []
     is_supported_list = []
     arrow_types = []
@@ -1457,7 +1456,7 @@ def parquet_file_schema(
         field = pa_schema.field(c)
         dtype, supported = _get_numba_typ_from_pa_typ(
             field,
-            c == index_col,
+            c in index_col_names,
             nullable_from_metadata[c],
             pq_dataset._category_info,
             str_as_dict=c in str_as_dict,
@@ -1501,15 +1500,12 @@ def parquet_file_schema(
     for c in selected_columns:
         if c not in col_names_map:
             raise BodoError(f"Selected column {c} not in Parquet file schema")
-    if (
-        index_col
-        and not isinstance(index_col, dict)
-        and index_col not in selected_columns
-    ):
-        # if index_col is "__index__level_0" or some other name, append it.
-        # If the index column is not selected when reading parquet, the index
-        # should still be included.
-        selected_columns.append(index_col)
+    for index_col in index_cols:
+        if not isinstance(index_col, dict) and index_col not in selected_columns:
+            # if index_col is "__index__level_0" or some other name, append it.
+            # If the index column is not selected when reading parquet, the index
+            # should still be included.
+            selected_columns.append(index_col)
 
     col_names = selected_columns
     col_indices = []
@@ -1528,7 +1524,7 @@ def parquet_file_schema(
     return (
         col_names,
         col_types,
-        index_col,
+        index_cols,
         col_indices,
         partition_names,
         unsupported_columns,

--- a/bodo/io/parquet_write.cpp
+++ b/bodo/io/parquet_write.cpp
@@ -445,8 +445,6 @@ void pq_write_partitioned_py_entry(
     // - sequential (only rank 0 writes, or all write with same name -which?-)
     // - create directories
     //     - what if directories already have files?
-    // - write index
-    // - write metadata?
     // - convert values to strings for other dtypes like datetime, decimal, etc
     // (see array_info::val_to_str)
 

--- a/bodo/io/parquet_write.py
+++ b/bodo/io/parquet_write.py
@@ -424,7 +424,11 @@ def gen_pandas_parquet_metadata(
 
 
 # TODO: Determine caching issue and re-enable
-@overload(gen_pandas_parquet_metadata, no_unliteral=True)
+@overload(
+    gen_pandas_parquet_metadata,
+    no_unliteral=True,
+    # jit_options={"cache": True}
+)
 def overload_gen_pandas_parquet_metadata(
     df,
     col_names_arr,

--- a/bodo/io/parquet_write.py
+++ b/bodo/io/parquet_write.py
@@ -526,3 +526,27 @@ def overload_gen_pandas_parquet_metadata(
     }
     exec(func_text, glbls, loc_vars)
     return loc_vars["impl"]
+
+
+def get_index_field_names(index_names) -> list[str]:  # type: ignore
+    """
+    Return a list of index field names for the given DataFrame.
+    Field names are used to identify the index columns in the Parquet file.
+    If an index doesn't have a name, we use the name __index_level_{idx}__ to identify the column.
+    """
+    pass
+
+
+@overload(get_index_field_names, no_unliteral=True)
+def overload_get_index_field_names(index_names):
+    def impl(index_names):
+        with bodo.no_warning_objmode(field_names=bodo.string_array_type):
+            field_names = pd.array(
+                [
+                    f"__index_level_{idx}__" if name is None else name
+                    for idx, name in enumerate(index_names)
+                ]
+            )
+        return field_names
+
+    return impl

--- a/bodo/ir/parquet_ext.py
+++ b/bodo/ir/parquet_ext.py
@@ -959,7 +959,6 @@ def _gen_pq_reader_py(
     func_text += "    delete_table(out_table)\n"
     func_text += "    ev.finalize()\n"
     func_text += "    return (total_rows, T, index_arr)\n"
-    print(func_text)
     loc_vars = {}
     glbs = {
         f"py_table_type_{call_id}": py_table_type,
@@ -967,7 +966,7 @@ def _gen_pq_reader_py(
         f"selected_cols_arr_{call_id}": np.array(selected_cols, np.int32),
         f"nullable_cols_arr_{call_id}": np.array(nullable_cols, np.int32),
         f"pyarrow_schema_{call_id}": pyarrow_schema_no_meta,
-        "index_arr_types": list(index_arr_inds.values()),
+        "index_arr_types": tuple(index_arr_inds.values()),
         "cpp_table_to_py_table": cpp_table_to_py_table,
         "array_from_cpp_table": array_from_cpp_table,
         "delete_table": delete_table,

--- a/bodo/ir/parquet_ext.py
+++ b/bodo/ir/parquet_ext.py
@@ -1,6 +1,6 @@
 """IR node for the parquet data access"""
 
-from typing import TYPE_CHECKING
+import typing as pt
 
 import llvmlite.binding as ll
 import numba
@@ -51,6 +51,7 @@ from bodo.libs.array import (
     table_type,
 )
 from bodo.libs.dict_arr_ext import dict_str_arr_type
+from bodo.libs.struct_arr_ext import StructArrayType
 from bodo.transforms import distributed_analysis, distributed_pass
 from bodo.transforms.table_column_del_pass import (
     ir_extension_table_column_use,
@@ -71,7 +72,7 @@ from bodo.utils.utils import (
     sanitize_varname,
 )
 
-if TYPE_CHECKING:  # pragma: no cover
+if pt.TYPE_CHECKING:  # pragma: no cover
     from llvmlite.ir.builder import IRBuilder
     from numba.core.base import BaseContext
 
@@ -114,7 +115,7 @@ class ParquetHandler:
         self,
         file_name,
         lhs: ir.Var,
-        columns,
+        columns: list[str],
         storage_options=None,
         input_file_name_col=None,
         read_as_dict_cols=None,
@@ -162,13 +163,12 @@ class ParquetHandler:
             # FilenameType. If so, the schema will be part of the type
             var_def = guard(get_definition, self.func_ir, file_name)
             if isinstance(var_def, ir.Arg) and isinstance(
-                self.args[var_def.index], FilenameType
+                (typ := self.args[var_def.index]), FilenameType
             ):
-                typ: FilenameType = self.args[var_def.index]
                 (
                     col_names,
                     col_types,
-                    index_col,
+                    index_cols,
                     col_indices,
                     partition_names,
                     unsupported_columns,
@@ -179,7 +179,7 @@ class ParquetHandler:
                 (
                     col_names,
                     col_types,
-                    index_col,
+                    index_cols,
                     col_indices,
                     partition_names,
                     unsupported_columns,
@@ -200,7 +200,7 @@ class ParquetHandler:
             col_types_total = list(table_types.values())
 
             # TODO: allow specifying types of only selected columns
-            col_names: list[str] = all_col_names if columns is None else columns
+            col_names = all_col_names if columns is None else columns
             col_indices = [all_col_names_map[c] for c in col_names]
             col_types = [col_types_total[all_col_names_map[c]] for c in col_names]
 
@@ -210,9 +210,7 @@ class ParquetHandler:
             # while; newer versions added options to specify the index in
             # metadata only. Need to investigate and/or have another parameter
             # TODO: https://bodo.atlassian.net/browse/BE-4110
-            index_col = next(
-                (x for x in col_names if x.startswith("__index_level_")), None
-            )
+            index_cols = [x for x in col_names if x.startswith("__index_level_")]
 
             partition_names = []
             # If a user provides the schema, all types must be valid Bodo types.
@@ -222,17 +220,15 @@ class ParquetHandler:
                 DataFrameType(data=tuple(col_types), columns=tuple(col_names)),
             )
 
-        index_colname = (
-            None if (isinstance(index_col, dict) or index_col is None) else index_col
-        )
-        # If we have an index column, remove it from the type to simplify the table.
-        index_column_index = None
-        index_column_type = types.none
-        if index_colname:
-            type_index = col_names.index(index_colname)
+        index_column_info = {}
+        for index_col in index_cols:
+            if isinstance(index_col, dict):
+                continue
+            type_index = col_names.index(index_col)
             index_column_index = col_indices.pop(type_index)
             index_column_type = col_types.pop(type_index)
             col_names.pop(type_index)
+            index_column_info[index_column_index] = index_column_type
 
         # HACK convert types using decorator for int columns with NaN
         for i, c in enumerate(col_names):
@@ -258,8 +254,7 @@ class ParquetHandler:
                 loc,
                 partition_names,
                 storage_options,
-                index_column_index if use_index else None,
-                index_column_type if use_index else types.none,
+                index_column_info,
                 input_file_name_col,
                 unsupported_columns,
                 unsupported_arrow_types,
@@ -270,7 +265,7 @@ class ParquetHandler:
             )
         ]
 
-        return col_names, data_arrs, index_col, nodes, col_types, index_column_type
+        return col_names, data_arrs, index_cols, nodes, col_types
 
 
 class ParquetReader(Connector):
@@ -288,8 +283,7 @@ class ParquetReader(Connector):
         partition_names,
         # These are the same storage_options that would be passed to pandas
         storage_options,
-        index_column_index,
-        index_column_type,
+        index_column_info: dict[int, types.ArrayCompatible],
         input_file_name_col,
         unsupported_columns,
         unsupported_arrow_types,
@@ -329,8 +323,7 @@ class ParquetReader(Connector):
         self.filters = None
         # storage_options passed to pandas during read_parquet
         self.storage_options = storage_options
-        self.index_column_index = index_column_index
-        self.index_column_type = index_column_type
+        self.index_column_info = index_column_info
         # Columns within the output table type that are actually used.
         # These will be updated during optimzations and do not contain
         # the actual columns numbers that should be loaded. For more
@@ -352,9 +345,16 @@ class ParquetReader(Connector):
 
     def __repr__(self):  # pragma: no cover
         # TODO
-        return f"({self.df_out_varname}) = ReadParquet({self.file_name.name}, {self.out_table_col_names}, {self.col_indices}, {self.out_table_col_types}, {self.original_table_col_types}, {self.original_df_colnames}, {self.out_vars}, {self.partition_names}, {self.filters}, {self.storage_options}, {self.index_column_index}, {self.index_column_type}, {self.out_used_cols}, {self.input_file_name_col}, {self.unsupported_columns}, {self.unsupported_arrow_types}, {self.arrow_schema}, chunksize={self.chunksize}, sql_op_id={self.sql_op_id})"
+        return f"({self.df_out_varname}) = ReadParquet({self.file_name.name}, {self.out_table_col_names}, {self.col_indices}, {self.out_table_col_types}, {self.original_table_col_types}, {self.original_df_colnames}, {self.out_vars}, {self.partition_names}, {self.filters}, {self.storage_options}, {self.index_column_info}, {self.out_used_cols}, {self.input_file_name_col}, {self.unsupported_columns}, {self.unsupported_arrow_types}, {self.arrow_schema}, chunksize={self.chunksize}, sql_op_id={self.sql_op_id})"
 
-    def out_vars_and_types(self) -> list[tuple[str, types.Type]]:
+    def _index_type(self):
+        if len(self.index_column_info) == 0:
+            return None
+        if len(self.index_column_info) == 1:
+            return next(iter(self.index_column_info.values()))
+        return StructArrayType(tuple(self.index_column_info.values()))
+
+    def out_vars_and_types(self) -> list[tuple[str, pt.Any]]:
         return (
             [
                 (
@@ -365,7 +365,7 @@ class ParquetReader(Connector):
             if self.is_streaming
             else [
                 (self.out_vars[0].name, TableType(tuple(self.out_table_col_types))),
-                (self.out_vars[1].name, self.index_column_type),
+                (self.out_vars[1].name, self._index_type()),
             ]
         )
 
@@ -401,9 +401,8 @@ def remove_dead_pq(
 
     elif index_var not in lives:
         # If the index_var not in lives we don't load the index.
-        # To do this we mark the index_column_index as None
-        pq_node.index_column_index = None
-        pq_node.index_column_type = types.none
+        # To do this we mark the index_column_info as empty
+        pq_node.index_column_info = {}
 
     # TODO: Update the usecols if only 1 of the variables is live.
     return pq_node
@@ -556,8 +555,7 @@ def pq_distributed_run(
         extra_args,
         parallel,
         meta_head_only_info,
-        pq_node.index_column_index,
-        pq_node.index_column_type,
+        pq_node.index_column_info,
         pq_node.input_file_name_col,
         not pq_node.is_live_table,
         pq_node.arrow_schema,
@@ -602,13 +600,14 @@ def pq_distributed_run(
     nodes[-2].target = pq_node.out_vars[0]
     # assign output index array
     nodes[-1].target = pq_node.out_vars[1]
+
     # At most one of the table and the index
     # can be dead because otherwise the whole
     # node should have already been removed.
-    assert not (pq_node.index_column_index is None and not pq_node.is_live_table), (
+    assert not (len(pq_node.index_column_info) == 0 and not pq_node.is_live_table), (
         "At most one of table and index should be dead if the Parquet IR node is live"
     )
-    if pq_node.index_column_index is None:
+    if len(pq_node.index_column_info) == 0:
         # If the index_col is dead, remove the node.
         nodes.pop(-1)
     elif not pq_node.is_live_table:
@@ -625,8 +624,7 @@ def pq_reader_params(
     partition_names,
     input_file_name_col,
     out_used_cols,
-    index_column_index,
-    index_column_type,
+    index_column_info: dict,
     out_types: list[types.ArrayCompatible],
 ):
     # head-only optimization: we may need to read only the first few rows
@@ -677,7 +675,7 @@ def pq_reader_params(
             # Track which partitions are valid to simplify filtering later
             partition_indices.add(col_indices[i])
 
-    if index_column_index is not None:
+    for index_column_index in index_column_info.keys():
         selected_cols.append(index_column_index)
     selected_cols = sorted(selected_cols)
     selected_cols_map = {c: i for i, c in enumerate(selected_cols)}
@@ -692,8 +690,8 @@ def pq_reader_params(
     nullable_cols = [
         (
             int(is_nullable_ignore_sentinels(out_types[col_indices_map[col_in_idx]]))
-            if col_in_idx != index_column_index
-            else int(is_nullable_ignore_sentinels(index_column_type))
+            if col_in_idx not in index_column_info
+            else int(is_nullable_ignore_sentinels(index_column_info[col_in_idx]))
         )
         for col_in_idx in selected_cols
     ]
@@ -702,8 +700,8 @@ def pq_reader_params(
     # in dictionary-encoded format
     str_as_dict_cols = []
     for col_in_idx in selected_cols:
-        if col_in_idx == index_column_index:
-            t = index_column_type
+        if col_in_idx in index_column_info:
+            t = index_column_info[col_in_idx]
         else:
             t = out_types[col_indices_map[col_in_idx]]
         if t == dict_str_arr_type:
@@ -769,8 +767,7 @@ def _gen_pq_reader_py(
     extra_args,
     is_parallel,
     meta_head_only_info,
-    index_column_index,
-    index_column_type,
+    index_column_info: dict,
     input_file_name_col,
     is_dead_table: bool,
     pyarrow_schema: pa.Schema,
@@ -798,17 +795,13 @@ def _gen_pq_reader_py(
         partition_names,
         input_file_name_col,
         out_used_cols,
-        index_column_index,
-        index_column_type,
+        index_column_info,
         out_types,
     )
 
-    index_arr_ind = (
-        selected_cols_map[index_column_index]
-        if index_column_index is not None
-        else None
-    )
-    index_arr_type = index_column_type
+    index_arr_inds = {
+        selected_cols_map[idx]: types for idx, types in index_column_info.items()
+    }
     py_table_type = TableType(tuple(out_types))
     if is_dead_table:
         py_table_type = types.none
@@ -874,11 +867,10 @@ def _gen_pq_reader_py(
         sanitized_col_names,
         sel_partition_names_map,
         input_file_name_col,
-        index_arr_ind,
+        index_arr_inds,
         use_hive,
         is_dead_table,
         table_idx,
-        index_arr_type,
         pyarrow_schema_no_meta,
         *extra_args,
     )
@@ -948,13 +940,26 @@ def _gen_pq_reader_py(
         if len(out_used_cols) == 0:
             # Set the table length using the total rows if don't load any columns
             func_text += "    T = set_table_len(T, local_rows)\n"
-    if index_column_index is None:
+
+    if len(index_arr_inds) == 0:
         func_text += "    index_arr = None\n"
+    elif len(index_arr_inds) == 1:
+        func_text += f"    index_arr = array_from_cpp_table(out_table, {next(iter(index_arr_inds))}, index_arr_types[0])\n"
     else:
-        func_text += f"    index_arr = array_from_cpp_table(out_table, {index_arr_ind}, index_arr_type)\n"
+        index_names = list(map(str, index_arr_inds.keys()))
+        func_text += "    index_arr = init_struct_arr({}, ({}), np.empty((local_rows + 7) >> 3, np.uint8), ({}))\n".format(
+            len(index_arr_inds),
+            ", ".join(
+                f"array_from_cpp_table(out_table, {i}, index_arr_types[{idx}])"
+                for idx, i in enumerate(index_names)
+            ),
+            ", ".join(f'"f{idx}"' for idx in range(len(index_arr_inds))),
+        )
+
     func_text += "    delete_table(out_table)\n"
     func_text += "    ev.finalize()\n"
     func_text += "    return (total_rows, T, index_arr)\n"
+    print(func_text)
     loc_vars = {}
     glbs = {
         f"py_table_type_{call_id}": py_table_type,
@@ -962,7 +967,7 @@ def _gen_pq_reader_py(
         f"selected_cols_arr_{call_id}": np.array(selected_cols, np.int32),
         f"nullable_cols_arr_{call_id}": np.array(nullable_cols, np.int32),
         f"pyarrow_schema_{call_id}": pyarrow_schema_no_meta,
-        "index_arr_type": index_arr_type,
+        "index_arr_types": list(index_arr_inds.values()),
         "cpp_table_to_py_table": cpp_table_to_py_table,
         "array_from_cpp_table": array_from_cpp_table,
         "delete_table": delete_table,
@@ -976,10 +981,10 @@ def _gen_pq_reader_py(
         "bodo": bodo,
         "get_node_portion": bodo.libs.distributed_api.get_node_portion,
         "set_table_len": bodo.hiframes.table.set_table_len,
+        "init_struct_arr": bodo.libs.struct_arr_ext.init_struct_arr,
     }
 
     pq_reader_py = bodo_exec(func_text, glbs, loc_vars, __name__)
-
     jit_func = numba.njit(pq_reader_py, no_cpython_wrapper=True, cache=True)
     return jit_func
 
@@ -995,8 +1000,7 @@ def _gen_pq_reader_chunked_py(
     extra_args,
     is_parallel,
     meta_head_only_info,
-    index_column_index,
-    index_column_type,
+    index_column_info: dict,
     input_file_name_col,
     is_dead_table: bool,
     pyarrow_schema: pa.Schema,
@@ -1050,8 +1054,7 @@ def _gen_pq_reader_chunked_py(
         partition_names,
         input_file_name_col,
         out_used_cols,
-        index_column_index,
-        index_column_type,
+        index_column_info,
         out_table_col_types,
     )
 

--- a/bodo/libs/struct_arr_ext.py
+++ b/bodo/libs/struct_arr_ext.py
@@ -57,7 +57,7 @@ class StructArrayType(types.ArrayCompatible):
     data: tuple[types.ArrayCompatible, ...]
     names: tuple[str, ...]
 
-    def __init__(self, data, names=None):
+    def __init__(self, data: tuple[types.ArrayCompatible, ...], names=None):
         # data is tuple of Array types
         # names is a tuple of field names
         assert isinstance(data, tuple) and all(

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -529,9 +529,10 @@ def test_pq_multi_idx(memory_leak_check):
             arrays = [
                 ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
                 ["one", "two", "one", "two", "one", "two", "one", "two"],
+                [1, 2, 2, 1] * 2,
             ]
             tuples = list(zip(*arrays))
-            idx = pd.MultiIndex.from_tuples(tuples, names=["first", None])
+            idx = pd.MultiIndex.from_tuples(tuples, names=["first", None, "count"])
             df = pd.DataFrame(np.random.randn(8, 2), index=idx, columns=["A", "B"])
             df.to_parquet("multi_idx_parquet.pq")
         bodo.barrier()

--- a/bodo/tests/test_parquet_write.py
+++ b/bodo/tests/test_parquet_write.py
@@ -1112,7 +1112,11 @@ def test_to_pq_multiIdx_no_name(check_write_func, memory_leak_check):
         lambda df, fname: df.to_parquet(fname),
         df,
         "multi_idx_parquet_no_name",
+<<<<<<< HEAD
         check_index=["__index_level_0__", "__index_level_1__", "nums"],
+=======
+        check_index=["first", "__index_level_1__"],
+>>>>>>> 5e4f2ecdeb ([run ci] fix tests)
     )
 
 

--- a/bodo/tests/test_parquet_write.py
+++ b/bodo/tests/test_parquet_write.py
@@ -2,6 +2,7 @@ import os
 import random
 import shutil
 import traceback
+from datetime import date
 from decimal import Decimal
 
 import numba
@@ -1112,11 +1113,62 @@ def test_to_pq_multiIdx_no_name(check_write_func, memory_leak_check):
         lambda df, fname: df.to_parquet(fname),
         df,
         "multi_idx_parquet_no_name",
-<<<<<<< HEAD
         check_index=["__index_level_0__", "__index_level_1__", "nums"],
-=======
-        check_index=["first", "__index_level_1__"],
->>>>>>> 5e4f2ecdeb ([run ci] fix tests)
+    )
+
+
+def test_to_pq_partition_by_index(memory_leak_check, check_write_func):
+    """Test to_parquet with a partitioned index"""
+    df = pd.DataFrame(
+        {
+            "date": [
+                date(2021, 1, 1),
+                date(2021, 1, 1),
+                date(2021, 1, 2),
+                date(2021, 1, 2),
+            ],
+            "sensor": ["Sensor1", "Sensor2", "Sensor1", "Sensor2"],
+            "value": np.random.randn(4),
+        }
+    )
+    df_date = df.set_index("date")
+
+    check_write_func(
+        lambda df, path: df.to_parquet(path, partition_cols=["date"]),
+        df_date,
+        "test_to_pq_partition_by_index",
+        check_index=["date"],
+    )
+
+    check_write_func(
+        lambda df, path: df.to_parquet(path, partition_cols=["date", "sensor"]),
+        df_date,
+        "test_to_pq_partition_by_index2",
+        check_index=["date", "sensor"],
+    )
+
+
+def test_to_pq_partition_by_multiIdx(memory_leak_check, check_write_func):
+    """Test to_parquet with a partitioning by all levels of a MultiIndex"""
+    df = pd.DataFrame(
+        {
+            "date": [
+                date(2021, 1, 1),
+                date(2021, 1, 1),
+                date(2021, 1, 2),
+                date(2021, 1, 2),
+            ],
+            "sensor": ["Sensor1", "Sensor2", "Sensor1", "Sensor2"],
+            "value": np.random.randn(4),
+        }
+    )
+    df_idx = df.set_index(["date", "sensor"])
+
+    check_write_func(
+        lambda df, path: df.to_parquet(path, partition_cols=["sensor", "date"]),
+        df_idx,
+        "test_to_pq_partition_by_multiIdx",
+        check_index=["sensor", "date"],
     )
 
 

--- a/bodo/tests/test_parquet_write.py
+++ b/bodo/tests/test_parquet_write.py
@@ -53,10 +53,19 @@ def check_write_func(datapath):
         ],
     }
 
-    def impl(fn, df: pd.DataFrame, file_id: str, check_index: list[str] | None = None):
+    def impl(
+        fn,
+        df: pd.DataFrame,
+        file_id: str,
+        no_seq: bool = False,
+        partition_cols: list[str] | None = None,
+        check_index: list[str] | None = None,
+    ):
         bodo_file_path = datapath(f"bodo_{file_id}.pq", check_exists=False)
         pandas_file_path = datapath(f"pandas_{file_id}.pq", check_exists=False)
-        for dist_func, args, kwargs in DISTRIBUTIONS.values():
+        for dist_name, (dist_func, args, kwargs) in DISTRIBUTIONS.items():
+            if no_seq and dist_name == "sequential":
+                continue
             with ensure_clean2(bodo_file_path), ensure_clean2(pandas_file_path):
                 write_jit = bodo.jit(fn, **kwargs)
                 write_jit(dist_func(df, *args), bodo_file_path)
@@ -88,6 +97,23 @@ def check_write_func(datapath):
                             assert (
                                 index_cols
                                 == pandas_meta.pandas_metadata["index_columns"]
+                            )
+
+                if partition_cols is not None:
+                    pandas_meta = pq.read_schema(pandas_file_path)
+                    bodo_fps = (
+                        list(os.walk(bodo_file_path))
+                        if os.path.isdir(bodo_file_path)
+                        else [("", [], [bodo_file_path])]
+                    )
+                    for prefix, _, file_names in bodo_fps:
+                        for file in file_names:
+                            bodo_meta = pq.read_schema(os.path.join(prefix, file))
+                            assert set(partition_cols) == set(
+                                bodo_meta.pandas_metadata["partition_columns"]
+                            )
+                            assert set(partition_cols) == set(
+                                pandas_meta.pandas_metadata["partition_columns"]
                             )
 
     return impl
@@ -1137,6 +1163,8 @@ def test_to_pq_partition_by_index(memory_leak_check, check_write_func):
         lambda df, path: df.to_parquet(path, partition_cols=["date"]),
         df_date,
         "test_to_pq_partition_by_index",
+        no_seq=True,
+        partition_cols=["date"],
         check_index=["date"],
     )
 
@@ -1144,6 +1172,8 @@ def test_to_pq_partition_by_index(memory_leak_check, check_write_func):
         lambda df, path: df.to_parquet(path, partition_cols=["date", "sensor"]),
         df_date,
         "test_to_pq_partition_by_index2",
+        no_seq=True,
+        partition_cols=["date", "sensor"],
         check_index=["date", "sensor"],
     )
 
@@ -1159,15 +1189,18 @@ def test_to_pq_partition_by_multiIdx(memory_leak_check, check_write_func):
                 date(2021, 1, 2),
             ],
             "sensor": ["Sensor1", "Sensor2", "Sensor1", "Sensor2"],
+            "flag": [True, True, True, True],
             "value": np.random.randn(4),
         }
     )
     df_idx = df.set_index(["date", "sensor"])
 
     check_write_func(
-        lambda df, path: df.to_parquet(path, partition_cols=["sensor", "date"]),
+        lambda df, path: df.to_parquet(path, partition_cols=["flag", "sensor", "date"]),
         df_idx,
         "test_to_pq_partition_by_multiIdx",
+        no_seq=True,
+        partition_cols=["flag", "sensor", "date"],
         check_index=["sensor", "date"],
     )
 

--- a/bodo/transforms/distributed_analysis.py
+++ b/bodo/transforms/distributed_analysis.py
@@ -2405,12 +2405,14 @@ class DistributedAnalysis:
         if fdef == ("init_multi_index", "bodo.hiframes.pd_multi_index_ext"):
             # input arrays and output index have the same distribution
             tup_list = guard(find_build_tuple, self.func_ir, rhs.args[0])
-            assert tup_list is not None
-            for v in tup_list:
-                _meet_array_dists(self.typemap, lhs, v.name, array_dists)
-            for v in tup_list:
-                _meet_array_dists(self.typemap, lhs, v.name, array_dists)
-            return
+            if tup_list is not None:
+                for v in tup_list:
+                    _meet_array_dists(self.typemap, lhs, v.name, array_dists)
+                for v in tup_list:
+                    _meet_array_dists(self.typemap, lhs, v.name, array_dists)
+                return
+            else:
+                _meet_array_dists(self.typemap, lhs, rhs.args[0], array_dists)
 
         if fdef == ("init_series", "bodo.hiframes.pd_series_ext"):
             # NOTE: constant sizes Series/Index is not distributed

--- a/bodo/transforms/distributed_analysis.py
+++ b/bodo/transforms/distributed_analysis.py
@@ -912,7 +912,7 @@ class DistributedAnalysis:
         return out_dist, non_concat_redvars
 
     def _analyze_call(
-        self, inst, lhs, rhs, func_var, args, kws, equiv_set, array_dists
+        self, inst, lhs, rhs: ir.Expr, func_var, args, kws, equiv_set, array_dists
     ):
         """analyze array distributions in function calls"""
         from bodo.transforms.distributed_analysis_call_registry import (
@@ -2410,9 +2410,11 @@ class DistributedAnalysis:
                     _meet_array_dists(self.typemap, lhs, v.name, array_dists)
                 for v in tup_list:
                     _meet_array_dists(self.typemap, lhs, v.name, array_dists)
-                return
             else:
-                _meet_array_dists(self.typemap, lhs, rhs.args[0], array_dists)
+                tup_arr_dists = array_dists[rhs.args[0].name]
+                assert all(tup_arr_dists[0] == arr_dist for arr_dist in tup_arr_dists)
+                _set_var_dist(self.typemap, lhs, array_dists, tup_arr_dists[0])
+            return
 
         if fdef == ("init_series", "bodo.hiframes.pd_series_ext"):
             # NOTE: constant sizes Series/Index is not distributed
@@ -2635,6 +2637,23 @@ class DistributedAnalysis:
             out_arrname = rhs.args[0].name
             in_arrname = rhs.args[2].name
             _meet_array_dists(self.typemap, out_arrname, in_arrname, array_dists)
+            return
+
+        if fdef == ("get_data", "bodo.libs.struct_arr_ext"):
+            in_arrname = rhs.args[0].name
+            if lhs not in array_dists:
+                _set_var_dist(self.typemap, lhs, array_dists, Distribution.OneD)
+            if in_arrname not in array_dists:
+                _set_var_dist(self.typemap, in_arrname, array_dists, Distribution.OneD)
+
+            lhs_dists, rhs_dist = array_dists[lhs], array_dists[in_arrname]
+            new_dist = Distribution(
+                min(min(x.value for x in lhs_dists), rhs_dist.value)
+            )
+            new_dist = _min_dist_top(new_dist, Distribution.OneD)
+
+            array_dists[lhs] = [new_dist] * len(lhs_dists)
+            array_dists[in_arrname] = new_dist
             return
 
         if fdef == ("init_spark_df", "bodo.libs.pyspark_ext"):
@@ -4271,7 +4290,7 @@ def _get_user_varname(metadata, v):
     return v
 
 
-def _meet_array_dists(typemap, arr1, arr2, array_dists, top_dist=None):
+def _meet_array_dists(typemap, arr1: str, arr2: str, array_dists, top_dist=None):
     """meet distributions of arrays for consistent distribution"""
 
     if top_dist is None:
@@ -4313,7 +4332,7 @@ def _get_var_dist(varname, array_dists, typemap):
     return array_dists[varname]
 
 
-def _set_var_dist(typemap, varname, array_dists, dist, check_type=True):
+def _set_var_dist(typemap, varname: str, array_dists, dist, check_type=True):
     # some non-distributable types could need to be assigned distribution
     # sometimes, e.g. SeriesILocType. check_type=False handles these cases.
     typ = typemap[varname]

--- a/bodo/transforms/untyped_pass.py
+++ b/bodo/transforms/untyped_pass.py
@@ -2652,9 +2652,8 @@ class UntypedPass:
         (
             columns,
             data_arrs,
-            index_col,
+            index_cols,
             nodes,
-            _,
             _,
         ) = self.pq_handler.gen_parquet_read(
             fname,
@@ -2670,41 +2669,58 @@ class UntypedPass:
         )
         n_cols = len(columns)
 
-        if chunksize is not None and use_index and index_col is not None:
+        if chunksize is not None and use_index and index_cols:
             raise BodoError(
                 "pd.read_parquet(): Bodo currently does not support batched reads "
                 "of Parquet files with an index column"
             )
 
-        if not use_index or index_col is None:
+        if not use_index or len(index_cols) == 0:
             assert n_cols > 0
-            index_arg = (
+            agg_index_arg = [
                 "bodo.hiframes.pd_index_ext.init_range_index(0, len(T), 1, None)"
-            )
-
-        elif isinstance(index_col, dict):
-            if index_col["name"] is None:
-                index_col_name = None
-                index_col_name_str = None
+            ]
+        elif len(index_cols) == 1:
+            index_col = index_cols[0]
+            if isinstance(index_col, dict):
+                if index_col["name"] is None:
+                    index_col_name = None
+                    index_col_name_str = None
+                else:
+                    index_col_name = index_col["name"]
+                    index_col_name_str = f"'{index_col_name}'"
+                # ignore range index information in pandas metadata
+                agg_index_arg = f"bodo.hiframes.pd_index_ext.init_range_index(0, len(T), 1, {index_col_name_str})"
             else:
-                index_col_name = index_col["name"]
-                index_col_name_str = f"'{index_col_name}'"
-            # ignore range index information in pandas metadata
-            index_arg = f"bodo.hiframes.pd_index_ext.init_range_index(0, len(T), 1, {index_col_name_str})"
+                # if the index_col is __index_level_0__, it means it has no name.
+                # Thus we do not write the name instead of writing '__index_level_0__' as the name
+                field_name = None if "__index_level_" in index_col else index_col
+                agg_index_arg = (
+                    f"bodo.utils.conversion.convert_to_index(index_arr, {field_name!r})"
+                )
         else:
-            # if the index_col is __index_level_0_, it means it has no name.
-            # Thus we do not write the name instead of writing '__index_level_0_' as the name
-            index_name = None if "__index_level_" in index_col else index_col
-            index_arg = (
-                f"bodo.utils.conversion.convert_to_index(index_arr, {index_name!r})"
-            )
+            index_field_names = []
+            for index_col in index_cols:
+                # I don't think RangeIndex is possible here, but just in case
+                assert isinstance(index_col, str)
+                index_field_names.append(
+                    None if "__index_level_" in index_col else index_col
+                )
+            agg_index_arg = f"bodo.hiframes.pd_multi_index_ext.init_multi_index(bodo.libs.struct_arr_ext.get_data(index_arr), {tuple(index_field_names)!r})"
 
         # _bodo_read_as_table = do not wrap the output table in a DataFrame
-        if _bodo_read_as_table or chunksize is not None:  # pragma: no cover
+        if _bodo_read_as_table or chunksize is not None:
             nodes += [ir.Assign(data_arrs[0], lhs, lhs.loc)]
         else:
-            func_text = "def _init_df(T, index_arr):\n"
-            func_text += f"  return bodo.hiframes.pd_dataframe_ext.init_dataframe((T,), {index_arg}, __col_name_meta_value_pq_read)\n"
+            func_text = (
+                f"def _init_df(T, index_arr):\n"
+                f"  return bodo.hiframes.pd_dataframe_ext.init_dataframe(\n"
+                f"    (T,),\n"
+                f"    {agg_index_arg},\n"
+                f"    __col_name_meta_value_pq_read\n"
+                f"  )\n"
+            )
+            print(func_text)
             loc_vars = {}
             exec(func_text, {}, loc_vars)
             _init_df = loc_vars["_init_df"]
@@ -3353,6 +3369,7 @@ class JSONFileInfo(FileInfo):
         self.json_sample_nrows = json_sample_nrows
         super().__init__()
 
+    # TODO: Return type is not consistent with base class and Parquet?
     def _get_schema(self, fname):
         return _get_json_df_type_from_file(
             fname,
@@ -3958,6 +3975,7 @@ class CSVFileInfo(FileInfo):
         self.csv_sample_nrows = csv_sample_nrows
         super().__init__()
 
+    # TODO: Return type is not consistent with base class and Parquet?
     def _get_schema(self, fname):
         return _get_csv_df_type_from_file(
             fname,

--- a/bodo/transforms/untyped_pass.py
+++ b/bodo/transforms/untyped_pass.py
@@ -2720,7 +2720,6 @@ class UntypedPass:
                 f"    __col_name_meta_value_pq_read\n"
                 f"  )\n"
             )
-            print(func_text)
             loc_vars = {}
             exec(func_text, {}, loc_vars)
             _init_df = loc_vars["_init_df"]

--- a/bodo/utils/typing.py
+++ b/bodo/utils/typing.py
@@ -7,6 +7,7 @@ import itertools
 import operator
 import types as pytypes
 import typing
+import typing as pt
 import warnings
 from inspect import getfullargspec
 from typing import Any
@@ -54,8 +55,10 @@ INDEX_SENTINEL = "$_bodo_index_"
 
 
 list_cumulative = {"cumsum", "cumprod", "cummin", "cummax"}
-Index = str | dict | None
-FileSchema = tuple[list[str], list, Index, list[int], list, list, list, pa.Schema]
+Index: pt.TypeAlias = list[str | dict]
+FileSchema: pt.TypeAlias = tuple[
+    list[str], list, Index, list[int], list, list, list, pa.Schema
+]
 
 
 def is_timedelta_type(in_type):


### PR DESCRIPTION
## Changes included in this PR

Support Parquet partitioned write where some of the partition columns are index columns. That can be either the index or a subset of index columns in the case of a MultiIndex.

## Testing strategy

- [ ] Run PR CI with the test enabled
- [ ] Ran locally

## User facing changes

Closes #223, all Parquet features should be supported now.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.