### PR TITLE
Use Arrow for Datetime array boxing/unboxing

### DIFF
--- a/BodoSQL/bodosql/tests/test_conversions/test_snowflake_date_conversion_fns.py
+++ b/BodoSQL/bodosql/tests/test_conversions/test_snowflake_date_conversion_fns.py
@@ -6,6 +6,7 @@ import datetime
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 import bodo
@@ -874,6 +875,10 @@ def test_to_timestamp_format_str(
     """
     data, format_str, answer = to_timestamp_string_data_format_str
     query = f"SELECT {to_timestamp_fn}(t, '{format_str}') FROM table1"
+
+    # Set proper timezone for the answer if LTZ
+    if to_timestamp_fn in ("TO_TIMESTAMP_LTZ", "TRY_TO_TIMESTAMP_LTZ"):
+        answer = answer.astype(pd.ArrowDtype(pa.timestamp("ns", "UTC")))
 
     ctx = {"TABLE1": pd.DataFrame({"T": data})}
     expected_output = pd.DataFrame({0: answer})

--- a/bodo/io/helpers.py
+++ b/bodo/io/helpers.py
@@ -450,6 +450,8 @@ def _numba_to_pyarrow_type(
         # for timezone aware types, and for timezone
         # naive, it won't matter.
         tz = numba_type.tz if isinstance(numba_type, bodo.DatetimeArrayType) else None
+        if isinstance(tz, int):
+            tz = bodo.libs.pd_datetime_arr_ext.nanoseconds_to_offset(tz)
         dtype = pa.timestamp("us", "UTC") if is_iceberg else pa.timestamp("ns", tz)
 
     # TODO: Figure out how to raise an error here for Iceberg (is_iceberg is set to True).

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -1346,8 +1346,7 @@ def _test_equal(
         and not isinstance(bodo_out, pd.arrays.ArrowStringArray)
         and not isinstance(py_out, pd.arrays.ArrowExtensionArray)
     ):
-        py_out = _to_pa_array(py_out, bodo.typeof(bodo_out))
-        py_out = pd.Series(py_out)
+        py_out = _to_pa_array(py_out, bodo.typeof(bodo_out)).to_pandas()
         bodo_out = pd.Series(bodo_out)
         if sort_output:
             py_out = py_out.sort_values().reset_index(drop=True)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Avoids Pandas warnings for DatetimeArray constructor and segfaults in Pandas 3. Also, allows zero-copy boxing/unboxing through Arrow.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.