### PR TITLE
Add support for parquet read date

### DIFF
--- a/bodo/libs/_bodo_common.cpp
+++ b/bodo/libs/_bodo_common.cpp
@@ -701,9 +701,8 @@ std::shared_ptr<Schema> Schema::FromArrowSchema(
     std::vector<std::unique_ptr<DataType>> column_types;
     for (const auto& field : schema->fields()) {
         // TODO: support dictionary-encoded arrays
-        auto bodo_type = arrow_to_bodo_type(field->type()->id());
-        column_types.push_back(std::make_unique<DataType>(
-            type_to_array_type(bodo_type), bodo_type));
+        auto bodo_type = arrow_type_to_bodo_data_type(field->type());
+        column_types.push_back(bodo_type->copy());
     }
     return std::make_shared<Schema>(std::move(column_types),
                                     schema->field_names());

--- a/bodo/libs/_bodo_common.cpp
+++ b/bodo/libs/_bodo_common.cpp
@@ -145,31 +145,6 @@ Bodo_CTypes::CTypeEnum arrow_to_bodo_type(arrow::Type::type type) {
     }
 }
 
-bodo_array_type::arr_type_enum type_to_array_type(Bodo_CTypes::CTypeEnum typ) {
-    // TODO: support other types
-    switch (typ) {
-        case Bodo_CTypes::STRUCT:
-            return bodo_array_type::STRUCT;
-        case Bodo_CTypes::LIST:
-            return bodo_array_type::ARRAY_ITEM;
-        case Bodo_CTypes::MAP:
-            return bodo_array_type::MAP;
-        case Bodo_CTypes::COMPLEX64:
-        case Bodo_CTypes::COMPLEX128:
-        case Bodo_CTypes::TIMESTAMPTZ:
-            throw std::runtime_error(
-                fmt::format("Unsupported type for array type conversion: {}",
-                            GetDtype_as_string(typ)));
-
-        case Bodo_CTypes::STRING:
-        case Bodo_CTypes::BINARY:
-            return bodo_array_type::STRING;
-
-        default:
-            return bodo_array_type::NULLABLE_INT_BOOL;
-    }
-}
-
 int32_t decimal_precision_to_integer_bytes(int32_t precision) {
     if (precision < 3) {
         return 1;

--- a/bodo/libs/_bodo_common.h
+++ b/bodo/libs/_bodo_common.h
@@ -532,14 +532,6 @@ struct bodo_array_type {
 };
 
 /**
- * @brief Get array type for a given Bodo_CTypes::CTypeEnum (assuming nullable)
- *
- * @param typ input Bodo_CTypes::CTypeEnum
- * @return bodo_array_type::arr_type_enum array type that can hold it
- */
-bodo_array_type::arr_type_enum type_to_array_type(Bodo_CTypes::CTypeEnum typ);
-
-/**
  * @brief Is typ a nested type (STRUCT, ARRAY_ITEM/LIST or MAP)?
  *
  */

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -379,24 +379,41 @@ std::pair<duckdb::string, duckdb::LogicalType> arrow_field_to_duckdb(
     // TODO: handle all types
     duckdb::LogicalType duckdb_type;
     const std::shared_ptr<arrow::DataType> &arrow_type = field->type();
-    if ((arrow_type->id() == arrow::Type::STRING) ||
-        (arrow_type->id() == arrow::Type::LARGE_STRING)) {
-        duckdb_type = duckdb::LogicalType::VARCHAR;
-    } else if (arrow_type->id() == arrow::Type::INT32) {
-        duckdb_type = duckdb::LogicalType::INTEGER;
-    } else if (arrow_type->id() == arrow::Type::INT64) {
-        duckdb_type = duckdb::LogicalType::BIGINT;
-    } else if (arrow_type->id() == arrow::Type::FLOAT) {
-        duckdb_type = duckdb::LogicalType::FLOAT;
-    } else if (arrow_type->id() == arrow::Type::DOUBLE) {
-        duckdb_type = duckdb::LogicalType::DOUBLE;
-    } else if (arrow_type->id() == arrow::Type::BOOL) {
-        duckdb_type = duckdb::LogicalType::BOOLEAN;
-    } else {
-        throw std::runtime_error(
-            "Unsupported Arrow type: " + arrow_type->ToString() +
-            ". Please extend the arrow_schema_to_duckdb function to handle "
-            "this type.");
+    switch (arrow_type->id()) {
+        case arrow::Type::STRING:
+        case arrow::Type::LARGE_STRING: {
+            duckdb_type = duckdb::LogicalType::VARCHAR;
+            break;
+        }
+        case arrow::Type::INT32: {
+            duckdb_type = duckdb::LogicalType::INTEGER;
+            break;
+        }
+        case arrow::Type::INT64: {
+            duckdb_type = duckdb::LogicalType::BIGINT;
+            break;
+        }
+        case arrow::Type::FLOAT: {
+            duckdb_type = duckdb::LogicalType::FLOAT;
+            break;
+        }
+        case arrow::Type::DOUBLE: {
+            duckdb_type = duckdb::LogicalType::DOUBLE;
+            break;
+        }
+        case arrow::Type::BOOL: {
+            duckdb_type = duckdb::LogicalType::BOOLEAN;
+            break;
+        }
+        case arrow::Type::DATE32: {
+            duckdb_type = duckdb::LogicalType::DATE;
+            break;
+        }
+        default:
+            throw std::runtime_error(
+                "Unsupported Arrow type: " + arrow_type->ToString() +
+                ". Please extend the arrow_schema_to_duckdb function to handle "
+                "this type.");
     }
     return {field->name(), duckdb_type};
 }

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -44,12 +44,11 @@ pytestmark = pytest.mark.parquet
 
 
 # ---------------------------- Test Different DataTypes ---------------------------- #
+@pytest.mark.df_lib
 @pytest.mark.parametrize(
     "fname",
     [
-        pytest.param(
-            "int_nulls_single.pq", id="int_single", marks=pytest.mark.df_lib
-        ),  # single piece
+        pytest.param("int_nulls_single.pq", id="int_single"),  # single piece
         pytest.param("int_nulls_multi.pq", id="int_multi"),  # multi piece
     ],
 )
@@ -69,10 +68,16 @@ def test_pq_nullable(fname, datapath, memory_leak_check):
         pytest.param("list_str_arr.pq", id="list_str_arr"),
         pytest.param("list_str_parts.pq", id="list_str_parts"),
         pytest.param("decimal1.pq", id="decimal"),
-        pytest.param("date32_1.pq", id="date32"),
-        pytest.param("small_strings.pq", id="processes_greater_than_string_rows"),
+        pytest.param("date32_1.pq", id="date32", marks=pytest.mark.df_lib),
+        pytest.param(
+            "small_strings.pq",
+            id="processes_greater_than_string_rows",
+            marks=pytest.mark.df_lib,
+        ),
         pytest.param("parquet_data_nonascii1.parquet", id="nonascii"),
-        pytest.param("nullable_float.pq", id="nullable_float"),
+        pytest.param(
+            "nullable_float.pq", id="nullable_float", marks=pytest.mark.df_lib
+        ),
     ],
 )
 def test_pq_read_types(fname, datapath, memory_leak_check):


### PR DESCRIPTION
## Changes included in this PR

Added support for read parquet with date column.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

Using Bodo check func override behavior to reuse tests. Tests passing locally, `test_apply` appears to be hanging on CI.

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.