### PR TITLE
Fix plan execution result type when it should be a series.

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -1,10 +1,13 @@
 import pandas as pd
 from pandas._libs import lib
 
-from bodo.ext import plan_optimizer
 from bodo.pandas.frame import BodoDataFrame
 from bodo.pandas.series import BodoSeries
-from bodo.pandas.utils import LazyPlan, check_args_fallback
+from bodo.pandas.utils import (
+    LazyPlan,
+    check_args_fallback,
+    wrap_plan,
+)
 
 
 def from_pandas(df):
@@ -35,7 +38,7 @@ def from_pandas(df):
     else:
         plan = LazyPlan("LogicalGetPandasReadSeq", df, arrow_schema)
 
-    return plan_optimizer.wrap_plan(empty_df, plan=plan, nrows=n_rows, res_id=res_id)
+    return wrap_plan(empty_df, plan=plan, nrows=n_rows, res_id=res_id)
 
 
 @check_args_fallback("all")
@@ -72,7 +75,7 @@ def read_parquet(
     empty_df.index = pd.RangeIndex(0)
 
     plan = LazyPlan("LogicalGetParquetRead", path.encode(), arrow_schema)
-    return plan_optimizer.wrap_plan(empty_df, plan=plan)
+    return wrap_plan(empty_df, plan=plan)
 
 
 def merge(lhs, rhs, *args, **kwargs):

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -16,6 +16,7 @@ from bodo.pandas.utils import (
     LazyPlan,
     check_args_fallback,
     get_lazy_manager_class,
+    wrap_plan,
 )
 from bodo.utils.typing import (
     BodoError,
@@ -475,7 +476,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             ],
         )
 
-        return plan_optimizer.wrap_plan(new_metadata, planComparisonJoin)
+        return wrap_plan(new_metadata, planComparisonJoin)
 
     @check_args_fallback("all")
     def __getitem__(self, key):
@@ -494,7 +495,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             )
             zero_size_key = _empty_like(key)
             new_metadata = zero_size_self.__getitem__(zero_size_key)
-            return plan_optimizer.wrap_plan(
+            return wrap_plan(
                 new_metadata,
                 plan=LazyPlan("LogicalFilter", self._plan, key_plan),
             )
@@ -516,7 +517,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                     complain. """
                 key = key[0]
                 new_metadata = zero_size_self.__getitem__(key)
-                return plan_optimizer.wrap_plan(
+                return wrap_plan(
                     new_metadata,
                     plan=LazyPlan(
                         "LogicalProjection",
@@ -527,7 +528,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 )
             else:
                 new_metadata = zero_size_self.__getitem__(key)
-                return plan_optimizer.wrap_plan(
+                return wrap_plan(
                     new_metadata,
                     plan=LazyPlan(
                         "LogicalProjection",

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -449,7 +449,7 @@ cpdef py_optimize_plan(object plan):
     optimized_plan.c_logical_operator = optimize_plan(move(wrapped_operator.c_logical_operator))
     return optimized_plan
 
-cpdef py_execute_plan(object plan, bint dataframe_output):
+cpdef py_execute_plan(object plan, output_func):
     """Execute a logical plan in the C++ backend
     """
     cdef LogicalOperator wrapped_operator
@@ -464,10 +464,5 @@ cpdef py_execute_plan(object plan, bint dataframe_output):
     exec_output = execute_plan(move(wrapped_operator.c_logical_operator))
     cpp_table = exec_output.first
     arrow_schema = <object>exec_output.second
-    assert dataframe_output is not None
-    if dataframe_output:
-        from bodo.pandas.utils import cpp_table_to_df
-        return cpp_table_to_df(cpp_table, arrow_schema)
-    else:
-        from bodo.pandas.utils import cpp_table_to_series
-        return cpp_table_to_series(cpp_table, arrow_schema)
+    assert output_func is not None
+    return output_func(cpp_table, arrow_schema)

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -449,54 +449,9 @@ cpdef py_optimize_plan(object plan):
     optimized_plan.c_logical_operator = optimize_plan(move(wrapped_operator.c_logical_operator))
     return optimized_plan
 
-def _del_func(x):
-    # Intentionally do nothing
-    pass
-
-cpdef wrap_plan(schema, plan, res_id=None, nrows=None, index_data=None):
-    """ Create a BodoDataFrame or BodoSeries with the given
-        schema and given plan node.
-    """
-    import pandas as pd
-    from bodo.pandas.utils import LazyPlan
-    from bodo.pandas.frame import BodoDataFrame
-    from bodo.pandas.series import BodoSeries
-    from bodo.pandas.lazy_metadata import LazyMetadata
-    from bodo.pandas.utils import get_lazy_manager_class, get_lazy_single_manager_class
-
-    assert isinstance(plan, LazyPlan), "wrap_plan: LazyPlan expected"
-
-    if isinstance(schema, dict):
-        schema = {
-            col: pd.Series(dtype=col_type.dtype) for col, col_type in schema.items()
-        }
-
-    if nrows is None:
-        # Fake non-zero rows.  nrows should be overwritten upon plan execution.
-        nrows = 1
-
-    if isinstance(schema, (dict, pd.DataFrame)):
-        if isinstance(schema, dict):
-            schema = pd.DataFrame(schema)
-        metadata = LazyMetadata("LazyPlan_" + str(plan.plan_class) if res_id is None else res_id, schema, nrows=nrows, index_data=index_data)
-        mgr = get_lazy_manager_class()
-        new_df = BodoDataFrame.from_lazy_metadata(metadata, collect_func=mgr._collect, del_func=_del_func, plan=plan)
-    elif isinstance(schema, pd.Series):
-        metadata = LazyMetadata("LazyPlan_" + str(plan.plan_class) if res_id is None else res_id, schema, nrows=nrows, index_data=index_data)
-        mgr = get_lazy_single_manager_class()
-        new_df = BodoSeries.from_lazy_metadata(metadata, collect_func=mgr._collect, del_func=_del_func, plan=plan)
-    else:
-        assert False
-
-    new_df.plan = plan
-    return new_df
-
-
-cpdef py_execute_plan(object plan):
+cpdef py_execute_plan(object plan, bint dataframe_output):
     """Execute a logical plan in the C++ backend
     """
-    from bodo.pandas.utils import cpp_table_to_df
-
     cdef LogicalOperator wrapped_operator
     cdef pair[int64_t, PyObjectPtr] exec_output
     cdef int64_t cpp_table
@@ -509,5 +464,10 @@ cpdef py_execute_plan(object plan):
     exec_output = execute_plan(move(wrapped_operator.c_logical_operator))
     cpp_table = exec_output.first
     arrow_schema = <object>exec_output.second
-
-    return cpp_table_to_df(cpp_table, arrow_schema)
+    assert dataframe_output is not None
+    if dataframe_output:
+        from bodo.pandas.utils import cpp_table_to_df
+        return cpp_table_to_df(cpp_table, arrow_schema)
+    else:
+        from bodo.pandas.utils import cpp_table_to_series
+        return cpp_table_to_series(cpp_table, arrow_schema)

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -12,6 +12,7 @@ from bodo.pandas.utils import (
     LazyPlan,
     check_args_fallback,
     get_lazy_single_manager_class,
+    wrap_plan,
 )
 
 
@@ -52,7 +53,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Compute schema of new series.
         new_metadata = zero_size_self._cmp_method(zero_size_other, op)
         assert isinstance(new_metadata, pd.Series)
-        return plan_optimizer.wrap_plan(
+        return wrap_plan(
             new_metadata,
             plan=LazyPlan("LogicalBinaryOp", self._plan, other, op),
         )

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -100,6 +100,14 @@ def cpp_table_to_df(cpp_table, arrow_schema):
     return out_df
 
 
+def cpp_table_to_series(cpp_table, arrow_schema):
+    """Convert a C++ table (table_info) to a pandas Series."""
+
+    as_df = cpp_table_to_df(cpp_table, arrow_schema)
+    assert len(arrow_schema) == 1
+    return as_df[arrow_schema[0].name]
+
+
 @functools.lru_cache
 def get_dataframe_overloads():
     """Return a list of the functions supported on BodoDataFrame objects
@@ -311,6 +319,7 @@ class LazyPlan:
         self.plan_class = plan_class
         self.args = args
         self.kwargs = kwargs
+        self.dataframe_output = None  # filled in by wrap_plan
 
     def generate_duckdb(self, cache=None):
         from bodo.ext import plan_optimizer
@@ -365,7 +374,7 @@ def execute_plan(plan: LazyPlan):
             post_optimize_graphviz = optimized_plan.toGraphviz()
             with open("post_optimize" + str(id(plan)) + ".dot", "w") as f:
                 print(post_optimize_graphviz, file=f)
-        return plan_optimizer.py_execute_plan(optimized_plan)
+        return plan_optimizer.py_execute_plan(optimized_plan, plan.dataframe_output)
 
     if bodo.dataframe_library_run_parallel:
         import bodo.spawn.spawner
@@ -373,3 +382,67 @@ def execute_plan(plan: LazyPlan):
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
     return _exec_plan(plan)
+
+
+def _del_func(x):
+    # Intentionally do nothing
+    pass
+
+
+def wrap_plan(schema, plan, res_id=None, nrows=None, index_data=None):
+    """Create a BodoDataFrame or BodoSeries with the given
+    schema and given plan node.
+    """
+    import pandas as pd
+
+    from bodo.pandas.frame import BodoDataFrame
+    from bodo.pandas.lazy_metadata import LazyMetadata
+    from bodo.pandas.series import BodoSeries
+    from bodo.pandas.utils import (
+        LazyPlan,
+        get_lazy_manager_class,
+        get_lazy_single_manager_class,
+    )
+
+    assert isinstance(plan, LazyPlan), "wrap_plan: LazyPlan expected"
+
+    if isinstance(schema, dict):
+        schema = {
+            col: pd.Series(dtype=col_type.dtype) for col, col_type in schema.items()
+        }
+
+    if nrows is None:
+        # Fake non-zero rows.  nrows should be overwritten upon plan execution.
+        nrows = 1
+
+    if isinstance(schema, (dict, pd.DataFrame)):
+        if isinstance(schema, dict):
+            schema = pd.DataFrame(schema)
+        metadata = LazyMetadata(
+            "LazyPlan_" + str(plan.plan_class) if res_id is None else res_id,
+            schema,
+            nrows=nrows,
+            index_data=index_data,
+        )
+        mgr = get_lazy_manager_class()
+        new_df = BodoDataFrame.from_lazy_metadata(
+            metadata, collect_func=mgr._collect, del_func=_del_func, plan=plan
+        )
+        plan.dataframe_output = True
+    elif isinstance(schema, pd.Series):
+        metadata = LazyMetadata(
+            "LazyPlan_" + str(plan.plan_class) if res_id is None else res_id,
+            schema,
+            nrows=nrows,
+            index_data=index_data,
+        )
+        mgr = get_lazy_single_manager_class()
+        new_df = BodoSeries.from_lazy_metadata(
+            metadata, collect_func=mgr._collect, del_func=_del_func, plan=plan
+        )
+        plan.dataframe_output = False
+    else:
+        assert False
+
+    new_df.plan = plan
+    return new_df


### PR DESCRIPTION
1) Move wrap_plan from plan_optimizer to utils.  No reason for it to be in Cython so easier debugging in Python.

2) Add dataframe or series flag to LazyPlan which is filled in my wrap_plan and passed to py_execute_plan which uses it to call cpp_table_to_series if the output is of series type. 3) add cpp_table_to_series which uses the existing cpp_table_to_df and then selects the singular column to get the series.

## Changes included in this PR

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.