### PR TITLE
[iceberg] Support read/writing to GCS.

### DIFF
--- a/bodo/io/iceberg/catalog/__init__.py
+++ b/bodo/io/iceberg/catalog/__init__.py
@@ -65,6 +65,7 @@ def conn_str_to_catalog(conn_str: str) -> Catalog:
                 | "iceberg+s3"
                 | "iceberg+abfs"
                 | "iceberg+abfss"
+                | "iceberg+gs"
             ):
                 from .dir import DirCatalog
 
@@ -126,7 +127,7 @@ def conn_str_to_catalog(conn_str: str) -> Catalog:
             case _:
                 raise ValueError(
                     "Iceberg connection strings must start with one of the following: \n"
-                    "  Hadoop / Directory Catalog: 'iceberg://', 'iceberg+file://', 'iceberg+s3://', 'iceberg+abfs://', 'iceberg+abfss://'\n"
+                    "  Hadoop / Directory Catalog: 'iceberg://', 'iceberg+file://', 'iceberg+s3://', 'iceberg+abfs://', 'iceberg+abfss://', 'iceberg+gs://'\n"
                     "  REST Catalog: 'iceberg+http://', 'iceberg+https://', 'iceberg+rest://'\n"
                     "  Glue Catalog: 'iceberg+glue'\n"
                     "  Hive Catalog: 'iceberg+thrift://'\n"


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Created GCS bucket, authenticated with gcloud, test file:
``` py
import os

import pandas as pd
import bodo

df = pd.DataFrame({"a": [1,2,3,4,5,6]})

@bodo.jit
def write_iceberg_table(df):
    df.to_sql(
        name="TABLE",
        con="iceberg+gs://my_bucket921478/iceberg_db",
        schema="TEST2",
        if_exists="replace"
    )

write_iceberg_table(df)

@bodo.jit
def example_read_iceberg() -> pd.DataFrame:
    return pd.read_sql_table(
        table_name="TABLE",
        con = "iceberg+gs://my_bucket921478/iceberg_db",
        schema="TEST2",
    )

print(example_read_iceberg())
```
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.