### PR TITLE
Support setting DataFrame column

### DIFF
--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -156,6 +156,9 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
             self._axes,
             verify_integrity=(verify_integrity if (result_id is None) else False),
         )
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        self._disable_collect = False
 
     @property
     def is_single_block(self) -> bool:
@@ -263,6 +266,9 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
         If we have a plan, execute it and replace the blocks with the result.
         If the data is on the workers, collect it.
         """
+        if self._disable_collect:
+            return
+
         if self._plan is not None:
             debug_msg(
                 self.logger, "[LazyArrayManager] Executing Plan and collecting data..."
@@ -298,6 +304,7 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
             "logger",
             "_collect_func",
             "_del_func",
+            "_disable_collect",
         }:
             return object.__getattribute__(self, name)
         # If the attribute is 'arrays', we ensure we have the data.
@@ -451,6 +458,9 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             self._axes,
             verify_integrity=(verify_integrity if (result_id is None) else False),
         )
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        self._disable_collect = False
 
     @property
     def dtype(self):
@@ -491,6 +501,9 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
         If we have a plan, execute it and replace the blocks with the result.
         If the data is on the workers, collect it.
         """
+        if self._disable_collect:
+            return
+
         if self._plan is not None:
             debug_msg(
                 self.logger,
@@ -572,6 +585,7 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             "logger",
             "_collect_func",
             "_del_func",
+            "_disable_collect",
         }:
             return object.__getattribute__(self, name)
         # If the attribute is 'arrays', we ensure we have the data.

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -683,7 +683,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             self._mgr._disable_collect = original_flag
 
 
-def update_func_expr_source(
+def _update_func_expr_source(
     func_expr: LazyPlan, new_source_plan: LazyPlan, col_index_offset: int
 ):
     """Update source plan of PythonScalarFuncExpression and add an offset to its
@@ -729,7 +729,7 @@ def _add_proj_expr_to_plan(
     if func_expr.plan_class != "PythonScalarFuncExpression":
         return None
     func_expr = (
-        update_func_expr_source(func_expr, df_plan, ikey)
+        _update_func_expr_source(func_expr, df_plan, ikey)
         if replace_func_source
         else func_expr
     )

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -593,6 +593,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 head_val = value._head_s
                 self._head_df[key] = head_val
                 with self.disable_collect():
+                    # Update internal data manager (e.g. insert a new block or update an
+                    # existing one). See:
+                    # https://github.com/pandas-dev/pandas/blob/0691c5cf90477d3503834d983f69350f250a6ff7/pandas/core/frame.py#L4481
                     super().__setitem__(key, head_val)
                 return
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -692,8 +692,10 @@ def _update_func_expr_source(
     """Update source plan of PythonScalarFuncExpression and add an offset to its
     input data column index.
     """
+    # Previous input data column index
     in_col_ind = func_expr.args[2][0]
     n_source_cols = len(new_source_plan.out_schema.columns)
+    # Add Index columns of the new source plan as input
     index_cols = tuple(
         range(
             n_source_cols,

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -726,7 +726,7 @@ def _add_proj_expr_to_plan(
 
     # Get the function expression from the value plan to be added
     func_expr = value_plan.args[1][0]
-    if func_expr.plan_type != "PythonScalarFuncExpression":
+    if func_expr.plan_class != "PythonScalarFuncExpression":
         return None
     func_expr = (
         update_func_expr_source(func_expr, df_plan, ikey)

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -165,6 +165,9 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             if (result_id is None and plan is None)
             else False,
         )
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        self._disable_collect = False
         if result_id is not None:
             # Set pandas internal metadata
             self._rebuild_blknos_and_blklocs_lazy()
@@ -230,6 +233,9 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
         If we have a plan, execute it and replace the blocks with the result.
         If the data is on the workers, collect it.
         """
+        if self._disable_collect:
+            return
+
         # Execute the plan if we have one
         if self._plan is not None:
             debug_msg(
@@ -268,6 +274,7 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             "_del_func",
             "_plan",
             "execute_plan",
+            "_disable_collect",
         }:
             return object.__getattribute__(self, name)
         # Most of the time _rebuild_blknos_and_blklocs is called by pandas internals
@@ -400,6 +407,9 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
             axis_,
             verify_integrity=verify_integrity if (result_id is None) else False,
         )
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        self._disable_collect = False
 
     def get_dtypes(self) -> np.typing.NDArray[np.object_]:
         """
@@ -471,6 +481,9 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
         If we have a plan, execute it and replace the blocks with the result.
         If the data is on the workers, collect it.
         """
+        if self._disable_collect:
+            return
+
         # Execute the plan if we have one
         if self._plan is not None:
             debug_msg(
@@ -511,6 +524,7 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
             "_del_func",
             "_plan",
             "execute_plan",
+            "_disable_collect",
         }:
             return object.__getattribute__(self, name)
         if name == "blocks":

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -610,6 +610,19 @@ def get_proj_expr_single(proj: LazyPlan):
     return proj.args[1][0]
 
 
+def is_single_colref_projection(proj: LazyPlan):
+    # Check for projection
+    if not isinstance(proj, LazyPlan) and proj.plan_class == "LogicalProjection":
+        return False
+
+    # Check for single colref expression
+    exprs = proj.args[1]
+    return (
+        len(exprs) == (get_n_index_arrays(proj.out_schema.index) + 1)
+        and exprs[0].plan_class == "ColRefExpression"
+    )
+
+
 def make_col_ref_exprs(key_indices, src_plan):
     """Create column reference expressions for the given key indices for the input
     source plan.

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -610,16 +610,19 @@ def get_proj_expr_single(proj: LazyPlan):
     return proj.args[1][0]
 
 
-def is_single_colref_projection(proj: LazyPlan):
-    # Check for projection
-    if not isinstance(proj, LazyPlan) and proj.plan_class == "LogicalProjection":
-        return False
-
-    # Check for single colref expression
-    exprs = proj.args[1]
+def is_single_projection(proj: LazyPlan):
+    """Return True if plan is a projection with a single expression"""
     return (
-        len(exprs) == (get_n_index_arrays(proj.out_schema.index) + 1)
-        and exprs[0].plan_class == "ColRefExpression"
+        isinstance(proj, LazyPlan)
+        and proj.plan_class == "LogicalProjection"
+        and len(proj.args[1]) == (get_n_index_arrays(proj.out_schema.index) + 1)
+    )
+
+
+def is_single_colref_projection(proj: LazyPlan):
+    """Return True if plan is a projection with a single expression that is a column reference"""
+    return (
+        is_single_projection(proj) and proj.args[1][0].plan_class == "ColRefExpression"
     )
 
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -505,8 +505,8 @@ def test_series_map(datapath, index_val, set_stream_batch_size_three):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
-def test_set_column(datapath, index_val, set_stream_batch_size_three):
-    """Very simple test for Series.str.strip() for sanity checking."""
+def test_set_df_column(datapath, index_val, set_stream_batch_size_three):
+    """Test setting a dataframe column with a Series function of the same dataframe."""
     df = pd.DataFrame(
         {
             "A": pd.array([1, 2, 3, 7], "Int64"),

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -465,6 +465,24 @@ def test_str_strip(datapath, index_val, set_stream_batch_size_three):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
+def test_chain_python_func(datapath, index_val, set_stream_batch_size_three):
+    """Make sure chaining multiple Series functions that run in Python works"""
+    df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3, 7], "Int64"),
+            "B": ["A1\t", "B1 ", "C1\n", "Abc\t"],
+            "C": pd.array([4, 5, 6, -1], "Int64"),
+        }
+    )
+    df.index = index_val[: len(df)]
+    bdf = bd.from_pandas(df)
+    out_pd = df.B.str.strip().str.lower()
+    out_bodo = bdf.B.str.strip().str.lower()
+    assert out_bodo.is_lazy_plan()
+    assert out_bodo.plan is not None
+    _test_equal(out_bodo, out_pd, check_pandas_types=False)
+
+
 def test_series_map(datapath, index_val, set_stream_batch_size_three):
     """Very simple test for Series.map() for sanity checking."""
     df = pd.DataFrame(

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -505,6 +505,50 @@ def test_series_map(datapath, index_val, set_stream_batch_size_three):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
+def test_set_column(datapath, index_val, set_stream_batch_size_three):
+    """Very simple test for Series.str.strip() for sanity checking."""
+    df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3, 7], "Int64"),
+            "B": ["A1\t", "B1 ", "C1\n", "Abc\t"],
+            "C": pd.array([4, 5, 6, -1], "Int64"),
+        }
+    )
+    df.index = index_val[: len(df)]
+    bdf = bd.from_pandas(df)
+
+    # Single projection, new column
+    bdf["D"] = bdf["B"].str.strip()
+    pdf = df.copy()
+    pdf["D"] = pdf["B"].str.strip()
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+    # Single projection, existing column
+    bdf = bd.from_pandas(df)
+    bdf["B"] = bdf["B"].str.strip()
+    pdf = df.copy()
+    pdf["B"] = pdf["B"].str.strip()
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+    # Multiple projections, new column
+    bdf = bd.from_pandas(df)
+    bdf["D"] = bdf["B"].str.strip().map(lambda x: x + "1")
+    pdf = df.copy()
+    pdf["D"] = pdf["B"].str.strip().map(lambda x: x + "1")
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+    # Multiple projections, existing column
+    bdf = bd.from_pandas(df)
+    bdf["B"] = bdf["B"].str.strip().map(lambda x: x + "1")
+    pdf = df.copy()
+    pdf["B"] = pdf["B"].str.strip().map(lambda x: x + "1")
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+
 def test_parquet_read_partitioned(datapath, set_stream_batch_size_three):
     """Test reading a partitioned parquet dataset."""
     path = datapath("dataframe_library/example_partitioned.parquet")

--- a/bodo/tests/test_iceberg/conftest.py
+++ b/bodo/tests/test_iceberg/conftest.py
@@ -147,7 +147,7 @@ def polaris_package():
     @run_rank0
     def ensure_polaris_client():
         try:
-            subprocess.run(["pip", "show", "polaris.management"], check=True)
+            subprocess.run(["pip", "show", "polaris"], check=True)
         except subprocess.CalledProcessError:
             raise ValueError(
                 "Polaris client is not installed. Please install it manually."


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for setting a dataframe column with a Series plan that is created from the same dataframe. This works by creating a new projection plan that adds the data columns of the original dataframe as well as the new column from the Series. This PR also fixes a bug when chaining multiple Series function calls.

I think the plan manipulation code is hard to read and potentially fragile because of not having proper Python classes for the plan. We need to discuss the path forward if we are going to have a lot of these plan handling cases.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Setting dataframe column now works.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.