### PR TITLE
Enable streaming execution in DataFrame library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,7 @@ set(sources_list
   "bodo/pandas/_physical_conv.cpp"
   "bodo/pandas/_duckdb_util.cpp"
   "bodo/pandas/physical/expression.cpp"
+  "bodo/pandas/physical/operator.cpp"
   "bodo/io/_csv_json_writer.cpp"
   "bodo/io/_fs_io.cpp"
   "bodo/io/_hdfs_reader.cpp"

--- a/bodo/libs/_bodo_to_arrow.cpp
+++ b/bodo/libs/_bodo_to_arrow.cpp
@@ -1260,7 +1260,7 @@ std::shared_ptr<array_info> arrow_string_binary_array_to_bodo(
         }
         std::memcpy(out_arr->buffers[0]->mutable_data(),
                     arrow_bin_arr->raw_data() + first_offset, total_chars);
-        for (size_t i = 0; i < n; i++) {
+        for (int64_t i = 0; i < n; i++) {
             ::arrow::bit_util::SetBitTo((uint8_t *)out_arr->null_bitmask(), i,
                                         !arrow_bin_arr->IsNull(i));
         }

--- a/bodo/libs/_bodo_to_arrow.cpp
+++ b/bodo/libs/_bodo_to_arrow.cpp
@@ -1255,7 +1255,7 @@ std::shared_ptr<array_info> arrow_string_binary_array_to_bodo(
             alloc_string_array(Bodo_CTypes::STRING, n, total_chars,
                                array_id < 0 ? generate_array_id(n) : array_id);
         offset_t *out_offsets = (offset_t *)out_arr->buffers[1]->mutable_data();
-        for (size_t i = 0; i < n + 1; i++) {
+        for (size_t i = 0; i < static_cast<size_t>(n) + 1; i++) {
             out_offsets[i] = in_offsets[i] - first_offset;
         }
         std::memcpy(out_arr->buffers[0]->mutable_data(),

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -1,0 +1,6 @@
+#include "operator.h"
+
+int get_streaming_batch_size() {
+    char* env_str = std::getenv("BODO_STREAMING_BATCH_SIZE");
+    return (env_str != nullptr) ? std::stoi(env_str) : 4096;
+}

--- a/bodo/pandas/physical/operator.h
+++ b/bodo/pandas/physical/operator.h
@@ -79,7 +79,4 @@ class PhysicalSourceSink : public PhysicalOperator {
  *
  * @return int batch size to be used in streaming operators
  */
-int get_streaming_batch_size() {
-    char* env_str = std::getenv("BODO_STREAMING_BATCH_SIZE");
-    return (env_str != nullptr) ? std::stoi(env_str) : 4096;
-}
+int get_streaming_batch_size();

--- a/bodo/pandas/physical/operator.h
+++ b/bodo/pandas/physical/operator.h
@@ -74,7 +74,7 @@ class PhysicalSourceSink : public PhysicalOperator {
 
 /**
  * @brief Get the streaming batch size from environment variable.
- * It looked up the environment variable dynamically to enable setting it
+ * It looks up the environment variable dynamically to enable setting it
  * in tests during runtime.
  *
  * @return int batch size to be used in streaming operators

--- a/bodo/pandas/physical/operator.h
+++ b/bodo/pandas/physical/operator.h
@@ -71,3 +71,15 @@ class PhysicalSourceSink : public PhysicalOperator {
     virtual std::pair<std::shared_ptr<table_info>, OperatorResult> ProcessBatch(
         std::shared_ptr<table_info> input_batch) = 0;
 };
+
+/**
+ * @brief Get the streaming batch size from environment variable.
+ * It looked up the environment variable dynamically to enable setting it
+ * in tests during runtime.
+ *
+ * @return int batch size to be used in streaming operators
+ */
+int get_streaming_batch_size() {
+    char* env_str = std::getenv("BODO_STREAMING_BATCH_SIZE");
+    return (env_str != nullptr) ? std::stoi(env_str) : 4096;
+}

--- a/bodo/pandas/physical/read_parquet.h
+++ b/bodo/pandas/physical/read_parquet.h
@@ -122,7 +122,7 @@ class PhysicalReadParquet : public PhysicalSource {
 
         internal_reader = std::make_shared<ParquetReader>(
             py_path, true, arrowFilterExpr, storage_options, pyarrow_schema, -1,
-            selected_columns, is_nullable, false, -1);
+            selected_columns, is_nullable, false, get_streaming_batch_size());
         internal_reader->init_pq_reader({}, nullptr, nullptr, 0);
 
         // Extract column names from pyarrow schema using selected columns

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -343,8 +343,11 @@ def test_parquet_read_partitioned(datapath, set_stream_batch_size_three):
     # NOTE: Bodo dataframe library currently reads partitioned columns as
     # dictionary-encoded strings but Pandas reads them as categorical.
     _test_equal(
-        bodo_out,
+        bodo_out.copy(),
         py_out,
+        check_pandas_types=False,
+        sort_output=True,
+        reset_index=True,
     )
 
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -202,7 +202,13 @@ def test_filter_pushdown(datapath, file_path, op, set_stream_batch_size_three):
     py_df1 = pd.read_parquet(datapath(file_path))
     py_df2 = py_df1[eval(f"py_df1.A {op_str} 20")]
 
-    _test_equal(bodo_df2, py_df2, check_pandas_types=False)
+    _test_equal(
+        bodo_df2.copy(),
+        py_df2,
+        check_pandas_types=False,
+        sort_output=True,
+        reset_index=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -168,7 +168,16 @@ def test_projection(datapath, set_stream_batch_size_three):
     py_df1 = pd.read_parquet(datapath("dataframe_library/df1.parquet"))
     py_df2 = py_df1["D"]
 
-    _test_equal(bodo_df2, py_df2, check_pandas_types=False)
+    # TODO: remove copy when df.apply(axis=0) is implemented
+    # TODO: remove forcing collect when copy() bug with RangeIndex(1) is fixed
+    str(bodo_df2)
+    _test_equal(
+        bodo_df2.copy(),
+        py_df2,
+        check_pandas_types=False,
+        sort_output=True,
+        reset_index=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -202,6 +211,7 @@ def test_filter_pushdown(datapath, file_path, op, set_stream_batch_size_three):
     py_df1 = pd.read_parquet(datapath(file_path))
     py_df2 = py_df1[eval(f"py_df1.A {op_str} 20")]
 
+    # TODO: remove copy when df.apply(axis=0) is implemented
     _test_equal(
         bodo_df2.copy(),
         py_df2,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -40,7 +40,7 @@ def test_from_pandas(datapath, index_val, set_stream_batch_size_three):
         {
             "a": [1, 2, 3, 7] * 2,
             "b": [4, 5, 6, 8] * 2,
-            "c": ["a", "b", "c", "abc"] * 2,
+            "c": ["a", "b", None, "abc"] * 2,
         },
     )
     df.index = index_val[: len(df)]


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Enables streaming batch data in from_pandas and read_parquet and updates tests. Also fixes a critical bug with Arrow string to Bodo conversion.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Updated the tests to be streaming.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.