### PR TITLE
Fix the Parquet read storage_options reference management

### DIFF
--- a/bodo/io/parquet_reader.cpp
+++ b/bodo/io/parquet_reader.cpp
@@ -206,7 +206,6 @@ void ParquetReader::init_pq_scanner() {
     Py_DECREF(pq_mod);
     Py_DECREF(this->expr_filters);
     Py_DECREF(selected_fields_py);
-    Py_DECREF(this->storage_options);
     Py_DECREF(this->filesystem);
     Py_DECREF(fnames_list_py);
     Py_DECREF(str_as_dict_cols_py);

--- a/bodo/io/parquet_reader.h
+++ b/bodo/io/parquet_reader.h
@@ -28,6 +28,7 @@ class ParquetReader : public ArrowReader {
         if (storage_options == Py_None) {
             throw std::runtime_error("ParquetReader: storage_options is None");
         }
+        Py_INCREF(storage_options);
     }
 
     /**
@@ -111,6 +112,7 @@ class ParquetReader : public ArrowReader {
     virtual ~ParquetReader() {
         // Remove after reader is finished or on error
         Py_XDECREF(this->reader);
+        Py_DECREF(this->storage_options);
     }
 
     /// a piece is a single parquet file in the context of parquet


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes a segfault in parquet read.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.