### PR TITLE
BSE-4705: Support passing BodoDataFrame with plan to jit

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -28,13 +28,14 @@ def from_pandas(df):
     n_rows = len(df)
     arrow_schema = pa.Schema.from_pandas(df)
 
+    res_id = None
     if bodo.dataframe_library_run_parallel:
         res_id = bodo.spawn.utils.scatter_data(df)
         plan = LazyPlan("LogicalGetPandasReadParallel", res_id, arrow_schema)
     else:
         plan = LazyPlan("LogicalGetPandasReadSeq", df, arrow_schema)
 
-    return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=n_rows)
+    return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=n_rows, res_id=res_id)
 
 
 @check_args_fallback("all")

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -449,7 +449,7 @@ def _del_func(x):
     # Intentionally do nothing
     pass
 
-cpdef wrap_plan(schema, plan, nrows=None, index_data=None):
+cpdef wrap_plan(schema, plan, res_id=None, nrows=None, index_data=None):
     """ Create a BodoDataFrame or BodoSeries with the given
         schema and given plan node.
     """
@@ -474,11 +474,11 @@ cpdef wrap_plan(schema, plan, nrows=None, index_data=None):
     if isinstance(schema, (dict, pd.DataFrame)):
         if isinstance(schema, dict):
             schema = pd.DataFrame(schema)
-        metadata = LazyMetadata("LazyPlan_" + str(plan.plan_class), schema, nrows=nrows, index_data=index_data)
+        metadata = LazyMetadata("LazyPlan_" + str(plan.plan_class) if res_id is None else res_id, schema, nrows=nrows, index_data=index_data)
         mgr = get_lazy_manager_class()
         new_df = BodoDataFrame.from_lazy_metadata(metadata, collect_func=mgr._collect, del_func=_del_func, plan=plan)
     elif isinstance(schema, pd.Series):
-        metadata = LazyMetadata("LazyPlan_" + str(plan.plan_class), schema, nrows=nrows, index_data=index_data)
+        metadata = LazyMetadata("LazyPlan_" + str(plan.plan_class) if res_id is None else res_id, schema, nrows=nrows, index_data=index_data)
         mgr = get_lazy_single_manager_class()
         new_df = BodoSeries.from_lazy_metadata(metadata, collect_func=mgr._collect, del_func=_del_func, plan=plan)
     else:

--- a/bodo/tests/test_df_lib/test_jit_interop.py
+++ b/bodo/tests/test_df_lib/test_jit_interop.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+import bodo
+import bodo.pandas as bd
+from bodo.tests.utils import _test_equal, pytest_mark_spawn_mode
+
+
+def test_bodo_df_to_jit():
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "c": ["a", "b", "c"],
+        }
+    )
+    bdf = bd.from_pandas(df)
+
+    @bodo.jit()
+    def f(df):
+        return df
+
+    _test_equal(f(bdf), df)
+
+
+@pytest_mark_spawn_mode
+def test_bodo_df_to_jit_spawn():
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "c": ["a", "b", "c"],
+        }
+    )
+    bdf = bd.from_pandas(df)
+
+    @bodo.jit(spawn=True)
+    def f(df):
+        return df
+
+    _test_equal(f(bdf), df)

--- a/bodo/tests/test_df_lib/test_jit_interop.py
+++ b/bodo/tests/test_df_lib/test_jit_interop.py
@@ -15,7 +15,7 @@ def test_bodo_df_to_jit():
     )
     bdf = bd.from_pandas(df)
 
-    @bodo.jit()
+    @bodo.jit(spawn=False)
     def f(df):
         return df
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Uses the correct result id when creating a lazy metadata object if we have one.

## Testing strategy
Added tests and ran them locally
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
As title
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.