### PR TITLE
[WIP] Refactor env vars to clarify they are for individual ranks

### DIFF
--- a/bodo/libs/_memory.cpp
+++ b/bodo/libs/_memory.cpp
@@ -730,7 +730,7 @@ BufferPoolOptions BufferPoolOptions::Defaults() {
     // If env var is not set, we will get the memory
     // information from the OS.
     if (char* memory_size_env_ =
-            std::getenv("BODO_BUFFER_POOL_MEMORY_SIZE_MiB")) {
+            std::getenv("BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB")) {
         options.memory_size = std::stoi(memory_size_env_);
         // If user is setting the memory manually, we can allocate extra frames.
         options._allocate_extra_frames = true;
@@ -821,8 +821,8 @@ BufferPoolOptions BufferPoolOptions::Defaults() {
             !std::strcmp(enforce_max_limit_env_, "1");
     }
 
-    if (const char* malloc_free_trim_threshold_env_ =
-            std::getenv("BODO_BUFFER_POOL_MALLOC_FREE_TRIM_THRESHOLD_MiB")) {
+    if (const char* malloc_free_trim_threshold_env_ = std::getenv(
+            "BODO_BUFFER_POOL_MALLOC_FREE_TRIM_THRESHOLD_PER_WORKER_MiB")) {
         options.malloc_free_trim_threshold =
             std::stoi(malloc_free_trim_threshold_env_) * 1024 * 1024;
     }

--- a/bodo/libs/_memory.h
+++ b/bodo/libs/_memory.h
@@ -103,7 +103,8 @@ class IBufferPool : public ::arrow::MemoryPool {
 
 /// @brief Options for the Buffer Pool implementation
 struct BufferPoolOptions {
-    /// @brief Total available memory (in MiB) for the buffer pool.
+    /// @brief Total memory available to this rank (in MiB)
+    /// for the buffer pool.
     uint64_t memory_size = 200;
 
     /// @brief Real system memory (in MiB) available to this rank.

--- a/bodo/tests/table_generator.hpp
+++ b/bodo/tests/table_generator.hpp
@@ -106,7 +106,7 @@ void _cppToArrow_inner(std::vector<std::shared_ptr<arrow::Array>>& arrays,
  * @param fields vector of arrow Fields to append to as output
  * @param names
  * @param is_nullable
- * @param str_as_dict_cols
+ * @param
  * @param input_column
  **/
 template <typename T>

--- a/bodo/tests/test_memory.py
+++ b/bodo/tests/test_memory.py
@@ -69,13 +69,13 @@ def test_default_buffer_pool_options():
     # env vars are set.
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
             "BODO_BUFFER_POOL_ENFORCE_MAX_ALLOCATION_LIMIT": None,
             "BODO_BUFFER_POOL_DEBUG_MODE": None,
-            "BODO_BUFFER_POOL_MALLOC_FREE_TRIM_THRESHOLD_MiB": None,
+            "BODO_BUFFER_POOL_MALLOC_FREE_TRIM_THRESHOLD_PER_WORKER_MiB": None,
         }
     ):
         options = BufferPoolOptions.defaults()
@@ -90,7 +90,7 @@ def test_default_buffer_pool_options():
     # expected.
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": "128",
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": "128",
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -106,7 +106,7 @@ def test_default_buffer_pool_options():
     # expected
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": "32",
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": "5",
@@ -121,7 +121,7 @@ def test_default_buffer_pool_options():
     # through env vars works as expected
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -134,7 +134,7 @@ def test_default_buffer_pool_options():
 
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -149,11 +149,11 @@ def test_default_buffer_pool_options():
     # through env vars works as expected
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
-            "BODO_BUFFER_POOL_MALLOC_FREE_TRIM_THRESHOLD_MiB": "20",
+            "BODO_BUFFER_POOL_MALLOC_FREE_TRIM_THRESHOLD_PER_WORKER_MiB": "20",
         }
     ):
         options = BufferPoolOptions.defaults()
@@ -170,7 +170,7 @@ def test_default_memory_options(tmp_path: Path):
     total_mem = 0
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": "100",
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -182,7 +182,7 @@ def test_default_memory_options(tmp_path: Path):
     # Now set it to 65 and verify that memory_size is 65% of total_mem.
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": "65",
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -199,7 +199,7 @@ def test_default_memory_options(tmp_path: Path):
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_DRIVES": str(tmp_path),
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_SPACE_PER_DRIVE_GiB": "1",
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_USABLE_PERCENTAGE": "100",
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -214,7 +214,7 @@ def test_default_memory_options(tmp_path: Path):
     # Also check that the default min size class is 64KiB.
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -234,7 +234,7 @@ def test_default_memory_options(tmp_path: Path):
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_DRIVES": str(tmp_path),
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_SPACE_PER_DRIVE_GiB": "1",
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_USABLE_PERCENTAGE": "100",
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -253,7 +253,7 @@ def test_default_memory_options(tmp_path: Path):
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_DRIVES": str(tmp_path),
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_SPACE_PER_DRIVE_GiB": "1",
             "BODO_BUFFER_POOL_STORAGE_CONFIG_1_USABLE_PERCENTAGE": "100",
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -318,7 +318,7 @@ def test_default_memory_options(tmp_path: Path):
     for mem_percent in range(40, 150, 5):
         with temp_env_override(
             {
-                "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+                "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
                 "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": str(mem_percent),
                 "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
                 "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -338,7 +338,7 @@ def test_default_memory_options(tmp_path: Path):
     for mem_percent in range(40, 150, 5):
         with temp_env_override(
             {
-                "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+                "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
                 "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": str(mem_percent),
                 "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
                 "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -433,7 +433,7 @@ def test_default_storage_options(tmp_path: Path):
     # create a option in BufferPoolOptions
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -449,7 +449,7 @@ def test_default_storage_options(tmp_path: Path):
     # create a option in BufferPoolOptions
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,
@@ -472,7 +472,7 @@ def test_default_storage_options(tmp_path: Path):
     # create a option in BufferPoolOptions
     with temp_env_override(
         {
-            "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": None,
+            "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": None,
             "BODO_BUFFER_POOL_MEMORY_USABLE_PERCENT": None,
             "BODO_BUFFER_POOL_MIN_SIZE_CLASS_KiB": None,
             "BODO_BUFFER_POOL_MAX_NUM_SIZE_CLASSES": None,

--- a/e2e-tests/groupby/streaming_groupby/test_stream_groupby.py
+++ b/e2e-tests/groupby/streaming_groupby/test_stream_groupby.py
@@ -57,7 +57,7 @@ def test_stream_groupby(
         unpin_behavior(),
         temp_env_override(
             {
-                "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": str(mem_size_mib)
+                "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": str(mem_size_mib)
                 if (mem_size_mib is not None)
                 else None,
                 "BODO_DEBUG_STREAM_GROUPBY_PARTITIONING": "1",

--- a/e2e-tests/join/streaming_hash_join/test_stream_hash_join.py
+++ b/e2e-tests/join/streaming_hash_join/test_stream_hash_join.py
@@ -42,7 +42,7 @@ def test_hash_join(
         unpin_behavior(),
         temp_env_override(
             {
-                "BODO_BUFFER_POOL_MEMORY_SIZE_MiB": str(mem_size_mib)
+                "BODO_BUFFER_POOL_MEMORY_SIZE_PER_WORKER_MiB": str(mem_size_mib)
                 if (mem_size_mib is not None)
                 else None,
                 "BODO_DEBUG_STREAM_HASH_JOIN_PARTITIONING": "1",


### PR DESCRIPTION
## Changes included in this PR

See [here](https://bodo.atlassian.net/wiki/spaces/B/pages/2254405633/Potential+Memory+Improvements#Improve-Buffer-Pool-UX) for more context. Essentially the environment variables for setting the amount of available memory and thresholds are for the buffer pool are split between single-node and individual ranks.

For example:
`BODO_BUFFER_POOL_MEMORY_SIZE_MiB` specifies the memory available to this rank for the buffer pool, whereas 
`BODO_BUFFER_POOL_STORAGE_CONFIG_1_SPACE_PER_DRIVE_GiB` Is the space available for each node.

Ideally IMO `BODO_BUFFER_POOL_MEMORY_SIZE_MiB` should just specify the amount of space available to all processes and then that space gets divided among ranks evenly, but then it creates a weird situation with `BODO_BUFFER_POOL_MALLOC_FREE_TRIM_THRESHOLD_MiB`, which is still per rank, and doesn't really make sense to have that describe the node as a whole because different ranks could have different memory usage.

Adding "per worker" makes it a bit more clear but make the environment variables too long e.g. `BODO_BUFFER_POOL_PER_WORKER_MALLOC_FREE_TRIM_THRESHOLD_MiB`


<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.