### PR TITLE
Add one LazyPlan class to lazily wrap the creation of actual duckdb proxy objects.

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -44,7 +44,7 @@ def read_parquet(
             )
         else:
             assert False and "Unsupported option to read_parquet"
-    pr = plan_optimizer.LogicalGetParquetRead(path.encode())
+    pr = plan_optimizer.LazyPlan(plan_optimizer.LogicalGetParquetRead, path.encode())
     return plan_optimizer.wrap_plan(get_pandas_schema(path), pr)
 
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -458,7 +458,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 left_on = []
             if right_on is None:
                 right_on = []
-            planComparisonJoin = plan_optimizer.LogicalComparisonJoin(
+            planComparisonJoin = plan_optimizer.LazyPlan(
+                plan_optimizer.LogicalComparisonJoin,
                 self.plan,
                 right.plan,
                 plan_optimizer.CJoinType.INNER,
@@ -488,7 +489,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 new_metadata = zero_size_self.__getitem__(zero_size_key)
                 return plan_optimizer.wrap_plan(
                     new_metadata,
-                    plan=plan_optimizer.LogicalFilter(self.plan, key.plan),
+                    plan=plan_optimizer.LazyPlan(
+                        plan_optimizer.LogicalFilter, self.plan, key.plan
+                    ),
                 )
             else:
                 """ This is selecting one or more columns. Be a bit more
@@ -510,16 +513,20 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                     new_metadata = zero_size_self.__getitem__(key)
                     return plan_optimizer.wrap_plan(
                         new_metadata,
-                        plan=plan_optimizer.LogicalProjection(
-                            self.plan, zip(key_indices, key_types)
+                        plan=plan_optimizer.LazyPlan(
+                            plan_optimizer.LogicalProjection,
+                            self.plan,
+                            list(zip(key_indices, key_types)),
                         ),
                     )
                 else:
                     new_metadata = zero_size_self.__getitem__(key)
                     return plan_optimizer.wrap_plan(
                         new_metadata,
-                        plan=plan_optimizer.LogicalProjection(
-                            self.plan, zip(key_indices, key_types)
+                        plan=plan_optimizer.LazyPlan(
+                            plan_optimizer.LogicalProjection,
+                            self.plan,
+                            list(zip(key_indices, key_types)),
                         ),
                     )
 

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -412,6 +412,43 @@ cdef class LogicalGetParquetRead(LogicalOperator):
         return f"LogicalGetParquetRead({self.path})"
 
 
+class LazyPlan:
+    """ Easiest mode to use DuckDB is to generate isolated queries and try to minimize
+        node re-use issues due to the frequent use of unique_ptr.  This class should be
+        used when constructing all plans and holds them lazily.  On demand, generate_duckdb
+        can be used to convert to an isolated set of DuckDB objects for execution.
+    """
+    def __init__(self, plan_class, *args, **kwargs):
+        self.plan_class = plan_class
+        self.args = args
+        self.kwargs = kwargs
+
+    def generate_duckdb(self, cache=None):
+        # Sometimes the same LazyPlan object is encountered twice during the same
+        # query so  we use the cache dict to only convert it once.
+        if cache is None:
+            cache = {}
+        # If previously converted then use the last result.
+        if id(self) in cache:
+            return cache[id(self)]
+
+        def recursive_check(x):
+            """ Recursively convert LazyPlans but return other types unmodified.
+            """
+            if isinstance(x, LazyPlan):
+                return x.generate_duckdb(cache=cache)
+            else:
+                return x
+
+        # Convert any LazyPlan in the args or kwargs.
+        args = [recursive_check(x) for x in self.args]
+        kwargs = {k:recursive_check(v) for k,v in self.kwargs.items()}
+        # Create real duckdb class.
+        ret = self.plan_class(*args, **kwargs)
+        # Add to cache so we don't convert it again.
+        cache[id(self)] = ret
+        return ret
+
 cpdef py_optimize_plan(object plan):
     """Optimize a logical plan using DuckDB's optimizer
     """
@@ -419,7 +456,7 @@ cpdef py_optimize_plan(object plan):
 
     if not isinstance(plan, LogicalOperator):
         raise TypeError("Expected a LogicalOperator instance")
-   
+
     wrapped_operator = plan
 
     optimized_plan = LogicalOperator()
@@ -430,6 +467,8 @@ cpdef convert_and_execute(plan):
     opt_plan = py_optimize_plan(plan)
 
 cpdef collect_func(plan_to_execute):
+    assert isinstance(plan_to_execute, LazyPlan)
+    plan_to_execute = plan_to_execute.generate_duckdb()
     convert_and_execute(plan_to_execute)
 
 cpdef del_func(res_id):
@@ -443,6 +482,8 @@ cpdef wrap_plan(schema, plan):
     from bodo.pandas.frame import BodoDataFrame
     from bodo.pandas.series import BodoSeries
     from bodo.pandas.utils import get_lazy_manager_class, get_lazy_single_manager_class
+
+    assert isinstance(plan, LazyPlan)
 
     if isinstance(schema, dict):
         schema = {

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -37,7 +37,9 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             assert isinstance(new_metadata, pd.Series)
             return plan_optimizer.wrap_plan(
                 new_metadata,
-                plan=plan_optimizer.LogicalBinaryOp(self.plan, other, op),
+                plan=plan_optimizer.LazyPlan(
+                    plan_optimizer.LogicalBinaryOp, self.plan, other, op
+                ),
             )
 
         return super()._cmp_method(other, op)


### PR DESCRIPTION
## Changes included in this PR

Back to lazy duckdb object generation strategy but without duplicating the inheritance hierarchy.  One new class that lazily constructs the duckdb objects as required.  The purpose of this is to avoid the need to copy duckdb nodes.

## Testing strategy

None

## User facing changes

None

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.