### PR TITLE
[WIP] Avoid collecting lazy plan immediately after executing

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -43,6 +43,12 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             "Plan not available for this manager, recreate this dataframe with from_pandas"
         )
 
+    @property
+    def index(self):
+        if self.is_lazy_plan():
+            self._mgr._collect()
+        return super().index
+
     @staticmethod
     def from_lazy_mgr(
         lazy_mgr: LazyArrayManager | LazyBlockManager,
@@ -80,6 +86,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             plan=plan,
         )
         return cls.from_lazy_mgr(lazy_mgr, lazy_metadata.head)
+
+    def is_lazy_plan(self):
+        return getattr(self._mgr, "_plan", None) is not None
 
     def update_from_lazy_metadata(self, lazy_metadata: LazyMetadata):
         """

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -209,12 +209,15 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             )
             data = execute_plan(self._plan)
             self._plan = None
-            self.blocks = data._mgr.blocks
             self.axes = data._mgr.axes
-            self._md_result_id = None
-            self._md_nrows = None
-            self._md_head = None
-            BlockManager._rebuild_blknos_and_blklocs(self)
+            self._md_result_id = data._mgr._md_result_id
+            self._md_nrows = data._mgr._md_nrows
+            self._md_head = data._mgr._md_head
+            self._collect_func = data._mgr._collect_func
+            self._del_func = data._mgr._del_func
+
+            # avoid deleting function after it is collected
+            data._mgr._del_func = None
 
         if self._md_result_id is not None:
             debug_msg(self.logger, "[LazyBlockManager] Collecting data from workers...")

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -219,7 +219,7 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             # avoid deleting function after it is collected
             data._mgr._del_func = None
 
-        if self._md_result_id is not None:
+        elif self._md_result_id is not None:
             debug_msg(self.logger, "[LazyBlockManager] Collecting data from workers...")
             assert self._md_nrows is not None
             assert self._md_head is not None

--- a/bodo/tests/test_df_lib/test_read_parquet.py
+++ b/bodo/tests/test_df_lib/test_read_parquet.py
@@ -11,10 +11,24 @@ def test_read_parquet(datapath):
     bodo_out = bd.read_parquet(path)
     py_out = pd.read_parquet(path)
 
-    # Evaluate LazyDataFrame to get correct shape
-    bodo_out._mgr._collect()
-
     _test_equal(
         bodo_out,
         py_out,
     )
+
+
+def test_read_parquet_md(datapath):
+    """Test to ensure we can access Metadata after executing plan while keeping
+    result distributed across workers.
+    """
+    path = datapath("example.parquet")
+
+    bodo_out = bd.read_parquet(path)
+    py_out = pd.read_parquet(path)
+
+    assert len(bodo_out) == len(py_out)
+    assert bodo_out.shape == py_out.shape
+
+    bodo_out.head()
+
+    assert bodo_out._lazy


### PR DESCRIPTION
## Changes included in this PR

When executing a plan, try to keep results distributed across nodes. Also adds workaround for getting length from lazy dataframes generated with plan by first executing and returning metadata. 

It ended up being a little messier than I thought, the main issue is that our `_collect`behaves differently when called with a plan vs a regular Lazy DataFrame. When executing a plan without collecting, we would probably want to just return a new `BodoDataFrame`. 

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.