### PR TITLE
[BSE-4679] Get Parquet dataset without row count.

### DIFF
--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -247,6 +247,7 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
             data = execute_plan(self._plan)
             self._plan = None
             self.arrays = data._mgr.arrays
+            self._axes = data._mgr._axes
             self._md_result_id = None
             self._md_nrows = None
             self._md_head = None
@@ -457,6 +458,7 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             data = execute_plan(self._plan)
             self._plan = None
             self.arrays = data._mgr.arrays
+            self._axes = data._mgr._axes
             self._md_result_id = None
             self._md_nrows = None
             self._md_head = None

--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -247,6 +247,7 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
             data = execute_plan(self._plan)
             self._plan = None
             self.arrays = data._mgr.arrays
+            # Update index here since the plan created a dummy index
             self._axes = data._mgr._axes
             self._md_result_id = None
             self._md_nrows = None
@@ -458,6 +459,7 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             data = execute_plan(self._plan)
             self._plan = None
             self.arrays = data._mgr.arrays
+            # Update index here since the plan created a dummy index
             self._axes = data._mgr._axes
             self._md_result_id = None
             self._md_nrows = None

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -80,16 +80,15 @@ def read_parquet(
 
     # Read Parquet schema and row count
     # TODO: Make this more robust (e.g. handle Index, etc.)
-    use_hive = True
+    use_hive = kwargs.get("_bodo_use_hive", True)
     pq_dataset = get_parquet_dataset(
         path,
-        get_row_counts=True,
+        get_row_counts=False,
         storage_options=storage_options,
         read_categories=True,
         partitioning="hive" if use_hive else None,
     )
     arrow_schema = pq_dataset.schema
-    nrows = pq_dataset._bodo_total_rows
 
     empty_df = pa.Table.from_pydict(
         {k: [] for k in arrow_schema.names}, schema=arrow_schema
@@ -97,7 +96,7 @@ def read_parquet(
     empty_df.index = pd.RangeIndex(0)
 
     plan = LazyPlan("LogicalGetParquetRead", path.encode(), arrow_schema)
-    return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=nrows)
+    return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=None)
 
 
 def merge(lhs, rhs, *args, **kwargs):

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -80,7 +80,7 @@ def read_parquet(
 
     # Read Parquet schema and row count
     # TODO: Make this more robust (e.g. handle Index, etc.)
-    use_hive = kwargs.get("_bodo_use_hive", True)
+    use_hive = True
     pq_dataset = get_parquet_dataset(
         path,
         get_row_counts=False,

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -53,7 +53,7 @@ def read_parquet(
 
     from bodo.io.parquet_pio import get_parquet_dataset
 
-    # Read Parquet schema and row count
+    # Read Parquet schema
     # TODO: Make this more robust (e.g. handle Index, etc.)
     use_hive = True
     pq_dataset = get_parquet_dataset(
@@ -71,7 +71,7 @@ def read_parquet(
     empty_df.index = pd.RangeIndex(0)
 
     plan = LazyPlan("LogicalGetParquetRead", path.encode(), arrow_schema)
-    return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=None)
+    return plan_optimizer.wrap_plan(empty_df, plan=plan)
 
 
 def merge(lhs, rhs, *args, **kwargs):

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -94,6 +94,10 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         self._mgr._md_result_id = lazy_metadata.result_id
         self._mgr._md_head = lazy_metadata.head._mgr
 
+    def is_lazy_plan(self):
+        """Returns whether the BodoDataFrame is represented by a plan."""
+        return getattr(self._mgr, "_plan", None) is not None
+
     def head(self, n: int = 5):
         """
         Return the first n rows. If head_df is available and larger than n, then use it directly.
@@ -104,6 +108,17 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         else:
             # If head_df is available and larger than n, then use it directly.
             return self._head_df.head(n)
+
+    def __len__(self):
+        if self.is_lazy_plan():
+            self._mgr._collect()
+        return super().__len__()
+
+    @property
+    def shape(self):
+        if self.is_lazy_plan():
+            self._mgr._collect()
+        return super().shape
 
     def to_parquet(
         self,

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -210,6 +210,7 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             data = execute_plan(self._plan)
             self._plan = None
             self.blocks = data._mgr.blocks
+            self.axes = data._mgr.axes
             self._md_result_id = None
             self._md_nrows = None
             self._md_head = None
@@ -431,6 +432,7 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
             data = execute_plan(self._plan)
             self._plan = None
             self.blocks = data._mgr.blocks
+            self.axes = data._mgr.axes
             self._md_result_id = None
             self._md_nrows = None
             self._md_head = None

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -210,6 +210,7 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             data = execute_plan(self._plan)
             self._plan = None
             self.blocks = data._mgr.blocks
+            # Update index here since the plan created a dummy index
             self.axes = data._mgr.axes
             self._md_result_id = None
             self._md_nrows = None
@@ -432,6 +433,7 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
             data = execute_plan(self._plan)
             self._plan = None
             self.blocks = data._mgr.blocks
+            # Update index here since the plan created a dummy index
             self.axes = data._mgr.axes
             self._md_result_id = None
             self._md_nrows = None

--- a/bodo/tests/test_df_lib/test_read_parquet.py
+++ b/bodo/tests/test_df_lib/test_read_parquet.py
@@ -24,10 +24,10 @@ def test_read_parquet_len_shape(datapath):
     bodo_out = bd.read_parquet(path)
     py_out = pd.read_parquet(path)
 
-    len(bodo_out) == py_out
+    assert len(bodo_out) == len(py_out)
 
     # create a new lazy DF
     bodo_out2 = bd.read_parquet(path)
 
     # test shape
-    bodo_out2.shape == py_out.shape
+    assert bodo_out2.shape == py_out.shape

--- a/bodo/tests/test_df_lib/test_read_parquet.py
+++ b/bodo/tests/test_df_lib/test_read_parquet.py
@@ -11,9 +11,6 @@ def test_read_parquet(datapath):
     bodo_out = bd.read_parquet(path)
     py_out = pd.read_parquet(path)
 
-    # Evaluate LazyDataFrame to get correct shape
-    bodo_out._mgr._collect()
-
     _test_equal(
         bodo_out,
         py_out,

--- a/bodo/tests/test_df_lib/test_read_parquet.py
+++ b/bodo/tests/test_df_lib/test_read_parquet.py
@@ -11,6 +11,8 @@ def test_read_parquet(datapath):
     bodo_out = bd.read_parquet(path)
     py_out = pd.read_parquet(path)
 
+    print(bodo_out)
+
     _test_equal(
         bodo_out,
         py_out,

--- a/bodo/tests/test_df_lib/test_read_parquet.py
+++ b/bodo/tests/test_df_lib/test_read_parquet.py
@@ -15,3 +15,19 @@ def test_read_parquet(datapath):
         bodo_out,
         py_out,
     )
+
+
+def test_read_parquet_len_shape(datapath):
+    """Test length after read parquet is correct"""
+    path = datapath("example.parquet")
+
+    bodo_out = bd.read_parquet(path)
+    py_out = pd.read_parquet(path)
+
+    len(bodo_out) == py_out
+
+    # create a new lazy DF
+    bodo_out2 = bd.read_parquet(path)
+
+    # test shape
+    bodo_out2.shape == py_out.shape

--- a/bodo/tests/test_df_lib/test_read_parquet.py
+++ b/bodo/tests/test_df_lib/test_read_parquet.py
@@ -18,7 +18,7 @@ def test_read_parquet(datapath):
 
 
 def test_read_parquet_len_shape(datapath):
-    """Test length after read parquet is correct"""
+    """Test length/shape after read parquet is correct"""
     path = datapath("example.parquet")
 
     bodo_out = bd.read_parquet(path)

--- a/bodo/tests/test_df_lib/test_read_parquet.py
+++ b/bodo/tests/test_df_lib/test_read_parquet.py
@@ -11,7 +11,8 @@ def test_read_parquet(datapath):
     bodo_out = bd.read_parquet(path)
     py_out = pd.read_parquet(path)
 
-    print(bodo_out)
+    # Evaluate LazyDataFrame to get correct shape
+    bodo_out._mgr._collect()
 
     _test_equal(
         bodo_out,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Removes getting nrows eagerly. Note that this will give incorrect `shape` and `len` when called before the plan is executed. (The columns will be correct but length is 1), this impacts our testing because we will have to make sure we call `_collect` before using any of the `pd.testing` functionality since they check the shape first.

## Testing strategy
`pytest -svW ignore bodo/tests/test_df_lib`
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.