### PR TITLE
Fix Polaris link on Nightly

### DIFF
--- a/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
@@ -92,7 +92,7 @@ jobs:
       set -exo pipefail
 
       # This isn't published on pypi so no good way to list it as a dependency
-      pixi run -e azure pip install 'git+https://github.com/apache/polaris.git#subdirectory=regtests/client/python'
+      pixi run -e azure pip install 'git+https://github.com/apache/polaris.git#subdirectory=client/python'
 
       unamestr=`uname`
       if [[ "$unamestr" == 'Linux' ]]; then

--- a/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodosql/azure/azure-test-conda-linux-macos.yml
@@ -79,7 +79,7 @@ jobs:
       pixi run -e azure python -c "import bodosql; print(bodosql.__version__)"
 
       # This isn't published on pypi so no good way to list it as a dependency
-      pixi run -e azure pip install 'git+https://github.com/apache/polaris.git#subdirectory=regtests/client/python'
+      pixi run -e azure pip install 'git+https://github.com/apache/polaris.git#subdirectory=client/python'
 
       unamestr=`uname`
       if [[ "$unamestr" == 'Linux' ]]; then


### PR DESCRIPTION
## Changes included in this PR

Polaris refactored yesterday which broke CI.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Ran Nightly
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.