### PR TITLE
Support handling Pandas classes imported directly in the compiler

### DIFF
--- a/bodo/numba_compat.py
+++ b/bodo/numba_compat.py
@@ -6978,6 +6978,7 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
                 elif (hasattr(numpy.random, value)
                         and def_val == getattr(numpy.random, value)):
                     attrs += ['random', 'numpy']
+                # Bodo change: handle pandas
                 elif (pandas_toplevel and hasattr(pandas, value)
                         and def_val == getattr(pandas, value)):
                     attrs += ['pandas']
@@ -7016,3 +7017,7 @@ if _check_numba_change:  # pragma: no cover
 
 
 numba.core.ir_utils.find_callname = find_callname
+numba.core.inline_closurecall.find_callname = find_callname
+numba.parfors.array_analysis.find_callname = find_callname
+numba.parfors.parfor.find_callname = find_callname
+numba.stencils.stencilparfor.find_callname = find_callname

--- a/bodo/tests/test_dataframe_part2.py
+++ b/bodo/tests/test_dataframe_part2.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from numba.core.utils import PYVERSION
+from pandas import Series
 
 import bodo
 import bodo.tests.dataframe_common
@@ -605,6 +606,18 @@ def test_df_apply_name_homogeneous(memory_leak_check):
 
     def test_impl(df):
         return df.apply(lambda x: x.name, axis=1)
+
+    df = pd.DataFrame({"A": [1, 2, 3, 4, 1]})
+    check_func(test_impl, (df,))
+
+
+def test_df_apply_direct_import(memory_leak_check):
+    """
+    Check that Series class works if imported directly instead of pd.Series.
+    """
+
+    def test_impl(df):
+        return df.apply(lambda x: Series([1, 2, 3]), axis=1)
 
     df = pd.DataFrame({"A": [1, 2, 3, 4, 1]})
     check_func(test_impl, (df,))


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support in the compiler's function call matching for Series class imported directly from Pandas instead of `pd.Series`. Monkey-patches Numba's `find_callname` to handle Pandas in these cases similar to Numpy.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
`Series` now works inside JIT if imported directly.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.