### PR TITLE
Support projection pushdown for Parquet read

### DIFF
--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -126,7 +126,8 @@ std::pair<int64_t, PyObject*> PhysicalReadParquet::execute() {
 
     auto batch = internal_reader->read_all();
 
-    return {reinterpret_cast<int64_t>(new table_info(*batch)), pyarrow_schema};
+    return {reinterpret_cast<int64_t>(new table_info(*batch)),
+            selected_pyarrow_schema};
 }
 
 std::pair<int64_t, PyObject*> PhysicalReadPandas::execute() {

--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -32,9 +32,16 @@ std::shared_ptr<PhysicalOperator> Executor::processNode(
         case duckdb::LogicalOperatorType::LOGICAL_GET: {
             duckdb::LogicalGet& get_plan = plan->Cast<duckdb::LogicalGet>();
 
+            // Get selected columns from LogicalGet to pass to physical
+            // operators
+            std::vector<int> selected_columns;
+            for (auto& ci : get_plan.GetColumnIds()) {
+                selected_columns.push_back(ci.GetPrimaryIndex());
+            }
+
             std::shared_ptr<PhysicalOperator> physical_op =
                 get_plan.bind_data->Cast<BodoScanFunctionData>()
-                    .CreatePhysicalOperator();
+                    .CreatePhysicalOperator(selected_columns);
 
             this->pipelines.emplace_back(
                 std::vector<std::shared_ptr<PhysicalOperator>>({physical_op}));

--- a/bodo/pandas/_executor.h
+++ b/bodo/pandas/_executor.h
@@ -39,7 +39,8 @@ class PhysicalReadParquet : public PhysicalOperator {
    public:
     // TODO: Fill in the contents with info from the logical operator
     PhysicalReadParquet(std::string path, PyObject *pyarrow_schema,
-                        PyObject *storage_options)
+                        PyObject *storage_options,
+                        std::vector<int> &selected_columns)
         : pyarrow_schema(pyarrow_schema) {
         PyObject *py_path = PyUnicode_FromString(path.c_str());
 
@@ -47,18 +48,12 @@ class PhysicalReadParquet : public PhysicalOperator {
             unwrap_schema(pyarrow_schema);
 
         int num_fields = arrow_schema->num_fields();
-        std::vector<int> selected_fields(num_fields);
         // TODO: Arrow fields are always nullable?
         std::vector<bool> is_nullable(num_fields, true);
-        // Select all fields for now, TODO: get selected fields from Logical
-        // Node.
-        for (int i = 0; i < num_fields; i++) {
-            selected_fields[i] = i;
-        }
 
         internal_reader = new ParquetReader(
             py_path, true, Py_None, storage_options, pyarrow_schema, -1,
-            selected_fields, is_nullable, false, -1);
+            selected_columns, is_nullable, false, -1);
         internal_reader->init_pq_reader({}, nullptr, nullptr, 0);
     }
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -269,7 +269,7 @@ duckdb::unique_ptr<duckdb::LogicalGet> make_parquet_get_node(
     // Column ids need to be added separately.
     // DuckDB column id initialization example:
     // https://github.com/duckdb/duckdb/blob/d29a92f371179170688b4df394478f389bf7d1a6/src/catalog/catalog_entry/table_catalog_entry.cpp#L252
-    for (int i = 0; i < return_names.size(); i++) {
+    for (size_t i = 0; i < return_names.size(); i++) {
         out_get->AddColumnId(i);
     }
 

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -234,6 +234,16 @@ duckdb::unique_ptr<duckdb::LogicalProjection> make_projection(
     std::vector<int> &select_vec, PyObject *out_schema_py);
 
 /**
+ * @brief Get column indices that are pushed down from a projection node to its
+ * source. Used for testing.
+ *
+ * @param proj input projection node
+ * @return std::vector<int> pushed down column indices
+ */
+std::vector<int> get_projection_pushed_down_columns(
+    std::unique_ptr<duckdb::LogicalOperator> &proj);
+
+/**
  * @brief Creates a LogicalProjection node with a UDF inside.
  *
  * @param source input table plan

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -35,7 +35,8 @@ class BodoScanFunctionData : public duckdb::TableFunctionData {
      *
      * @return std::shared_ptr<PhysicalOperator> read operator
      */
-    virtual std::shared_ptr<PhysicalOperator> CreatePhysicalOperator() = 0;
+    virtual std::shared_ptr<PhysicalOperator> CreatePhysicalOperator(
+        std::vector<int> &selected_columns) = 0;
 };
 
 /**
@@ -65,9 +66,10 @@ class BodoParquetScanFunctionData : public BodoScanFunctionData {
         : path(path),
           pyarrow_schema(pyarrow_schema),
           storage_options(storage_options) {}
-    std::shared_ptr<PhysicalOperator> CreatePhysicalOperator() override {
-        return std::make_shared<PhysicalReadParquet>(path, pyarrow_schema,
-                                                     storage_options);
+    std::shared_ptr<PhysicalOperator> CreatePhysicalOperator(
+        std::vector<int> &selected_columns) override {
+        return std::make_shared<PhysicalReadParquet>(
+            path, pyarrow_schema, storage_options, selected_columns);
     }
     // Parquet dataset path
     std::string path;
@@ -101,7 +103,8 @@ class BodoDataFrameSeqScanFunctionData : public BodoScanFunctionData {
      *
      * @return std::shared_ptr<PhysicalOperator> dataframe read operator
      */
-    std::shared_ptr<PhysicalOperator> CreatePhysicalOperator() override {
+    std::shared_ptr<PhysicalOperator> CreatePhysicalOperator(
+        std::vector<int> &selected_columns) override {
         return std::make_shared<PhysicalReadPandas>(df);
     }
 
@@ -123,7 +126,8 @@ class BodoDataFrameParallelScanFunctionData : public BodoScanFunctionData {
      *
      * @return std::shared_ptr<PhysicalOperator> dataframe read operator
      */
-    std::shared_ptr<PhysicalOperator> CreatePhysicalOperator() override {
+    std::shared_ptr<PhysicalOperator> CreatePhysicalOperator(
+        std::vector<int> &selected_columns) override {
         // Read the dataframe from the result registry using
         // sys.modules["__main__"].RESULT_REGISTRY since importing
         // bodo.spawn.worker creates a new module with new empty registry.

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -259,6 +259,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_col_ref_expr(object field, int col_idx)
     cdef pair[int64_t, PyObjectPtr] execute_plan(unique_ptr[CLogicalOperator])
     cdef c_string plan_to_string(unique_ptr[CLogicalOperator])
+    cdef vector[int] get_projection_pushed_down_columns(unique_ptr[CLogicalOperator] proj)
 
 
 def join_type_to_string(CJoinType join_type):
@@ -338,6 +339,14 @@ cdef class LogicalProjection(LogicalOperator):
 
     def __str__(self):
         return f"LogicalProjection({self.select_vec}, {self.out_schema})"
+
+
+cpdef get_pushed_down_columns(proj):
+    """Get column indices that are pushed down from projection to its source node. Used for testing.
+    """
+    cdef LogicalOperator wrapped_operator = proj
+    cdef vector[int] pushed_down_columns = get_projection_pushed_down_columns(wrapped_operator.c_logical_operator)
+    return pushed_down_columns
 
 
 cdef class LogicalProjectionUDF(LogicalOperator):

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -60,6 +60,19 @@ def test_read_parquet(datapath):
     )
 
 
+def test_read_parquet_projection_pushdown(datapath):
+    """Make sure basic projection pushdown works for Parquet read end to end."""
+    path = datapath("example_no_index.parquet")
+
+    bodo_out = bd.read_parquet(path)[["three", "four"]]
+    py_out = pd.read_parquet(path)[["three", "four"]]
+
+    _test_equal(
+        bodo_out,
+        py_out,
+    )
+
+
 @pytest.mark.parametrize(
     "df",
     [


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for projection pushdown for Parquet read end to end.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.