### PR TITLE
Run dataframe library plans in parallel

### DIFF
--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -184,6 +184,10 @@ sql_plan_cache_loc = os.environ.get("BODO_SQL_PLAN_CACHE_DIR")
 # This is expected to be a distributed filesystem which all nodes have access to.
 dataframe_library_enabled = os.environ.get("BODO_ENABLE_DATAFRAME_LIBRARY", "0") != "0"
 
+# Runs the DataFrame library in parallel mode if enabled (disable for debugging on a
+# single core).
+dataframe_library_run_parallel = os.environ.get("BODO_DATAFRAME_LIBRARY_RUN_PARALLEL", "1") != "0"
+
 # -------------------------- End DataFrame Library Config --------------------------
 
 bodo_use_native_type_inference = (

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -178,7 +178,7 @@ duckdb::unique_ptr<duckdb::LogicalGet> make_parquet_get_node(
         return_types, return_names, virtual_columns);
 }
 
-duckdb::unique_ptr<duckdb::LogicalGet> make_dataframe_get_node(
+duckdb::unique_ptr<duckdb::LogicalGet> make_dataframe_get_seq_node(
     PyObject *df, PyObject *pyarrow_schema) {
     // See DuckDB Pandas scan code:
     // https://github.com/duckdb/duckdb/blob/d29a92f371179170688b4df394478f389bf7d1a6/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_scan.hpp#L19
@@ -189,7 +189,26 @@ duckdb::unique_ptr<duckdb::LogicalGet> make_dataframe_get_node(
 
     BodoDataFrameScanFunction table_function = BodoDataFrameScanFunction();
     duckdb::unique_ptr<duckdb::FunctionData> bind_data1 =
-        duckdb::make_uniq<BodoDataFrameScanFunctionData>(df);
+        duckdb::make_uniq<BodoDataFrameSeqScanFunctionData>(df);
+
+    // Convert Arrow schema to DuckDB
+    std::shared_ptr<arrow::Schema> arrow_schema = unwrap_schema(pyarrow_schema);
+    auto [return_names, return_types] = arrow_schema_to_duckdb(arrow_schema);
+
+    duckdb::virtual_column_map_t virtual_columns;
+
+    return duckdb::make_uniq<duckdb::LogicalGet>(
+        binder->GenerateTableIndex(), table_function, std::move(bind_data1),
+        return_types, return_names, virtual_columns);
+}
+
+duckdb::unique_ptr<duckdb::LogicalGet> make_dataframe_get_parallel_node(
+    std::string result_id, PyObject *pyarrow_schema) {
+    duckdb::shared_ptr<duckdb::Binder> binder = get_duckdb_binder();
+
+    BodoDataFrameScanFunction table_function = BodoDataFrameScanFunction();
+    duckdb::unique_ptr<duckdb::FunctionData> bind_data1 =
+        duckdb::make_uniq<BodoDataFrameParallelScanFunctionData>(result_id);
 
     // Convert Arrow schema to DuckDB
     std::shared_ptr<arrow::Schema> arrow_schema = unwrap_schema(pyarrow_schema);

--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -239,24 +239,12 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
         If the data is on the workers, collect it.
         """
         if self._plan is not None:
+            from bodo.pandas.utils import execute_plan
+
             debug_msg(
                 self.logger, "[LazyArrayManager] Executing Plan and collecting data..."
             )
-            from bodo.ext import plan_optimizer
-
-            optimized_plan = plan_optimizer.py_optimize_plan(
-                self._plan.generate_duckdb()
-            )
-
-            # TODO: run on workers
-            # def exec_plan(optimized_plan):
-            #     pass
-
-            # data = bodo.spawn.spawner.submit_func_to_workers(
-            #     exec_plan, [], optimized_plan
-            # )
-            data = plan_optimizer.py_execute_plan(optimized_plan)
-
+            data = execute_plan(self._plan)
             self._plan = None
             self.arrays = data._mgr.arrays
             self._md_result_id = None
@@ -460,25 +448,13 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
         If the data is on the workers, collect it.
         """
         if self._plan is not None:
+            from bodo.pandas.utils import execute_plan
+
             debug_msg(
                 self.logger,
                 "[LazySingleArrayManager] Executing Plan and collecting data...",
             )
-            from bodo.ext import plan_optimizer
-
-            optimized_plan = plan_optimizer.py_optimize_plan(
-                self._plan.generate_duckdb()
-            )
-
-            # TODO: run on workers
-            # def exec_plan(optimized_plan):
-            #     pass
-
-            # data = bodo.spawn.spawner.submit_func_to_workers(
-            #     exec_plan, [], optimized_plan
-            # )
-            data = plan_optimizer.py_execute_plan(optimized_plan)
-
+            data = execute_plan(self._plan)
             self._plan = None
             self.arrays = data._mgr.arrays
             self._md_result_id = None

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -4,7 +4,7 @@ from pandas._libs import lib
 from bodo.ext import plan_optimizer
 from bodo.pandas.frame import BodoDataFrame
 from bodo.pandas.series import BodoSeries
-from bodo.pandas.utils import LazyPlan, scatter_data
+from bodo.pandas.utils import LazyPlan
 
 
 def from_pandas(df):
@@ -29,7 +29,7 @@ def from_pandas(df):
     arrow_schema = pa.Schema.from_pandas(df)
 
     if bodo.dataframe_library_run_parallel:
-        res_id = scatter_data(df)
+        res_id = bodo.spawn.utils.scatter_data(df)
         plan = LazyPlan("LogicalGetPandasReadParallel", res_id, arrow_schema)
     else:
         plan = LazyPlan("LogicalGetPandasReadSeq", df, arrow_schema)

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -16,6 +16,14 @@ def from_pandas(df):
     if not isinstance(df, pd.DataFrame):
         raise TypeError("Input must be a pandas DataFrame")
 
+    # TODO: Add support for Index
+    if (
+        not isinstance(df.index, pd.RangeIndex)
+        or df.index.start != 0
+        or df.index.step != 1
+    ):
+        raise ValueError("Only RangeIndex with start=0 and step=1 is supported")
+
     empty_df = df.iloc[:0]
     n_rows = len(df)
     arrow_schema = pa.Schema.from_pandas(df)
@@ -25,7 +33,6 @@ def from_pandas(df):
         plan = LazyPlan("LogicalGetPandasReadParallel", res_id, arrow_schema)
     else:
         plan = LazyPlan("LogicalGetPandasReadSeq", df, arrow_schema)
-    # TODO: Add support for Index
 
     return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=n_rows)
 

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -4,6 +4,7 @@ from pandas._libs import lib
 from bodo.ext import plan_optimizer
 from bodo.pandas.frame import BodoDataFrame
 from bodo.pandas.series import BodoSeries
+from bodo.pandas.utils import LazyPlan
 
 
 def from_pandas(df):
@@ -18,9 +19,7 @@ def from_pandas(df):
     arrow_schema = pa.Schema.from_pandas(df)
 
     # TODO: distribute to workers and get result_id
-    plan = plan_optimizer.LazyPlan(
-        plan_optimizer.LogicalGetPandasRead, df, arrow_schema
-    )
+    plan = LazyPlan("LogicalGetPandasRead", df, arrow_schema)
     # TODO: Add support for Index
 
     return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=n_rows)
@@ -85,9 +84,7 @@ def read_parquet(
     ).to_pandas()
     empty_df.index = pd.RangeIndex(0)
 
-    plan = plan_optimizer.LazyPlan(
-        plan_optimizer.LogicalGetParquetRead, path.encode(), arrow_schema
-    )
+    plan = LazyPlan("LogicalGetParquetRead", path.encode(), arrow_schema)
     return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=nrows)
 
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -11,7 +11,7 @@ from bodo.pandas.lazy_metadata import LazyMetadata
 from bodo.pandas.lazy_wrapper import BodoLazyWrapper
 from bodo.pandas.managers import LazyBlockManager, LazyMetadataMixin
 from bodo.pandas.series import BodoSeries
-from bodo.pandas.utils import get_lazy_manager_class
+from bodo.pandas.utils import LazyPlan, get_lazy_manager_class
 from bodo.utils.typing import (
     BodoError,
     check_unsupported_args,
@@ -485,8 +485,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             left_on = []
         if right_on is None:
             right_on = []
-        planComparisonJoin = plan_optimizer.LazyPlan(
-            plan_optimizer.LogicalComparisonJoin,
+        planComparisonJoin = LazyPlan(
+            "LogicalComparisonJoin",
             self._plan,
             right._plan,
             plan_optimizer.CJoinType.INNER,
@@ -521,9 +521,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             new_metadata = zero_size_self.__getitem__(zero_size_key)
             return plan_optimizer.wrap_plan(
                 new_metadata,
-                plan=plan_optimizer.LazyPlan(
-                    plan_optimizer.LogicalFilter, self._plan, key_plan
-                ),
+                plan=LazyPlan("LogicalFilter", self._plan, key_plan),
             )
         else:
             """ This is selecting one or more columns. Be a bit more
@@ -545,8 +543,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 new_metadata = zero_size_self.__getitem__(key)
                 return plan_optimizer.wrap_plan(
                     new_metadata,
-                    plan=plan_optimizer.LazyPlan(
-                        plan_optimizer.LogicalProjection,
+                    plan=LazyPlan(
+                        "LogicalProjection",
                         self._plan,
                         key_indices,
                         pa_schema,
@@ -557,7 +555,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 return plan_optimizer.wrap_plan(
                     new_metadata,
                     plan=plan_optimizer.LazyPlan(
-                        plan_optimizer.LogicalProjection,
+                        "LogicalProjection",
                         self._plan,
                         key_indices,
                         pa_schema,

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -554,7 +554,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 new_metadata = zero_size_self.__getitem__(key)
                 return plan_optimizer.wrap_plan(
                     new_metadata,
-                    plan=plan_optimizer.LazyPlan(
+                    plan=LazyPlan(
                         "LogicalProjection",
                         self._plan,
                         key_indices,

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -202,24 +202,12 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
         """
         # Execute the plan if we have one
         if self._plan is not None:
+            from bodo.pandas.utils import execute_plan
+
             debug_msg(
                 self.logger, "[LazyBlockManager] Executing Plan and collecting data..."
             )
-            from bodo.ext import plan_optimizer
-
-            optimized_plan = plan_optimizer.py_optimize_plan(
-                self._plan.generate_duckdb()
-            )
-
-            # TODO: run on workers
-            # def exec_plan(optimized_plan):
-            #     pass
-
-            # data = bodo.spawn.spawner.submit_func_to_workers(
-            #     exec_plan, [], optimized_plan
-            # )
-            data = plan_optimizer.py_execute_plan(optimized_plan)
-
+            data = execute_plan(self._plan)
             self._plan = None
             self.blocks = data._mgr.blocks
             self._md_result_id = None
@@ -434,25 +422,13 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
         """
         # Execute the plan if we have one
         if self._plan is not None:
+            from bodo.pandas.utils import execute_plan
+
             debug_msg(
                 self.logger,
                 "[LazySingleBlockManager] Executing Plan and collecting data...",
             )
-            from bodo.ext import plan_optimizer
-
-            optimized_plan = plan_optimizer.py_optimize_plan(
-                self._plan.generate_duckdb()
-            )
-
-            # TODO: run on workers
-            # def exec_plan(optimized_plan):
-            #     pass
-
-            # data = bodo.spawn.spawner.submit_func_to_workers(
-            #     exec_plan, [], optimized_plan
-            # )
-            data = plan_optimizer.py_execute_plan(optimized_plan)
-
+            data = execute_plan(self._plan)
             self._plan = None
             self.blocks = data._mgr.blocks
             self._md_result_id = None

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -9,7 +9,7 @@ from bodo.pandas.array_manager import LazySingleArrayManager
 from bodo.pandas.lazy_metadata import LazyMetadata
 from bodo.pandas.lazy_wrapper import BodoLazyWrapper
 from bodo.pandas.managers import LazyMetadataMixin, LazySingleBlockManager
-from bodo.pandas.utils import get_lazy_single_manager_class
+from bodo.pandas.utils import LazyPlan, get_lazy_single_manager_class
 
 
 class BodoSeries(pd.Series, BodoLazyWrapper):
@@ -53,12 +53,8 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         assert isinstance(new_metadata, pd.Series)
         return plan_optimizer.wrap_plan(
             new_metadata,
-            plan=plan_optimizer.LazyPlan(
-                plan_optimizer.LogicalBinaryOp, self._plan, other, op
-            ),
+            plan=LazyPlan("LogicalBinaryOp", self._plan, other, op),
         )
-
-        return super()._cmp_method(other, op)
 
     @staticmethod
     def from_lazy_mgr(

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -1,7 +1,3 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 import numba
 from llvmlite import ir as lir
 from numba.extending import intrinsic
@@ -9,9 +5,6 @@ from numba.extending import intrinsic
 from bodo.libs.array import cpp_table_to_py_table, delete_table, table_type
 from bodo.pandas.array_manager import LazyArrayManager, LazySingleArrayManager
 from bodo.pandas.managers import LazyBlockManager, LazySingleBlockManager
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 
 def get_data_manager_pandas() -> str:
@@ -163,18 +156,3 @@ def execute_plan(plan: LazyPlan):
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
     return _exec_plan(plan)
-
-
-def scatter_data(data: pd.DataFrame | pd.Series | pd.Index | pd.array) -> str:
-    """Scatter data to all workers and return the result ID"""
-    import bodo.spawn.spawner
-    from bodo.mpi4py import MPI
-    from bodo.spawn.spawner import CommandType
-
-    spawner = bodo.spawn.spawner.get_spawner()
-    bcast_root = MPI.ROOT if bodo.get_rank() == 0 else MPI.PROC_NULL
-    spawner.worker_intercomm.bcast(CommandType.SCATTER.value, bcast_root)
-    bodo.libs.distributed_api.scatterv(
-        data, root=bcast_root, comm=spawner.worker_intercomm
-    )
-    return spawner.worker_intercomm.recv(None, source=0)

--- a/bodo/spawn/utils.py
+++ b/bodo/spawn/utils.py
@@ -1,12 +1,18 @@
 """Utilities for Spawn Mode"""
 
+from __future__ import annotations
+
 import logging
 import typing as pt
 from enum import Enum
 from time import sleep
+from typing import TYPE_CHECKING
 
 import bodo.user_logging
 from bodo.mpi4py import MPI
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class CommandType(str, Enum):
@@ -75,3 +81,18 @@ def set_global_config(config_name: str, config_value: pt.Any):
     exec(f"import {mod_name}; mod = {mod_name}", globals(), locs)
     mod = locs["mod"]
     setattr(mod, attr, config_value)
+
+
+def scatter_data(data: pd.DataFrame | pd.Series | pd.Index | pd.array) -> str:
+    """Scatter data to all workers and return the result ID"""
+    import bodo.spawn.spawner
+    from bodo.mpi4py import MPI
+    from bodo.spawn.spawner import CommandType
+
+    spawner = bodo.spawn.spawner.get_spawner()
+    bcast_root = MPI.ROOT if bodo.get_rank() == 0 else MPI.PROC_NULL
+    spawner.worker_intercomm.bcast(CommandType.SCATTER.value, bcast_root)
+    bodo.libs.distributed_api.scatterv(
+        data, root=bcast_root, comm=spawner.worker_intercomm
+    )
+    return spawner.worker_intercomm.recv(None, source=0)

--- a/bodo/tests/test_df_lib/test_from_pandas.py
+++ b/bodo/tests/test_df_lib/test_from_pandas.py
@@ -26,6 +26,8 @@ def test_from_pandas(datapath):
             bdf,
             df,
         )
+        assert not bdf._lazy
+        assert bdf._mgr._plan is None
 
     # Parallel test
     bdf = bd.from_pandas(df)
@@ -36,3 +38,5 @@ def test_from_pandas(datapath):
         bdf,
         df,
     )
+    assert not bdf._lazy
+    assert bdf._mgr._plan is None


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for running the plans in parallel and updates from_pandas and read_parquet to work in parallel. Added a flag to run the plan sequentially for debugging purposes.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.