### PR TITLE
Fix Output Print in the Platform

### DIFF
--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -653,7 +653,7 @@ class Spawner:
         # debug_msg(self.logger, "bcast_root: "+ str(self.bcast_root))
         # rank 0 broadcast its hostname and port for the zmq shell
         # if bodo.get_rank() == 0:
-            
+
         for attempt in range(max_attempts):
             try:
                 port = out_socket.bind_to_random_port("tcp://0.0.0.0")

--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -625,10 +625,12 @@ class Spawner:
         https://stackoverflow.com/questions/23947281/python-multiprocessing-redirect-stdout-of-a-child-process-to-a-tkinter-text
         """
 
-        # Skip if not in Jupyter or not on Windows
-        if not bodo.utils.utils.is_jupyter_on_windows():
-            self.worker_output_thread = None
-            return
+        # TODO: uncomment
+        # platform_cloud_provider = os.environ.get("BODO_PLATFORM_CLOUD_PROVIDER", None)
+        # Skip if not in Jupyter or not on Windows or not running on Bodo platform
+        # if platform_cloud_provider is None or not bodo.utils.utils.is_jupyter_on_windows():
+        #     self.worker_output_thread = None
+        #     return
 
         import errno
         import threading
@@ -646,9 +648,15 @@ class Spawner:
         except AttributeError:
             win_in_use = None
 
+        # using hardcoded 0 since self.bcast_root= -3!
+        # self.worker_intercomm.rank is None!!
+        # debug_msg(self.logger, "bcast_root: "+ str(self.bcast_root))
+        # rank 0 broadcast its hostname and port for the zmq shell
+        # if bodo.get_rank() == 0:
+            
         for attempt in range(max_attempts):
             try:
-                port = out_socket.bind_to_random_port("tcp://127.0.0.1")
+                port = out_socket.bind_to_random_port("tcp://0.0.0.0")
             except zmq.ZMQError as ze:
                 # Raise if we have any error not related to socket binding
                 if ze.errno != errno.EADDRINUSE and ze.errno != win_in_use:
@@ -656,7 +664,14 @@ class Spawner:
                 if attempt == max_attempts - 1:
                     raise
 
-        self.worker_intercomm.bcast(port, self.bcast_root)
+        hostname = socket.gethostname()
+        connection_info = f"tcp://{hostname}:{port}"
+        self.worker_intercomm.bcast(connection_info, self.bcast_root)
+        debug_msg(self.logger, f"Connection info: {connection_info}")
+
+        # Other ranks connect
+        # if bodo.get_rank() != 0:
+        # out_socket.connect(connection_info)
 
         def worker_output_thread_func():
             """Thread that receives all worker outputs and prints them."""

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -484,9 +484,6 @@ class StdoutQueue:
 
     def write(self, msg):
         # TODO(Ehsan): buffer output similar to ipykernel
-        debug_worker_msg(
-            bodo.user_logging.get_current_bodo_verbose_logger(), f"Writing {msg}"
-        )
         self.out_socket.send_string(f"{int(self.is_stderr)}{msg}")
 
     def flush(self):
@@ -520,7 +517,7 @@ def worker_loop(
     if bodo.utils.utils.is_jupyter_on_windows():
         # Multi-node Jupyter on Windows is not supported yet
         spawner_hostname = comm_world.bcast(
-            socket.gethostname() if bodo.get_rank() == 0 else None, root=0
+            spawner_hostname if bodo.get_rank() == 0 else None, root=0
         )
         if spawner_hostname != socket.gethostname():
             raise bodo.utils.typing.BodoError(

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -5,7 +5,6 @@ directly"""
 import logging
 import os
 import signal
-import socket
 import sys
 import typing as pt
 import uuid
@@ -519,7 +518,7 @@ def worker_loop(
     # don't inherit file descriptors from the parent process.
     out_socket = None
     # TODO: platform check
-    if True: #bodo.utils.utils.is_jupyter_on_windows():
+    if True:  # bodo.utils.utils.is_jupyter_on_windows():
         # Multi-node Jupyter on Windows is not supported yet
         # spawner_hostname = comm_world.bcast(
         #     socket.gethostname() if bodo.get_rank() == 0 else None, root=0

--- a/bodo/utils/utils.py
+++ b/bodo/utils/utils.py
@@ -1853,6 +1853,17 @@ def is_jupyter_on_windows() -> bool:
     )
 
 
+def is_jupyter_on_bodo_platform() -> bool:
+    """Returns True if running in Jupyter on Bodo Platform"""
+
+    return True
+    platform_cloud_provider = os.environ.get("BODO_PLATFORM_CLOUD_PROVIDER", None)
+    return (platform_cloud_provider is not None) and (
+        "JPY_SESSION_NAME" in os.environ
+        or "PYDEVD_IPYTHON_COMPATIBLE_DEBUGGING" in os.environ
+    )
+
+
 @dataclass
 class AWSCredentials:
     access_key: str


### PR DESCRIPTION
## Changes included in this PR
- Broadcast tcp:://hostname/port to workers
- Workers connect to and redirect their stdout to print



<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

Code used in notebook for testing
```Python
import os
import bodo
bodo.set_verbose_level(2)
@bodo.jit
def f():
    print("------hello world from", bodo.get_rank(), "|", bodo.get_size(), "\n")
# comment on platform
os.environ["BODO_NUM_WORKERS"]="2"
f()
```

### Platform
  - Created cluster with 2 node
  -  Copy PR files to its corresponding place in `/opt/conda/lib/python3.12/site-packages/bodo/...`
  -  Connect notebook and test
 
![Screenshot 2025-03-26 at 11 26 23 AM](https://github.com/user-attachments/assets/814b53db-e691-47a5-b0f4-60d97797ba00)




### Locally on Mac
- Create a kernel and connect to it from a separate instance of jupyter lab
      -  `pip install ipykernel` and `conda install -c conda-forge jupyterlab`
      -   `python -m ipykernel install --user --name my_test_kernel --display-name "My Test Kernel"`
      -   Open JupyterLab `jupyter lab`.
      -   Create a new notebook and use code above.
      -   In the notebook interface, go to Kernel > Change Kernel > My Test Kernel (or whatever name you used for --display-name).




<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [N/A] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.