### PR TITLE
Use PyIceberg for Iceberg read in tests

### DIFF
--- a/BodoSQL/bodosql/tests/test_types/test_table_path_iceberg.py
+++ b/BodoSQL/bodosql/tests/test_types/test_table_path_iceberg.py
@@ -15,7 +15,7 @@ from bodo.tests.conftest import (  # noqa: F401
     iceberg_database,
     iceberg_table_conn,
 )
-from bodo.tests.iceberg_database_helpers import spark_reader
+from bodo.tests.iceberg_database_helpers import pyiceberg_reader, spark_reader
 from bodo.tests.iceberg_database_helpers.utils import create_iceberg_table
 from bodo.tests.user_logging_utils import (
     check_logger_msg,
@@ -76,7 +76,7 @@ def test_simple_table_read(
         df = bc.sql("SELECT * FROM iceberg_tbl")
         return df
 
-    py_out = spark_reader.read_iceberg_table_single_rank(table_name, db_schema)
+    py_out = pyiceberg_reader.read_iceberg_table_single_rank(table_name, db_schema)
 
     if table_name == "SIMPLE_BOOL_BINARY_TABLE":
         # Bodo outputs binary data as bytes while Spark does bytearray (which Bodo doesn't support),

--- a/BodoSQL/bodosql/tests/test_window/test_rank_window_fns.py
+++ b/BodoSQL/bodosql/tests/test_window/test_rank_window_fns.py
@@ -83,9 +83,6 @@ def test_rank_fns(all_types_window_df, spark_info, order_clause, memory_leak_che
     first/last are parametrized so that each test can have total
     fusion into a single closure"""
     is_binary = isinstance(all_types_window_df["TABLE1"]["A"].iloc[0], bytes)
-    is_tz_aware = (
-        getattr(all_types_window_df["TABLE1"]["A"].dtype, "tz", None) is not None
-    )
     selects = []
     funcs = [
         "RANK()",
@@ -97,8 +94,7 @@ def test_rank_fns(all_types_window_df, spark_info, order_clause, memory_leak_che
         "ROW_NUMBER()",
     ]
     convert_columns_bytearray = ["A"] if is_binary else None
-    # Convert the spark input to tz-naive bc it can't handle timezones
-    convert_columns_tz_naive = ["A"] if is_tz_aware else None
+    convert_columns_tz_naive = None
     for i, func in enumerate(funcs):
         selects.append(f"{func} OVER (PARTITION BY W2 ORDER BY {order_clause}) AS C{i}")
     query = f"SELECT W2, A, {', '.join(selects)} FROM table1"

--- a/bodo/tests/iceberg_database_helpers/pyiceberg_reader.py
+++ b/bodo/tests/iceberg_database_helpers/pyiceberg_reader.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import pyarrow as pa
+from pyiceberg.catalog import WAREHOUSE_LOCATION
+
+from bodo.io.iceberg.catalog.dir import DirCatalog
+
+
+def read_iceberg_table(table_name: str, database_name: str) -> pd.DataFrame:
+    """Read an iceberg table from a given database path and return a Pandas DataFrame.
+    Converts datetime us unit to ns to match Bodo output.
+    """
+
+    # TODO: support other catalog types and properties
+    properties = {
+        WAREHOUSE_LOCATION: database_name,
+    }
+    catalog_name = database_name
+    catalog = DirCatalog(catalog_name, **properties)
+    table = catalog.load_table(table_name)
+    pa_table = table.scan().to_arrow()
+
+    # Convert datetime us unit to ns to match Bodo output
+    new_schema = pa_table.schema
+    for i, f in enumerate(pa_table.schema):
+        if isinstance(f.type, pa.TimestampType) and f.type.unit == "us":
+            new_schema = new_schema.remove(i)
+            new_schema = new_schema.insert(
+                i, pa.field(f.name, pa.timestamp("ns", tz=f.type.tz))
+            )
+
+    if new_schema != pa_table.schema:
+        pa_table = pa_table.cast(new_schema)
+
+    return pa_table.to_pandas()
+
+
+def read_iceberg_table_single_rank(table_name, database_name):
+    """Same as above but runs on a single rank and broadcasts the result."""
+    import bodo
+    from bodo.mpi4py import MPI
+
+    if bodo.get_rank() == 0:
+        py_out = read_iceberg_table(table_name, database_name)
+    else:
+        py_out = None
+
+    comm = MPI.COMM_WORLD
+    py_out = comm.bcast(py_out, root=0)
+    return py_out

--- a/bodo/tests/test_iceberg/test_read.py
+++ b/bodo/tests/test_iceberg/test_read.py
@@ -13,7 +13,7 @@ import bodo
 from bodo.io.arrow_reader import arrow_reader_del, read_arrow_next
 from bodo.io.iceberg.catalog import conn_str_to_catalog
 from bodo.mpi4py import MPI
-from bodo.tests.iceberg_database_helpers import spark_reader
+from bodo.tests.iceberg_database_helpers import pyiceberg_reader, spark_reader
 from bodo.tests.iceberg_database_helpers.utils import (
     create_iceberg_table,
     get_spark,
@@ -83,7 +83,7 @@ def test_simple_table_read(
         df = pd.read_sql_table(table_name, conn, db_schema)
         return df
 
-    py_out = spark_reader.read_iceberg_table_single_rank(table_name, db_schema)
+    py_out = pyiceberg_reader.read_iceberg_table_single_rank(table_name, db_schema)
     check_func(
         impl,
         (table_name, conn, db_schema),
@@ -119,7 +119,7 @@ def test_read_zero_cols(iceberg_database, iceberg_table_conn, table_name):
         df = pd.read_sql_table(table_name, conn, db_schema)
         return len(df)
 
-    py_out = spark_reader.read_iceberg_table_single_rank(table_name, db_schema)
+    py_out = pyiceberg_reader.read_iceberg_table_single_rank(table_name, db_schema)
     check_func(
         impl,
         (table_name, conn, db_schema),
@@ -162,7 +162,7 @@ def test_simple_tz_aware_table_read(
         df = pd.read_sql_table(table_name, conn, db_schema)
         return df
 
-    py_out = spark_reader.read_iceberg_table_single_rank(table_name, db_schema)
+    py_out = pyiceberg_reader.read_iceberg_table_single_rank(table_name, db_schema)
     check_func(
         impl,
         (table_name, conn, db_schema),


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes timezone-aware Iceberg read tests by replacing Spark with PyIceberg as baseline. Spark drops the timezone which causes issues in tests. This is exposed by the recent change to use Arrow for datetime array boxing. I think it's easier to just use PyIceberg instead of keep working around Spark issues. Leaving the rest of Spark uses in place for now to limit the scope.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Nightly: https://dev.azure.com/bodo-inc/Bodo/_build/results?buildId=25709&view=results

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.