### PR TITLE
Fix BodoDataFrame.to_csv()/to_json() string output in spawn

### DIFF
--- a/bodo/hiframes/pd_dataframe_ext.py
+++ b/bodo/hiframes/pd_dataframe_ext.py
@@ -4711,6 +4711,8 @@ def to_json_overload(
     storage_options=None,
     mode="w",
     _bodo_file_prefix="part-",
+    # Concatenate string output on rank 0 if set (used in spawn mode)
+    _bodo_concat_str_output=False,
 ):
     check_runtime_cols_unsupported(df, "DataFrame.to_json()")
     check_unsupported_args(
@@ -4745,7 +4747,14 @@ def to_json_overload(
             storage_options=None,
             mode="w",
             _bodo_file_prefix="part-",
+            _bodo_concat_str_output=False,
         ):  # pragma: no cover
+            if _bodo_concat_str_output:
+                # Return the concatenated string output on rank 0
+                # and empty string on all other ranks
+                df = bodo.gatherv(df)
+                if bodo.get_rank() != 0:
+                    return ""
             with bodo.no_warning_objmode(D="unicode_type"):
                 D = df.to_json(
                     path_or_buf,
@@ -4782,6 +4791,7 @@ def to_json_overload(
         storage_options=None,
         mode="w",
         _bodo_file_prefix="part-",
+        _bodo_concat_str_output=False,
     ):  # pragma: no cover
         # passing None for the first argument returns a string
         # containing contents to write to json

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -132,7 +132,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 + get_overload_const_str(compression)
             )
 
-        to_parquet_wrapper(
+        return to_parquet_wrapper(
             self,
             path,
             engine,
@@ -186,7 +186,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 method,
             )
 
-        to_sql_wrapper(
+        return to_sql_wrapper(
             self,
             name,
             con,
@@ -264,6 +264,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 doublequote=doublequote,
                 escapechar=escapechar,
                 decimal=decimal,
+                _bodo_concat_str_output=True,
             )
 
         # checks string arguments before jit performs conversion to unicode
@@ -286,7 +287,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             module_name="IO",
         )
 
-        to_csv_wrapper(
+        return to_csv_wrapper(
             self,
             path_or_buf,
             sep=sep,
@@ -357,7 +358,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 mode=mode,
             )
 
-        to_json_wrapper(
+        return to_json_wrapper(
             self,
             path_or_buf,
             date_format=date_format,

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -356,6 +356,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 indent=indent,
                 storage_options=storage_options,
                 mode=mode,
+                _bodo_concat_str_output=True,
             )
 
         return to_json_wrapper(

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -641,6 +641,22 @@ def test_json(collect_func):
 
 
 @pytest_mark_spawn_mode
+def test_json_str(collect_func):
+    """Tests that to_json() with string output works properly (returns all string data to spawner)"""
+
+    @bodo.jit(spawn=True)
+    def _get_bodo_df(df):
+        return df
+
+    df = collect_func(0)
+    bodo_df = _get_bodo_df(df)
+    assert bodo_df.to_json(orient="records", lines=True) == df.to_json(
+        orient="records", lines=True
+    )
+    assert bodo_df._lazy
+
+
+@pytest_mark_spawn_mode
 def test_map_partitions():
     """Test map_partitions on BodoDataFrame"""
 

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -563,6 +563,20 @@ def test_csv(collect_func):
 
 
 @pytest_mark_spawn_mode
+def test_csv_str(collect_func):
+    """Tests that to_csv() with string output works properly (returns all string data to spawner)"""
+
+    @bodo.jit(spawn=True)
+    def _get_bodo_df(df):
+        return df
+
+    df = collect_func(0)
+    bodo_df = _get_bodo_df(df)
+    assert bodo_df.to_csv(index=False) == df.to_csv(index=False)
+    assert bodo_df._lazy
+
+
+@pytest_mark_spawn_mode
 def test_csv_param(collect_func):
     """Tests that to_csv() raises an error on unsupported parameters"""
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes string output case (path set to None) for to_csv/to_json calls in our lazy dataframe wrapper. Makes sure the output string is concatenated on the spawner properly.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
df.to_csv() without path now works.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.