### PR TITLE
Fix RangeIndex handling in DataFrame reconstruction

### DIFF
--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -606,15 +606,11 @@ def _reconstruct_pandas_index(df, arrow_schema):
             df = df.drop(columns=[descr])
         elif descr["kind"] == "range":
             index_name = descr["name"]
-            # We only handle RangeIndex with start=0 and step=1 and
-            # don't carry stop value throughout the code for simplicity.
             start = descr["start"]
             step = descr["step"]
-            if start != 0 or step != 1:
-                raise ValueError(
-                    f"Unsupported RangeIndex with start={start} and step={step}"
-                )
-            stop = len(df)
+            # Set stop value to proper size since we create PyArrow schema from empty
+            # DataFrames
+            stop = start + step * len(df)
             index_level = pd.RangeIndex(start, stop, step, name=index_name)
         else:
             raise ValueError(f"Unrecognized index kind: {descr['kind']}")


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes handling of RangeIndex in Pandas DataFrame reconstruction steps. It was trying to guard against a Parquet corner case that's a followup and not as important.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.