### PR TITLE
Support non-constant UDF args in df.apply()

### DIFF
--- a/bodo/tests/test_dataframe_part2.py
+++ b/bodo/tests/test_dataframe_part2.py
@@ -787,6 +787,12 @@ def test_df_apply_args(memory_leak_check):
     df = pd.DataFrame({"A": np.arange(n)})
     check_func(test_impl, (df, 3))
 
+    # Test passing args as non-constant tuple
+    def test_impl2(df, args, v):
+        return df.apply(lambda r, a, c: r.A == a + c, axis=1, args=args, c=v)
+
+    check_func(test_impl2, (df, (1,), 2))
+
 
 def test_df_apply_kws(memory_leak_check):
     """test passing extra keyword args to apply UDF"""

--- a/bodo/tests/test_series_part1.py
+++ b/bodo/tests/test_series_part1.py
@@ -2737,6 +2737,12 @@ def test_series_apply_extra_arg(memory_leak_check):
     S = pd.Series(["A", "C", "FF", "AA", "CC", "B", "DD", "ABC", "A"])
     check_func(test_impl, (S, d))
 
+    # Test with a non-constant argument
+    def test_impl2(S, D):
+        return S.apply(lambda a, d: a not in d, args=D)
+
+    check_func(test_impl2, (S, (d,)))
+
 
 @pytest.mark.slow
 def test_series_apply_kwargs(memory_leak_check):

--- a/bodo/transforms/series_pass.py
+++ b/bodo/transforms/series_pass.py
@@ -1472,6 +1472,8 @@ class SeriesPass:
             tuple(self.typemap[v.name] for v in rhs.args),
             {k: self.typemap[v.name] for k, v in dict(rhs.kws).items()},
         ):
+            assert rhs.vararg is None, "vararg not supported for inlining UDFs"
+            assert rhs.varkwarg is None, "varkwarg not supported for inlining UDFs"
             return replace_func(
                 self,
                 func_type.dispatcher.py_func,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for `args` argument of `apply` to be a non-constant tuple.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Non-constant args now supported.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.