### PR TITLE
Add Pyobjectptr

### DIFF
--- a/bodo/io/parquet_reader.cpp
+++ b/bodo/io/parquet_reader.cpp
@@ -85,8 +85,8 @@ static void fill_input_file_name_col_dict(
 // -------- ParquetReader --------
 void ParquetReader::add_piece(PyObject* piece, int64_t num_rows) {
     // p = piece.path
-    PyObject* p = PyObject_GetAttrString(piece, "path");
-    const char* c_path = PyUnicode_AsUTF8(p);
+    PyObjectPtr p = PyObject_GetAttrString(piece, "path");
+    const char* c_path = PyUnicode_AsUTF8(p.get());
     file_paths.emplace_back(c_path);
     pieces_nrows.push_back(num_rows);
     if (this->input_file_name_col) {
@@ -112,29 +112,26 @@ void ParquetReader::add_piece(PyObject* piece, int64_t num_rows) {
 
     // for this parquet file: store partition value of each partition column
     get_partition_info(piece);
-    Py_DECREF(p);
 }
 
 PyObject* ParquetReader::get_dataset() {
     // partitioning = "hive" if use_hive else None
-    PyObject* partitioning = use_hive ? PyUnicode_FromString("hive") : Py_None;
+    PyObjectPtr partitioning =
+        use_hive ? PyUnicode_FromString("hive") : Py_None;
 
     // import bodo.io.parquet_pio
-    PyObject* pq_mod = PyImport_ImportModule("bodo.io.parquet_pio");
+    PyObjectPtr pq_mod = PyImport_ImportModule("bodo.io.parquet_pio");
 
     // ds = bodo.io.parquet_pio.get_parquet_dataset(path, get_row_counts=True,
     // filters, storage_options, read_categories=False, tot_rows_to_read,
     // schema, partitioning)
     PyObject* ds = PyObject_CallMethod(
-        pq_mod, "get_parquet_dataset", "OOOOOLOO", path, Py_True, expr_filters,
-        storage_options, Py_False, tot_rows_to_read, this->pyarrow_schema,
-        partitioning);
+        pq_mod, "get_parquet_dataset", "OOOOOLOO", this->path.get(), Py_True,
+        expr_filters.get(), this->storage_options.get(), Py_False,
+        tot_rows_to_read, this->pyarrow_schema, partitioning.get());
     if (ds == nullptr && PyErr_Occurred()) {
         throw std::runtime_error("python");
     }
-    Py_DECREF(path);
-    Py_DECREF(pq_mod);
-    Py_DECREF(partitioning);
     if (PyErr_Occurred()) {
         throw std::runtime_error("python");
     }
@@ -143,9 +140,8 @@ PyObject* ParquetReader::get_dataset() {
     this->set_arrow_schema(PyObject_GetAttrString(ds, "schema"));
 
     // prefix = ds.prefix
-    PyObject* prefix_py = PyObject_GetAttrString(ds, "_prefix");
+    PyObjectPtr prefix_py = PyObject_GetAttrString(ds, "_prefix");
     this->prefix.assign(PyUnicode_AsUTF8(prefix_py));
-    Py_DECREF(prefix_py);
 
     this->filesystem = PyObject_GetAttrString(ds, "filesystem");
     return ds;
@@ -159,13 +155,13 @@ void ParquetReader::init_pq_scanner() {
 
     // Construct Python lists from C++ vectors for values used in
     // get_scanner_batches
-    PyObject* fnames_list_py = PyList_New(this->file_paths.size());
+    PyObjectPtr fnames_list_py = PyList_New(this->file_paths.size());
     size_t i = 0;
     for (auto p : this->file_paths) {
         PyList_SetItem(fnames_list_py, i++, PyUnicode_FromString(p.c_str()));
     }
 
-    PyObject* str_as_dict_cols_py =
+    PyObjectPtr str_as_dict_cols_py =
         PyList_New(this->str_as_dict_colnames.size());
     i = 0;
     for (auto field_name : this->str_as_dict_colnames) {
@@ -173,24 +169,24 @@ void ParquetReader::init_pq_scanner() {
                        PyUnicode_FromString(field_name.c_str()));
     }
 
-    PyObject* selected_fields_py = PyList_New(selected_fields.size());
+    PyObjectPtr selected_fields_py = PyList_New(selected_fields.size());
     i = 0;
     for (int field_num : selected_fields) {
         PyList_SetItem(selected_fields_py, i++, PyLong_FromLong(field_num));
     }
 
-    PyObject* batch_size_py =
+    PyObjectPtr batch_size_py =
         batch_size == -1 ? Py_None : PyLong_FromLong(batch_size);
-    PyObject* pq_mod = PyImport_ImportModule("bodo.io.parquet_pio");
+    PyObjectPtr pq_mod = PyImport_ImportModule("bodo.io.parquet_pio");
     // This only loads record batches that match the filter.
     // get_scanner_batches returns a tuple with the record batch reader and the
     // updated offset for the first batch.
-    PyObject* scanner_batches_tup = PyObject_CallMethod(
-        pq_mod, "get_scanner_batches", "OOOdiOOLLOOO", fnames_list_py,
-        this->expr_filters, selected_fields_py, avg_num_pieces, int(parallel),
-        this->filesystem, str_as_dict_cols_py, this->start_row_first_piece,
-        this->count, this->ds_partitioning, this->pyarrow_schema,
-        batch_size_py);
+    PyObjectPtr scanner_batches_tup = PyObject_CallMethod(
+        pq_mod, "get_scanner_batches", "OOOdiOOLLOOO", fnames_list_py.get(),
+        this->expr_filters.get(), selected_fields_py.get(), avg_num_pieces,
+        int(parallel), this->filesystem.get(), str_as_dict_cols_py.get(),
+        this->start_row_first_piece, this->count, this->ds_partitioning.get(),
+        this->pyarrow_schema, batch_size_py.get());
     if (scanner_batches_tup == nullptr && PyErr_Occurred()) {
         throw std::runtime_error("python");
     }
@@ -203,17 +199,8 @@ void ParquetReader::init_pq_scanner() {
         PyLong_AsLongLong(PyTuple_GetItem(scanner_batches_tup, 1));
     this->rows_left_cur_piece = this->pieces_nrows[0];
 
-    Py_DECREF(pq_mod);
-    Py_DECREF(this->expr_filters);
-    Py_DECREF(selected_fields_py);
-    Py_DECREF(this->filesystem);
-    Py_DECREF(fnames_list_py);
-    Py_DECREF(str_as_dict_cols_py);
+    // This is from ArrowReader which doesn't use PyObjectPtrs yet
     Py_DECREF(this->pyarrow_schema);
-    Py_DECREF(this->ds_partitioning);
-    Py_DECREF(batch_size_py);
-
-    Py_DECREF(scanner_batches_tup);
 }
 
 std::shared_ptr<table_info> ParquetReader::get_empty_out_table() {
@@ -260,7 +247,7 @@ std::tuple<table_info*, bool, uint64_t> ParquetReader::read_inner_row_level() {
         while (this->rows_left_to_read > 0 &&
                this->out_batches->total_remaining <
                    static_cast<size_t>(this->batch_size)) {
-            PyObject* batch_py =
+            PyObjectPtr batch_py =
                 PyObject_CallMethod(this->reader, "read_next_batch", nullptr);
             if (batch_py == nullptr && PyErr_Occurred() &&
                 PyErr_ExceptionMatches(PyExc_StopIteration)) {
@@ -288,7 +275,6 @@ std::tuple<table_info*, bool, uint64_t> ParquetReader::read_inner_row_level() {
                 throw std::runtime_error(
                     "ParquetReader::read_batch(): The next batch is null");
             }
-            Py_DECREF(batch_py);
             int64_t batch_offset =
                 std::min(this->rows_to_skip, batch->num_rows());
             int64_t length = std::min(this->rows_left_to_read,
@@ -372,7 +358,7 @@ std::tuple<table_info*, bool, uint64_t> ParquetReader::read_inner_row_level() {
     size_t cur_piece = 0;
     int64_t rows_left_cur_piece = pieces_nrows[cur_piece];
 
-    PyObject* batch_py = nullptr;
+    PyObjectPtr batch_py = nullptr;
     while ((batch_py = PyObject_CallMethod(this->reader, "read_next_batch",
                                            nullptr))) {
         auto batch = arrow::py::unwrap_batch(batch_py).ValueOrDie();
@@ -411,7 +397,6 @@ std::tuple<table_info*, bool, uint64_t> ParquetReader::read_inner_row_level() {
             }
         }
         this->rows_to_skip -= batch_offset;
-        Py_DECREF(batch_py);
     }
 
     if (batch_py == nullptr && PyErr_Occurred() &&
@@ -473,24 +458,21 @@ std::tuple<table_info*, bool, uint64_t> ParquetReader::read_inner_row_level() {
 }
 
 void ParquetReader::get_partition_info(PyObject* piece) {
-    PyObject* partition_keys_py =
+    PyObjectPtr partition_keys_py =
         PyObject_GetAttrString(piece, "partition_keys");
     if (PyList_Size(partition_keys_py) > 0) {
         part_vals.emplace_back();
         std::vector<int64_t>& vals = part_vals.back();
 
-        PyObject* part_keys_iter = PyObject_GetIter(partition_keys_py);
-        PyObject* key_val_tuple;
+        PyObjectPtr part_keys_iter = PyObject_GetIter(partition_keys_py);
+        PyObjectPtr key_val_tuple = nullptr;
         while ((key_val_tuple = PyIter_Next(part_keys_iter))) {
             // PyTuple_GetItem returns borrowed reference, no need to decref
             PyObject* part_val_py = PyTuple_GetItem(key_val_tuple, 1);
             int64_t part_val = PyLong_AsLongLong(part_val_py);
             vals.emplace_back(part_val);
-            Py_DECREF(key_val_tuple);
         }
-        Py_DECREF(part_keys_iter);
     }
-    Py_DECREF(partition_keys_py);
 }
 
 /**

--- a/bodo/io/parquet_reader.cpp
+++ b/bodo/io/parquet_reader.cpp
@@ -127,8 +127,8 @@ PyObject* ParquetReader::get_dataset() {
     // schema, partitioning)
     PyObject* ds = PyObject_CallMethod(
         pq_mod, "get_parquet_dataset", "OOOOOLOO", this->path.get(), Py_True,
-        expr_filters.get(), this->storage_options.get(), Py_False,
-        tot_rows_to_read, this->pyarrow_schema, partitioning.get());
+        expr_filters.get(), this->storage_options, Py_False, tot_rows_to_read,
+        this->pyarrow_schema, partitioning.get());
     if (ds == nullptr && PyErr_Occurred()) {
         throw std::runtime_error("python");
     }

--- a/bodo/io/parquet_reader.h
+++ b/bodo/io/parquet_reader.h
@@ -157,7 +157,8 @@ class ParquetReader : public ArrowReader {
     std::vector<std::string> file_paths;
 
     PyObjectPtr path;  // path passed to pd.read_parquet() call
-    PyObjectPtr storage_options;
+    // We don't own storage options so store the raw pointer
+    PyObject* storage_options;
     bool input_file_name_col;
     bool use_hive;
 

--- a/bodo/io/parquet_reader.h
+++ b/bodo/io/parquet_reader.h
@@ -4,6 +4,7 @@
 
 #include "../libs/_bodo_to_arrow.h"
 #include "../libs/_distributed.h"
+#include "../libs/_utils.h"
 #include "arrow_reader.h"
 
 class ParquetReader : public ArrowReader {
@@ -146,17 +147,17 @@ class ParquetReader : public ArrowReader {
     // Prefix to add to each of the file paths (only used for input_file_name)
     std::string prefix;
 
-    PyObject* expr_filters = nullptr;
-    PyObject* filesystem = nullptr;
+    PyObjectPtr expr_filters = nullptr;
+    PyObjectPtr filesystem = nullptr;
     // dataset partitioning info (regardless of whether we select partition
     // columns or not)
-    PyObject* ds_partitioning = nullptr;
+    PyObjectPtr ds_partitioning = nullptr;
 
     // Parquet files that this process has to read
     std::vector<std::string> file_paths;
 
-    PyObject* path;  // path passed to pd.read_parquet() call
-    PyObject* storage_options;
+    PyObjectPtr path;  // path passed to pd.read_parquet() call
+    PyObjectPtr storage_options;
     bool input_file_name_col;
     bool use_hive;
 

--- a/bodo/libs/_utils.h
+++ b/bodo/libs/_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Python.h>
 #include <chrono>
 #include <optional>
 #include <string>
@@ -54,3 +55,11 @@ uint64_t get_physically_installed_memory();
     } while (0)
 
 #define ASSERT(x) ASSERT_WITH_ERR_MSG(x, "")
+
+/// @brief Class to manage PyObject pointers with automatic reference counting.
+class PyObjectPtr : public std::unique_ptr<PyObject, decltype(&Py_DECREF)> {
+   public:
+    PyObjectPtr(PyObject* obj)
+        : std::unique_ptr<PyObject, decltype(&Py_XDECREF)>(obj, Py_XDECREF) {}
+    operator PyObject*() const { return get(); }
+};

--- a/bodo/libs/_utils.h
+++ b/bodo/libs/_utils.h
@@ -57,9 +57,20 @@ uint64_t get_physically_installed_memory();
 #define ASSERT(x) ASSERT_WITH_ERR_MSG(x, "")
 
 /// @brief Class to manage PyObject pointers with automatic reference counting.
-class PyObjectPtr : public std::unique_ptr<PyObject, decltype(&Py_DECREF)> {
+class PyObjectPtr : public std::unique_ptr<PyObject, void (*)(PyObject*)> {
    public:
+    static void decref_check_none(PyObject* obj) {
+        // Python 3.12 allows Py_XDECREF to be used on nullptr and all decrefs
+        // have no effect on immortals (None becomes an immortal in 3.12).
+        // Once python 3.12 is our min version we can just use Py_XDECREF
+        // and remove this function.
+        if (obj != nullptr && obj != Py_None) {
+            Py_DECREF(obj);
+        }
+    }
+
     PyObjectPtr(PyObject* obj)
-        : std::unique_ptr<PyObject, decltype(&Py_XDECREF)>(obj, Py_XDECREF) {}
+        : std::unique_ptr<PyObject, void (*)(PyObject*)>(
+              obj, &(this->decref_check_none)) {}
     operator PyObject*() const { return get(); }
 };


### PR DESCRIPTION
## Changes included in this PR
Adds pyobject pointer for automatic pyobject decref.
Converts parquet reader to use PyObjectPtr as POC.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.