### PR TITLE
Decorator for argument checking and fallback.

### DIFF
--- a/bodo/numba_compat.py
+++ b/bodo/numba_compat.py
@@ -6895,3 +6895,17 @@ if hasattr(numba.core.caching, "CacheImpl"):
     # list of CacheLocators it has and uses the first one that doesn't return None.
     # This allows for the caching of text-generation functions created through bodo_exec.
     numba.core.caching.CacheImpl._locator_classes.append(BodoCacheLocator)
+
+def get_method_overloads(typ):
+    """Returns a list of method names with overloads
+       for the given Numba datatype.
+    """
+    from numba.core.registry import cpu_target
+    ctx = cpu_target._toplevel_typing_context
+    # Make sure the templates are present.
+    ctx.refresh()
+    # Get the templates for the given datatype.
+    attr_templates = ctx._attributes[typ]
+    # Not all templates are for method so filter for
+    # methods by presence of _attr attribute.
+    return [x._attr for x in attr_templates if hasattr(x, "_attr")]

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Iterable
 
 import pandas as pd
 import pyarrow as pa
+from pandas._typing import AnyArrayLike, IndexLabel, MergeHow, MergeValidate, Suffixes
 
 import bodo
 from bodo.ext import plan_optimizer
@@ -11,7 +12,7 @@ from bodo.pandas.lazy_metadata import LazyMetadata
 from bodo.pandas.lazy_wrapper import BodoLazyWrapper
 from bodo.pandas.managers import LazyBlockManager, LazyMetadataMixin
 from bodo.pandas.series import BodoSeries
-from bodo.pandas.utils import get_lazy_manager_class
+from bodo.pandas.utils import check_args_fallback, get_lazy_manager_class
 from bodo.utils.typing import (
     BodoError,
     check_unsupported_args,
@@ -400,64 +401,22 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             func, [], self, *args, **kwargs
         )
 
+    @check_args_fallback(["on"], supported=True)
     def merge(
         self,
-        right,  # BodoDataFrame | BodoSeries,
-        how="inner",  # MergeHow = "inner",
-        on=None,  # IndexLabel | AnyArrayLike | None = None,
-        left_on=None,  # IndexLabel | AnyArrayLike | None = None,
-        right_on=None,  # IndexLabel | AnyArrayLike | None = None,
-        left_index=False,  # bool = False,
-        right_index=False,  # bool = False,
-        sort=False,  # bool = False,
-        suffixes=("_x", "_y"),  # Suffixes = ("_x", "_y"),
-        copy=None,  # bool | None = None,
-        indicator=False,  # str | bool = False,
-        validate=None,  # MergeValidate | None = None,
+        right: "BodoDataFrame | BodoSeries",
+        how: MergeHow = "inner",
+        on: IndexLabel | AnyArrayLike | None = None,
+        left_on: IndexLabel | AnyArrayLike | None = None,
+        right_on: IndexLabel | AnyArrayLike | None = None,
+        left_index: bool = False,
+        right_index: bool = False,
+        sort: bool = False,
+        suffixes: Suffixes = ("_x", "_y"),
+        copy: bool | None = None,
+        indicator: str | bool = False,
+        validate: MergeValidate | None = None,
     ):  # -> BodoDataFrame:
-        if not bodo.dataframe_library_enabled:
-            return super().merge(
-                right,
-                how=how,
-                on=on,
-                left_on=left_on,
-                right_on=right_on,
-                left_index=left_index,
-                right_index=right_index,
-                sort=sort,
-                suffixes=suffixes,
-                copy=copy,
-                indicator=indicator,
-                validate=validate,
-            )
-
-        from bodo.pandas import BODO_PANDAS_FALLBACK
-
-        if (
-            isinstance(right, BodoSeries)
-            or how != "inner"
-            or indicator != False
-            or validate != None
-        ):
-            if BODO_PANDAS_FALLBACK != 0:
-                return pd.merge(
-                    self,
-                    right,
-                    how=how,
-                    on=on,
-                    left_on=left_on,
-                    right_on=right_on,
-                    left_index=left_index,
-                    right_index=right_index,
-                    sort=sort,
-                    suffixes=suffixes,
-                    copy=copy,
-                    indicator=indicator,
-                    validate=validate,
-                )
-            else:
-                assert False and "Unsupported option to DataFrame.merge"
-
         from bodo.pandas.base import _empty_like
 
         zero_size_self = _empty_like(self)
@@ -499,16 +458,13 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
 
         return plan_optimizer.wrap_plan(new_metadata, planComparisonJoin)
 
+    @check_args_fallback("all")
     def __getitem__(self, key):
         """Called when df[key] is used."""
-        if not bodo.dataframe_library_enabled:
-            return super().__getitem__(key)
-
         from bodo.pandas.base import _empty_like
 
         """ Create 0 length versions of the dataframe and the key and
             simulate the operation to see the resulting type. """
-
         zero_size_self = _empty_like(self)
         if isinstance(key, BodoSeries):
             """ This is a masking operation. """

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -3,13 +3,12 @@ from collections.abc import Callable, Hashable
 
 import pandas as pd
 
-import bodo
 from bodo.ext import plan_optimizer
 from bodo.pandas.array_manager import LazySingleArrayManager
 from bodo.pandas.lazy_metadata import LazyMetadata
 from bodo.pandas.lazy_wrapper import BodoLazyWrapper
 from bodo.pandas.managers import LazyMetadataMixin, LazySingleBlockManager
-from bodo.pandas.utils import get_lazy_single_manager_class
+from bodo.pandas.utils import check_args_fallback, get_lazy_single_manager_class
 
 
 class BodoSeries(pd.Series, BodoLazyWrapper):
@@ -32,13 +31,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             "Plan not available for this manager, recreate this series with from_pandas"
         )
 
+    @check_args_fallback("all")
     def _cmp_method(self, other, op):
         """Called when a BodoSeries is compared with a different entity (other)
         with the given operator "op".
         """
-        if not bodo.dataframe_library_enabled:
-            return super()._cmp_method(other, op)
-
         from bodo.pandas.base import _empty_like
 
         # Get empty Pandas objects for self and other with same schema.
@@ -57,8 +54,6 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 plan_optimizer.LogicalBinaryOp, self._plan, other, op
             ),
         )
-
-        return super()._cmp_method(other, op)
 
     @staticmethod
     def from_lazy_mgr(


### PR DESCRIPTION
## Changes included in this PR

Created a decorator for dataframe and series functions that does argument checking and fallback as required and consistent with env variable options.  You can say all or none of the parameters with default values are supported or you can specify a list of supported or unsupported functions with default values.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.