### PR TITLE
Refactor Projection handling to use proper Expressions

### DIFF
--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -220,12 +220,12 @@ std::vector<int> get_projection_pushed_down_columns(
     std::unique_ptr<duckdb::LogicalOperator> &proj);
 
 /**
- * @brief Creates a LogicalProjection node with a UDF inside.
+ * @brief Creates an Expression node with a UDF inside.
  *
  * @param source input table plan
  * @param func UDF function to execute
  * @param out_schema_py output data type (single column for df.apply)
- * @return duckdb::unique_ptr<duckdb::LogicalProjection> Projection node for UDF
+ * @return duckdb::unique_ptr<duckdb::Expression> Expression node for UDF
  */
 duckdb::unique_ptr<duckdb::Expression> make_python_scalar_func_expr(
     std::unique_ptr<duckdb::LogicalOperator> &source, PyObject *out_schema_py,

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -10,6 +10,7 @@
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/expression.hpp"
 #include "physical/expression.h"
 #include "physical/operator.h"
 
@@ -205,7 +206,8 @@ duckdb::unique_ptr<duckdb::LogicalComparisonJoin> make_comparison_join(
  */
 duckdb::unique_ptr<duckdb::LogicalProjection> make_projection(
     std::unique_ptr<duckdb::LogicalOperator> &source,
-    std::vector<int> &select_vec, PyObject *out_schema_py);
+    std::vector<std::unique_ptr<duckdb::Expression>> &expr_vec,
+    PyObject *out_schema_py);
 
 /**
  * @brief Get column indices that are pushed down from a projection node to its
@@ -225,8 +227,7 @@ std::vector<int> get_projection_pushed_down_columns(
  * @param out_schema_py output data type (single column for df.apply)
  * @return duckdb::unique_ptr<duckdb::LogicalProjection> Projection node for UDF
  */
-duckdb::unique_ptr<duckdb::LogicalProjection>
-make_projection_python_scalar_func(
+duckdb::unique_ptr<duckdb::Expression> make_python_scalar_func_expr(
     std::unique_ptr<duckdb::LogicalOperator> &source, PyObject *out_schema_py,
     PyObject *args);
 
@@ -275,7 +276,7 @@ duckdb::unique_ptr<duckdb::Expression> make_col_ref_expr(
  * @param etype - the expression type comparing the two sources
  * @return duckdb::unique_ptr<duckdb::Expression> - the output expr
  */
-duckdb::unique_ptr<duckdb::Expression> make_binop_expr(
+std::unique_ptr<duckdb::Expression> make_binop_expr(
     std::unique_ptr<duckdb::Expression> &lhs,
     std::unique_ptr<duckdb::Expression> &rhs, duckdb::ExpressionType etype);
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -15,6 +15,7 @@ from bodo.pandas.utils import (
     LazyPlan,
     check_args_fallback,
     get_lazy_manager_class,
+    get_proj_expr_single,
     wrap_plan,
 )
 from bodo.utils.typing import (
@@ -518,7 +519,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         if isinstance(key, BodoSeries):
             """ This is a masking operation. """
             key_plan = (
-                key._plan
+                # TODO: error checking for key to be a projection on the same dataframe
+                # with a binary operator
+                get_proj_expr_single(key._plan)
                 if key._plan is not None
                 else plan_optimizer.LogicalGetSeriesRead(key._mgr._md_result_id)
             )

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -478,6 +478,27 @@ cdef class BinaryOpExpression(Expression):
         return f"BinaryOpExpression({self.out_schema})"
 
 
+cdef class ConjunctionOpExpression(Expression):
+    """Wrapper around DuckDB's BoundConjunctionExpression and other binary operators to provide access in Python.
+    """
+
+    def __cinit__(self, object out_schema, lhs, rhs, binop):
+        cdef unique_ptr[CExpression] lhs_expr
+        cdef unique_ptr[CExpression] rhs_expr
+
+        lhs_expr = move((<Expression>lhs).c_expression) if isinstance(lhs, Expression) else move(make_expr(lhs))
+        rhs_expr = move((<Expression>rhs).c_expression) if isinstance(rhs, Expression) else move(make_expr(rhs))
+
+        self.out_schema = out_schema
+        self.c_expression = make_conjunction_expr(
+            lhs_expr,
+            rhs_expr,
+            str_to_expr_type(binop))
+
+    def __str__(self):
+        return f"ConjunctionOpExpression({self.out_schema})"
+
+
 cdef class LogicalUnaryOp(LogicalOperator):
     cdef public object op
 

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -269,8 +269,8 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CLogicalGet] make_dataframe_get_parallel_node(c_string res_id, object arrow_schema)
     cdef unique_ptr[CLogicalComparisonJoin] make_comparison_join(unique_ptr[CLogicalOperator] lhs, unique_ptr[CLogicalOperator] rhs, CJoinType join_type, vector[int_pair] cond_vec)
     cdef unique_ptr[CLogicalOperator] optimize_plan(unique_ptr[CLogicalOperator])
-    cdef unique_ptr[CLogicalProjection] make_projection(unique_ptr[CLogicalOperator] source, vector[int] select_vec, object out_schema)
-    cdef unique_ptr[CLogicalProjection] make_projection_python_scalar_func(unique_ptr[CLogicalOperator] source, object out_schema, object args)
+    cdef unique_ptr[CLogicalProjection] make_projection(unique_ptr[CLogicalOperator] source, vector[unique_ptr[CExpression]] expr_vec, object out_schema)
+    cdef unique_ptr[CExpression] make_python_scalar_func_expr(unique_ptr[CLogicalOperator] source, object out_schema, object args)
     cdef unique_ptr[CExpression] make_binop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype)
     cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype)
     cdef unique_ptr[CLogicalFilter] make_filter(unique_ptr[CLogicalOperator] source, unique_ptr[CExpression] filter_expr)
@@ -335,6 +335,17 @@ cdef class LogicalOperator:
     def toString(self):
         return plan_to_string(self.c_logical_operator, False).decode("utf-8")
 
+
+cdef class Expression:
+    """Wrapper around DuckDB's Expression to provide access in Python.
+    """
+    cdef readonly out_schema
+    cdef unique_ptr[CExpression] c_expression
+
+    def __str__(self):
+        return "Expression()"
+
+
 cdef class LogicalComparisonJoin(LogicalOperator):
     """Wrapper around DuckDB's LogicalComparisonJoin to provide access in Python.
     """
@@ -352,22 +363,25 @@ cdef class LogicalComparisonJoin(LogicalOperator):
         join_type = join_type_to_string((<CLogicalComparisonJoin*>(self.c_logical_operator.get())).join_type)
         return f"LogicalComparisonJoin({join_type})"
 
+
 cdef class LogicalProjection(LogicalOperator):
     """Wrapper around DuckDB's LogicalProjection to provide access in Python.
     """
 
-    cdef readonly vector[int] select_vec
+    def __cinit__(self, object out_schema, LogicalOperator source, object exprs):
+        cdef vector[unique_ptr[CExpression]] expr_vec
 
-    def __cinit__(self, object out_schema, LogicalOperator source, select_idxs):
+        for expr in exprs:
+            expr_vec.push_back(move((<Expression>expr).c_expression))
+
         self.out_schema = out_schema
-        self.select_vec = select_idxs
         self.sources = [source]
 
-        cdef unique_ptr[CLogicalProjection] c_logical_projection = make_projection(source.c_logical_operator, self.select_vec, self.out_schema)
+        cdef unique_ptr[CLogicalProjection] c_logical_projection = make_projection(source.c_logical_operator, expr_vec, out_schema)
         self.c_logical_operator = unique_ptr[CLogicalOperator](<CLogicalOperator*> c_logical_projection.release())
 
     def __str__(self):
-        return f"LogicalProjection({self.select_vec}, {self.out_schema})"
+        return f"LogicalProjection({self.out_schema})"
 
 
 cdef class LogicalColRef(LogicalOperator):
@@ -390,19 +404,28 @@ cpdef get_pushed_down_columns(proj):
     return pushed_down_columns
 
 
-cdef class LogicalProjectionPythonScalarFunc(LogicalOperator):
-    """Wrapper around DuckDB's LogicalProjection with a ScalarFunc inside to provide access in Python.
+cdef class ColRefExpression(Expression):
+    """Wrapper around DuckDB's BoundColumnRefExpression to provide access in Python.
+    """
+
+    def __cinit__(self, object out_schema, LogicalOperator source, int col_index):
+        self.out_schema = out_schema
+        self.c_expression = make_col_ref_expr(source.c_logical_operator, out_schema[0], col_index)
+
+    def __str__(self):
+        return f"ColRefExpression({self.out_schema})"
+
+
+cdef class PythonScalarFuncExpression(Expression):
+    """Wrapper around DuckDB's BoundFunctionExpression for running Python functions.
     """
 
     def __cinit__(self, object out_schema, LogicalOperator source, object args):
         self.out_schema = out_schema
-        self.sources = [source]
-
-        cdef unique_ptr[CLogicalProjection] c_logical_projection = make_projection_python_scalar_func(source.c_logical_operator, self.out_schema, args)
-        self.c_logical_operator = unique_ptr[CLogicalOperator](<CLogicalOperator*> c_logical_projection.release())
+        self.c_expression = make_python_scalar_func_expr(source.c_logical_operator, out_schema, args)
 
     def __str__(self):
-        return f"LogicalProjectionPythonScalarFunc({self.out_schema})"
+        return f"PythonScalarFuncExpression({self.out_schema})"
 
 
 cdef unique_ptr[CExpression] make_expr(val):
@@ -486,6 +509,28 @@ cdef class LogicalBinaryOp(LogicalOperator):
         self.rhs = rhs
         self.binop = binop
         self.sources = [lhs, rhs]
+
+
+cdef class BinaryOpExpression(Expression):
+    """Wrapper around DuckDB's BoundComparisonExpression and other binary operators to provide access in Python.
+    """
+
+    def __cinit__(self, object out_schema, lhs, rhs, binop):
+        cdef unique_ptr[CExpression] lhs_expr
+        cdef unique_ptr[CExpression] rhs_expr
+
+        lhs_expr = move((<Expression>lhs).c_expression) if isinstance(lhs, Expression) else move(make_expr(lhs))
+        rhs_expr = move((<Expression>rhs).c_expression) if isinstance(rhs, Expression) else move(make_expr(rhs))
+
+        self.out_schema = out_schema
+        self.c_expression = make_binop_expr(
+            lhs_expr,
+            rhs_expr,
+            str_to_expr_type(binop))
+
+    def __str__(self):
+        return f"BinaryOpExpression({self.out_schema})"
+
 
 cdef class LogicalConjunctionOp(LogicalOperator):
     cdef public object lhs

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -64,6 +64,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         plan = LazyPlan(
             "LogicalProjection",
+            # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
         )
@@ -107,6 +108,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         plan = LazyPlan(
             "LogicalProjection",
+            # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
         )
@@ -271,6 +273,8 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         udf_arg = LazyPlan(
             "PythonScalarFuncExpression",
+            # Use the plan including the projection on the original table to access
+            # the right column (TODO: refactor to include a child ColRefExpression?).
             self._plan,
             (
                 "map",
@@ -284,6 +288,8 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         plan = LazyPlan(
             "LogicalProjection",
+            # Use the plan including the projection on the original table to access
+            # the right column (TODO: refactor to include a child ColRefExpression?).
             self._plan,
             (udf_arg,),
         )
@@ -305,6 +311,8 @@ class StringMethods:
         )
         expr = LazyPlan(
             "PythonScalarFuncExpression",
+            # Use the plan including the projection on the original table to access
+            # the right column (TODO: refactor to include a child ColRefExpression?).
             self._series._plan,
             (
                 "str.lower",
@@ -319,6 +327,8 @@ class StringMethods:
             new_metadata,
             plan=LazyPlan(
                 "LogicalProjection",
+                # Use the plan including the projection on the original table to access
+                # the right column (TODO: refactor to include a child ColRefExpression?).
                 self._series._plan,
                 (expr,),
             ),
@@ -334,6 +344,8 @@ class StringMethods:
         )
         expr = LazyPlan(
             "PythonScalarFuncExpression",
+            # Use the plan including the projection on the original table to access
+            # the right column (TODO: refactor to include a child ColRefExpression?).
             self._series._plan,
             (
                 "str.strip",
@@ -348,6 +360,8 @@ class StringMethods:
             new_metadata,
             plan=LazyPlan(
                 "LogicalProjection",
+                # Use the plan including the projection on the original table to access
+                # the right column (TODO: refactor to include a child ColRefExpression?).
                 self._series._plan,
                 (expr,),
             ),

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -13,6 +13,7 @@ from bodo.pandas.utils import (
     LazyPlan,
     check_args_fallback,
     get_lazy_single_manager_class,
+    get_proj_expr_single,
     wrap_plan,
 )
 
@@ -54,10 +55,19 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Compute schema of new series.
         new_metadata = zero_size_self._cmp_method(zero_size_other, op)
         assert isinstance(new_metadata, pd.Series)
-        return wrap_plan(
-            new_metadata,
-            plan=LazyPlan("LogicalBinaryOp", self._plan, other, op),
+
+        # Extract argument expressions
+        lhs = get_proj_expr_single(self._plan)
+        rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
+        expr = LazyPlan("BinaryOpExpression", lhs, rhs, op)
+        expr.out_schema = new_metadata.to_frame()
+
+        plan = LazyPlan(
+            "LogicalProjection",
+            self._plan.args[0],
+            (expr,),
         )
+        return wrap_plan(new_metadata, plan=plan)
 
     def _conjunction_binop(self, other, op):
         """Called when a BodoSeries is element-wise boolean combined with a different entity (other)"""
@@ -248,8 +258,8 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         empty_series = empty_df.squeeze()
         empty_series.name = out_sample.name
 
-        plan = LazyPlan(
-            "LogicalProjectionPythonScalarFunc",
+        udf_arg = LazyPlan(
+            "PythonScalarFuncExpression",
             self._plan,
             (
                 "map",
@@ -258,6 +268,13 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 (arg,),  # args
                 {},  # kwargs
             ),
+        )
+        udf_arg.out_schema = empty_df
+
+        plan = LazyPlan(
+            "LogicalProjection",
+            self._plan,
+            (udf_arg,),
         )
         return wrap_plan(empty_series, plan=plan)
 
@@ -275,18 +292,24 @@ class StringMethods:
             name=self._series.name,
             index=index,
         )
+        expr = LazyPlan(
+            "PythonScalarFuncExpression",
+            self._series._plan,
+            (
+                "str.lower",
+                True,  # is_series
+                True,  # is_method
+                (),  # args
+                {},  # kwargs
+            ),
+        )
+        expr.out_schema = new_metadata.to_frame()
         return wrap_plan(
             new_metadata,
             plan=LazyPlan(
-                "LogicalProjectionPythonScalarFunc",
+                "LogicalProjection",
                 self._series._plan,
-                (
-                    "str.lower",
-                    True,  # is_series
-                    True,  # is_method
-                    (),  # args
-                    {},  # kwargs
-                ),
+                (expr,),
             ),
         )
 
@@ -298,17 +321,23 @@ class StringMethods:
             name=self._series.name,
             index=index,
         )
+        expr = LazyPlan(
+            "PythonScalarFuncExpression",
+            self._series._plan,
+            (
+                "str.strip",
+                True,  # is_series
+                True,  # is_method
+                (),  # args
+                {},  # kwargs
+            ),
+        )
+        expr.out_schema = new_metadata.to_frame()
         return wrap_plan(
             new_metadata,
             plan=LazyPlan(
-                "LogicalProjectionPythonScalarFunc",
+                "LogicalProjection",
                 self._series._plan,
-                (
-                    "str.strip",
-                    True,  # is_series
-                    True,  # is_method
-                    (),  # args
-                    {},  # kwargs
-                ),
+                (expr,),
             ),
         )

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -102,7 +102,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan("BinaryOpExpression", lhs, rhs, op)
+        expr = LazyPlan("ConjunctionOpExpression", lhs, rhs, op)
         expr.out_schema = new_metadata.to_frame()
 
         plan = LazyPlan(

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -333,6 +333,8 @@ class LazyPlan:
             """Recursively convert LazyPlans but return other types unmodified."""
             if isinstance(x, LazyPlan):
                 return x.generate_duckdb(cache=cache, in_filter=in_filter)
+            elif isinstance(x, (tuple, list)):
+                return type(x)(recursive_check(i, in_filter) for i in x)
             else:
                 return x
 
@@ -628,6 +630,16 @@ def wrap_plan(schema, plan, res_id=None, nrows=None):
 
     new_df.plan = plan
     return new_df
+
+
+def get_proj_expr_single(proj: LazyPlan):
+    """Get the single expression from a LogicalProjection node."""
+    assert (
+        isinstance(proj, LazyPlan)
+        and proj.plan_class == "LogicalProjection"
+        and len(proj.args[1]) == 1
+    ), "get_proj_expr_single: LogicalProjection with a single expr expected"
+    return proj.args[1][0]
 
 
 def _is_generated_index_name(name):

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -318,6 +318,19 @@ class LazyPlan:
         self.output_func = None  # filled in by wrap_plan
         self.out_schema = None  # filled in by wrap_plan
 
+    def __str__(self):
+        out = f"{self.plan_class}: \n"
+        for arg in self.args:
+            if isinstance(arg, pd.DataFrame):
+                out += f"  {arg.columns.tolist()}\n"
+                continue
+            out += f"  {arg}\n"
+        for k, v in self.kwargs.items():
+            out += f"  {k}: {v}\n"
+        return out
+
+    __repr__ = __str__
+
     def generate_duckdb(self, cache=None, in_filter=False):
         from bodo.ext import plan_optimizer
 

--- a/bodo/tests/test_df_lib/test_plan.py
+++ b/bodo/tests/test_df_lib/test_plan.py
@@ -37,8 +37,8 @@ def test_projection_node():
 def test_filter_node():
     """Make sure Cython wrapper around the filter node works. Just tests node creation."""
     P1 = plan_optimizer.LogicalGetParquetRead(pa.schema([]), b"example.parquet1", {})
-    A = plan_optimizer.LogicalColRef(pa.schema([("A", pa.int64())]), P1, [0])
-    B = plan_optimizer.LogicalBinaryOp(
+    A = plan_optimizer.ColRefExpression(pa.schema([("A", pa.int64())]), P1, 0)
+    B = plan_optimizer.BinaryOpExpression(
         pa.schema([("A", pa.bool_())]), A, 5, operator.gt
     )
     C = plan_optimizer.LogicalFilter(pa.schema([("A", pa.int64())]), P1, B)

--- a/bodo/tests/test_df_lib/test_plan.py
+++ b/bodo/tests/test_df_lib/test_plan.py
@@ -22,12 +22,16 @@ def test_join_node():
 def test_projection_node():
     """Make sure Cython wrapper around the projection node works. Just tests node creation."""
     P1 = plan_optimizer.LogicalGetParquetRead(pa.schema([]), b"example.parquet1", {})
+    exprs = [
+        plan_optimizer.ColRefExpression(pa.schema([("A", pa.int64())]), P1, 0),
+        plan_optimizer.ColRefExpression(pa.schema([("B", pa.string())]), P1, 1),
+    ]
     A = plan_optimizer.LogicalProjection(
         pa.schema([("A", pa.int64()), ("C", pa.string())]),
         P1,
-        [1, 3],
+        exprs,
     )
-    assert str(A) == "LogicalProjection([1, 3], A: int64\nC: string)"
+    assert str(A) == "LogicalProjection(A: int64\nC: string)"
 
 
 def test_filter_node():

--- a/bodo/tests/test_df_lib/test_plan.py
+++ b/bodo/tests/test_df_lib/test_plan.py
@@ -77,8 +77,12 @@ def test_parquet_projection_pushdown():
         b"example.parquet",
         {},
     )
+    exprs = [
+        plan_optimizer.ColRefExpression(pa.schema([("A", pa.int64())]), A, 0),
+        plan_optimizer.ColRefExpression(pa.schema([("C", pa.int32())]), A, 2),
+    ]
     B = plan_optimizer.LogicalProjection(
-        pa.schema([("A", pa.int64()), ("C", pa.int32())]), A, [0, 2]
+        pa.schema([("A", pa.int64()), ("C", pa.int32())]), A, exprs
     )
     C = plan_optimizer.py_optimize_plan(B)
     assert plan_optimizer.get_pushed_down_columns(C) == [0, 2], (


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Refactors Projection handling to use proper expression objects to allow more general projections with multiple expressions as well as plan analytics/transforms that are necessary for support for setting new columns.

Limiting the scope of the PR to be merged ASAP since it can affect other ongoing work.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.