### PR TITLE
Support printing plans to string to help development

### DIFF
--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -548,8 +548,10 @@ std::pair<duckdb::string, duckdb::LogicalType> arrow_field_to_duckdb(
     return {field->name(), duckdb_type};
 }
 
-std::string plan_to_string(std::unique_ptr<duckdb::LogicalOperator> &plan) {
-    return plan->ToString(duckdb::ExplainFormat::GRAPHVIZ);
+std::string plan_to_string(std::unique_ptr<duckdb::LogicalOperator> &plan,
+                           bool graphviz_format) {
+    return plan->ToString(graphviz_format ? duckdb::ExplainFormat::GRAPHVIZ
+                                          : duckdb::ExplainFormat::TEXT);
 }
 
 std::shared_ptr<PhysicalSource>

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -347,11 +347,14 @@ std::pair<duckdb::string, duckdb::LogicalType> arrow_field_to_duckdb(
     const std::shared_ptr<arrow::Field> &field);
 
 /**
- * @brief Convert a plan rooted at the given logical operator into graphviz.
+ * @brief Convert a plan rooted at the given logical operator into text or
+ * graphviz.
  *
- * @param plan - the root of the plan to convert to graphviz
+ * @param plan - the root of the plan to convert to graphviz or text
+ * @param graphviz_format - use graphviz format if true, otherwise text
  */
-std::string plan_to_string(std::unique_ptr<duckdb::LogicalOperator> &plan);
+std::string plan_to_string(std::unique_ptr<duckdb::LogicalOperator> &plan,
+                           bool graphviz_format);
 
 /**
  * @brief Get the table index of operator assuming there is only one table

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -7,6 +7,7 @@ from libcpp.memory cimport unique_ptr, make_unique, dynamic_pointer_cast
 from libcpp.utility cimport move, pair
 from libcpp.string cimport string as c_string
 from libcpp.vector cimport vector
+from libcpp cimport bool as c_bool
 import operator
 from libc.stdint cimport int64_t
 
@@ -269,7 +270,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_const_int_expr(int val)
     cdef unique_ptr[CExpression] make_col_ref_expr(unique_ptr[CLogicalOperator] source, object field, int col_idx)
     cdef pair[int64_t, PyObjectPtr] execute_plan(unique_ptr[CLogicalOperator], object out_schema)
-    cdef c_string plan_to_string(unique_ptr[CLogicalOperator])
+    cdef c_string plan_to_string(unique_ptr[CLogicalOperator], c_bool graphviz_format)
     cdef vector[int] get_projection_pushed_down_columns(unique_ptr[CLogicalOperator] proj)
     cdef int planCountNodes(unique_ptr[CLogicalOperator] root)
     cdef void set_table_meta_from_arrow(int64_t table_pointer, object arrow_schema)
@@ -320,7 +321,10 @@ cdef class LogicalOperator:
         self.c_logical_operator.get().estimated_cardinality = estimated_cardinality
 
     def toGraphviz(self):
-        return plan_to_string(self.c_logical_operator).decode("utf-8")
+        return plan_to_string(self.c_logical_operator, True).decode("utf-8")
+
+    def toString(self):
+        return plan_to_string(self.c_logical_operator, False).decode("utf-8")
 
 cdef class LogicalComparisonJoin(LogicalOperator):
     """Wrapper around DuckDB's LogicalComparisonJoin to provide access in Python.


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Adds a `toString` function to print plans using `print(bdf.plan.generate_duckdb().toString())` to help with development.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
NA.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.