### PR TITLE
Support passing empty tuple as argument in spawn mode

### DIFF
--- a/bodo/pandas_compat.py
+++ b/bodo/pandas_compat.py
@@ -333,10 +333,6 @@ if pandas_version >= (3, 0):
             if len(args):
                 args_str = ", ".join(f"args[{i}]" for i in range(len(args)))
                 args_str += ","
-            else:
-                # Add dummy value for args for spawn mode compatibility.
-                # TODO: fix in spawn mode.
-                args = (0,)
 
             apply_func_text = "def bodo_apply_func(data, axis, args):\n"
             apply_func_text += f"  return data.apply(udf, axis=axis, args=({args_str}))"

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -15,14 +15,16 @@ from copy import deepcopy
 import cloudpickle
 import numba
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 from numba import typed
 from numba.core import types
+from pandas.core.arrays.arrow import ArrowExtensionArray
+from pandas.core.base import ExtensionArray
 
 import bodo
 import bodo.hiframes
 import bodo.hiframes.table
-import pandas as pd
 from bodo.mpi4py import MPI
 from bodo.pandas import LazyMetadata
 from bodo.spawn.spawner import BodoSQLContextMetadata, env_var_prefix
@@ -36,8 +38,6 @@ from bodo.spawn.utils import (
 from bodo.spawn.worker_state import set_is_worker
 from bodo.utils.typing import BodoWarning
 from bodo.utils.utils import is_distributable_typ
-from pandas.core.arrays.arrow import ArrowExtensionArray
-from pandas.core.base import ExtensionArray
 
 DISTRIBUTED_RETURN_HEAD_SIZE: int = 5
 

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -15,16 +15,14 @@ from copy import deepcopy
 import cloudpickle
 import numba
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 from numba import typed
 from numba.core import types
-from pandas.core.arrays.arrow import ArrowExtensionArray
-from pandas.core.base import ExtensionArray
 
 import bodo
 import bodo.hiframes
 import bodo.hiframes.table
+import pandas as pd
 from bodo.mpi4py import MPI
 from bodo.pandas import LazyMetadata
 from bodo.spawn.spawner import BodoSQLContextMetadata, env_var_prefix
@@ -38,6 +36,8 @@ from bodo.spawn.utils import (
 from bodo.spawn.worker_state import set_is_worker
 from bodo.utils.typing import BodoWarning
 from bodo.utils.utils import is_distributable_typ
+from pandas.core.arrays.arrow import ArrowExtensionArray
+from pandas.core.base import ExtensionArray
 
 DISTRIBUTED_RETURN_HEAD_SIZE: int = 5
 
@@ -96,6 +96,8 @@ def _recv_arg(
 
     # Handle distributed data nested inside tuples
     if isinstance(arg, tuple):
+        if len(arg) == 0:
+            return arg, ()
         args, args_meta = zip(*[_recv_arg(v, spawner_intercomm) for v in arg])
         return args, args_meta
 

--- a/bodo/tests/test_spawn/test_spawn_mode.py
+++ b/bodo/tests/test_spawn/test_spawn_mode.py
@@ -3,10 +3,10 @@ import subprocess
 import sys
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import bodo
-import pandas as pd
 from bodo.pandas.array_manager import LazyArrayManager
 from bodo.pandas.frame import BodoDataFrame
 from bodo.pandas.managers import LazyBlockManager

--- a/bodo/tests/test_spawn/test_spawn_mode.py
+++ b/bodo/tests/test_spawn/test_spawn_mode.py
@@ -3,10 +3,10 @@ import subprocess
 import sys
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import bodo
+import pandas as pd
 from bodo.pandas.array_manager import LazyArrayManager
 from bodo.pandas.frame import BodoDataFrame
 from bodo.pandas.managers import LazyBlockManager
@@ -297,6 +297,15 @@ def test_args_tuple_list_dict():
     arg = [df, df]
     _test_equal(impl(arg), arg)
     arg = {"k1": df, "k23": df}
+    _test_equal(impl(arg), arg)
+
+
+def test_args_empty_tuple():
+    @bodo.jit(spawn=True)
+    def impl(A):
+        return A
+
+    arg = ()
     _test_equal(impl(arg), arg)
 
 


### PR DESCRIPTION
## Changes included in this PR

As titled, direct follow up to: https://github.com/bodo-ai/Bodo/pull/410

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
New unit test added.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.