### PR TITLE
BSE-4706: Fix test tmp_path sync

### DIFF
--- a/bodo/tests/test_parquet_write.py
+++ b/bodo/tests/test_parquet_write.py
@@ -158,6 +158,8 @@ def check_write_func(
     ),
 )
 def test_semi_structured_data(df, tmp_path):
+    comm = bodo.mpi4py.MPI.COMM_WORLD
+    tmp_path = comm.bcast(tmp_path if bodo.get_rank() == 0 else None, root=0)
     check_write_func(
         lambda df, path: df.to_parquet(path),
         df,
@@ -1086,6 +1088,8 @@ def test_streaming_parquet_write_rep(memory_leak_check):
 def test_to_pq_multiIdx(tmp_path, memory_leak_check):
     """Test to_parquet with MultiIndexType"""
     np.random.seed(0)
+    comm = bodo.mpi4py.MPI.COMM_WORLD
+    tmp_path = comm.bcast(tmp_path if bodo.get_rank() == 0 else None, root=0)
 
     arrays = [
         ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
@@ -1108,6 +1112,8 @@ def test_to_pq_multiIdx(tmp_path, memory_leak_check):
 def test_to_pq_multiIdx_no_name(tmp_path, memory_leak_check):
     """Test to_parquet with MultiIndexType with no name at 1 level"""
     np.random.seed(0)
+    comm = bodo.mpi4py.MPI.COMM_WORLD
+    tmp_path = comm.bcast(tmp_path if bodo.get_rank() == 0 else None, root=0)
 
     arrays = [
         ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
tmp_path is different when called on multiple we ranks, we should add our own tmp_path that handles this but just manually using rank 0 to unblock.

## Testing strategy
Ran tests locally
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.