### PR TITLE
Support fallbacks to Pandas in frontend

### DIFF
--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -151,6 +151,11 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
             # This is the base ArrayManager case
             assert nrows is None
             assert head is None
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        # Has to be set before calling super().__init__ since super may trigger collect
+        # depending on arguments.
+        self._disable_collect = False
         super().__init__(
             _arrays,
             self._axes,
@@ -158,9 +163,6 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
                 verify_integrity if (result_id is None and plan is None) else False
             ),
         )
-        # Flag for disabling collect to allow updating internal pandas metadata
-        # See DataFrame.__setitem__
-        self._disable_collect = False
 
     @property
     def is_single_block(self) -> bool:
@@ -455,6 +457,11 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             assert nrows is None
             assert head is None
 
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        # Has to be set before calling super().__init__ since super may trigger collect
+        # depending on arguments.
+        self._disable_collect = False
         super().__init__(
             _arrays,
             self._axes,
@@ -462,9 +469,6 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
                 verify_integrity if (result_id is None and plan is None) else False
             ),
         )
-        # Flag for disabling collect to allow updating internal pandas metadata
-        # See DataFrame.__setitem__
-        self._disable_collect = False
 
     @property
     def dtype(self):

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -471,7 +471,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             func, [], self, *args, **kwargs
         )
 
-    @check_args_fallback(supported=["on"])
+    @check_args_fallback(supported=["on"], disable=True)
     def merge(
         self,
         right: "BodoDataFrame | BodoSeries",

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -13,6 +13,7 @@ from bodo.pandas.lazy_wrapper import BodoLazyWrapper
 from bodo.pandas.managers import LazyBlockManager, LazyMetadataMixin
 from bodo.pandas.series import BodoSeries
 from bodo.pandas.utils import (
+    BodoLibNotImplementedException,
     LazyPlan,
     check_args_fallback,
     get_lazy_manager_class,
@@ -534,6 +535,12 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         """Called when df[key] is used."""
 
         from bodo.pandas.base import _empty_like
+
+        # Only selecting single column or filtering with BodoSeries is supported
+        if not isinstance(key, (str, BodoSeries)):
+            raise BodoLibNotImplementedException(
+                "DataFrame.__getitem__: only string and BodoSeries keys are supported"
+            )
 
         """ Create 0 length versions of the dataframe and the key and
             simulate the operation to see the resulting type. """

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -620,7 +620,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                     super().__setitem__(key, head_val)
                 return
 
-        return super().__setitem__(key, value)
+        raise BodoLibNotImplementedException(
+            "Only setting a column with a Series created from the same dataframe is supported."
+        )
 
     @check_args_fallback(supported=["func", "axis"])
     def apply(

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -539,7 +539,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # Only selecting single column or filtering with BodoSeries is supported
         if not isinstance(key, (str, BodoSeries)):
             raise BodoLibNotImplementedException(
-                "DataFrame.__getitem__: only string and BodoSeries keys are supported"
+                "only string and BodoSeries keys are supported"
             )
 
         """ Create 0 length versions of the dataframe and the key and

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -142,7 +142,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # Prevent infinite recursion when called from _empty_like and in general
         # data is never required for head(0) so making a plan is never necessary.
         if n == 0 and self._head_df is not None:
-            return self._head_df.head(0).copy().convert_dtypes(dtype_backend="pyarrow")
+            return pd.DataFrame(
+                index=self._head_df.index, columns=self._head_df.columns
+            ).astype(dict(zip(self._head_df.columns, self._head_df.dtypes)))
 
         if (self._head_df is None) or (n > self._head_df.shape[0]):
             from bodo.pandas.base import _empty_like

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -647,10 +647,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         pd_sample = pd.DataFrame(df_sample)
         out_sample = pd_sample.apply(func, axis)
 
-        # TODO: Should we fallback to Pandas in the DataFrame case?
         if not isinstance(out_sample, pd.Series):
-            raise BodoError(
-                f"DataFrame.apply(): expected output to be Series, got: {type(out_sample)}."
+            raise BodoLibNotImplementedException(
+                f"expected output to be Series, got: {type(out_sample)}."
             )
 
         out_sample = out_sample.convert_dtypes(dtype_backend="pyarrow")

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -540,8 +540,11 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
 
         from bodo.pandas.base import _empty_like
 
-        # Only selecting single column or filtering with BodoSeries is supported
-        if not isinstance(key, (str, BodoSeries)):
+        # Only selecting columns or filtering with BodoSeries is supported
+        if not (
+            isinstance(key, (str, BodoSeries))
+            or (isinstance(key, list) and all(isinstance(k, str) for k in key))
+        ):
             raise BodoLibNotImplementedException(
                 "only string and BodoSeries keys are supported"
             )

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -141,7 +141,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # Prevent infinite recursion when called from _empty_like and in general
         # data is never required for head(0) so making a plan is never necessary.
         if n == 0 and self._head_df is not None:
-            return self._head_df.head(0).copy()
+            return self._head_df.head(0).copy().convert_dtypes(dtype_backend="pyarrow")
 
         if (self._head_df is None) or (n > self._head_df.shape[0]):
             from bodo.pandas.base import _empty_like

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -141,9 +141,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # Prevent infinite recursion when called from _empty_like and in general
         # data is never required for head(0) so making a plan is never necessary.
         if n == 0 and self._head_df is not None:
-            return pd.DataFrame(
-                index=self._head_df.index, columns=self._head_df.columns
-            ).astype(dict(zip(self._head_df.columns, self._head_df.dtypes)))
+            return self._head_df.head(0).copy()
 
         if (self._head_df is None) or (n > self._head_df.shape[0]):
             from bodo.pandas.base import _empty_like

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -158,6 +158,11 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
         | tuple[ArrowExtensionArray, ArrowExtensionArray]
         | None = None,
     ):
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        # Has to be set before calling super().__init__ since super may trigger collect
+        # depending on arguments.
+        self._disable_collect = False
         super().__init__(
             blocks,
             axes,
@@ -165,9 +170,6 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             if (result_id is None and plan is None)
             else False,
         )
-        # Flag for disabling collect to allow updating internal pandas metadata
-        # See DataFrame.__setitem__
-        self._disable_collect = False
         if result_id is not None:
             # Set pandas internal metadata
             self._rebuild_blknos_and_blklocs_lazy()
@@ -401,6 +403,11 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
                         "Index type {type(head_axis)} not supported in LazySingleBlockManager"
                     )
 
+        # Flag for disabling collect to allow updating internal pandas metadata
+        # See DataFrame.__setitem__
+        # Has to be set before calling super().__init__ since super may trigger collect
+        # depending on arguments.
+        self._disable_collect = False
         super().__init__(
             block_,
             axis_,
@@ -408,9 +415,6 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
             if (result_id is None and plan is None)
             else False,
         )
-        # Flag for disabling collect to allow updating internal pandas metadata
-        # See DataFrame.__setitem__
-        self._disable_collect = False
 
     def get_dtypes(self) -> np.typing.NDArray[np.object_]:
         """

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -272,27 +272,27 @@ cdef extern from "duckdb/planner/operator/logical_get.hpp" namespace "duckdb" no
 
 
 cdef extern from "_plan.h" nogil:
-    cdef unique_ptr[CLogicalGet] make_parquet_get_node(c_string parquet_path, object arrow_schema, object storage_options)
-    cdef unique_ptr[CLogicalGet] make_dataframe_get_seq_node(object df, object arrow_schema)
-    cdef unique_ptr[CLogicalGet] make_dataframe_get_parallel_node(c_string res_id, object arrow_schema)
-    cdef unique_ptr[CLogicalComparisonJoin] make_comparison_join(unique_ptr[CLogicalOperator] lhs, unique_ptr[CLogicalOperator] rhs, CJoinType join_type, vector[int_pair] cond_vec)
-    cdef unique_ptr[CLogicalOperator] optimize_plan(unique_ptr[CLogicalOperator])
-    cdef unique_ptr[CLogicalProjection] make_projection(unique_ptr[CLogicalOperator] source, vector[unique_ptr[CExpression]] expr_vec, object out_schema)
-    cdef unique_ptr[CExpression] make_python_scalar_func_expr(unique_ptr[CLogicalOperator] source, object out_schema, object args, vector[int] input_column_indices)
-    cdef unique_ptr[CExpression] make_binop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype)
-    cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype)
-    cdef unique_ptr[CLogicalFilter] make_filter(unique_ptr[CLogicalOperator] source, unique_ptr[CExpression] filter_expr)
-    cdef unique_ptr[CExpression] make_const_int_expr(int val)
-    cdef unique_ptr[CExpression] make_const_float_expr(float val)
-    cdef unique_ptr[CExpression] make_const_string_expr(c_string val)
-    cdef unique_ptr[CExpression] make_col_ref_expr(unique_ptr[CLogicalOperator] source, object field, int col_idx)
-    cdef unique_ptr[CLogicalLimit] make_limit(unique_ptr[CLogicalOperator] source, int n)
-    cdef unique_ptr[CLogicalSample] make_sample(unique_ptr[CLogicalOperator] source, int n)
-    cdef pair[int64_t, PyObjectPtr] execute_plan(unique_ptr[CLogicalOperator], object out_schema)
-    cdef c_string plan_to_string(unique_ptr[CLogicalOperator], c_bool graphviz_format)
-    cdef vector[int] get_projection_pushed_down_columns(unique_ptr[CLogicalOperator] proj)
-    cdef int planCountNodes(unique_ptr[CLogicalOperator] root)
-    cdef void set_table_meta_from_arrow(int64_t table_pointer, object arrow_schema)
+    cdef unique_ptr[CLogicalGet] make_parquet_get_node(c_string parquet_path, object arrow_schema, object storage_options) except +
+    cdef unique_ptr[CLogicalGet] make_dataframe_get_seq_node(object df, object arrow_schema) except +
+    cdef unique_ptr[CLogicalGet] make_dataframe_get_parallel_node(c_string res_id, object arrow_schema) except +
+    cdef unique_ptr[CLogicalComparisonJoin] make_comparison_join(unique_ptr[CLogicalOperator] lhs, unique_ptr[CLogicalOperator] rhs, CJoinType join_type, vector[int_pair] cond_vec) except +
+    cdef unique_ptr[CLogicalOperator] optimize_plan(unique_ptr[CLogicalOperator]) except +
+    cdef unique_ptr[CLogicalProjection] make_projection(unique_ptr[CLogicalOperator] source, vector[unique_ptr[CExpression]] expr_vec, object out_schema) except +
+    cdef unique_ptr[CExpression] make_python_scalar_func_expr(unique_ptr[CLogicalOperator] source, object out_schema, object args, vector[int] input_column_indices) except +
+    cdef unique_ptr[CExpression] make_binop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
+    cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
+    cdef unique_ptr[CLogicalFilter] make_filter(unique_ptr[CLogicalOperator] source, unique_ptr[CExpression] filter_expr) except +
+    cdef unique_ptr[CExpression] make_const_int_expr(int val) except +
+    cdef unique_ptr[CExpression] make_const_float_expr(float val) except +
+    cdef unique_ptr[CExpression] make_const_string_expr(c_string val) except +
+    cdef unique_ptr[CExpression] make_col_ref_expr(unique_ptr[CLogicalOperator] source, object field, int col_idx) except +
+    cdef unique_ptr[CLogicalLimit] make_limit(unique_ptr[CLogicalOperator] source, int n) except +
+    cdef unique_ptr[CLogicalSample] make_sample(unique_ptr[CLogicalOperator] source, int n) except +
+    cdef pair[int64_t, PyObjectPtr] execute_plan(unique_ptr[CLogicalOperator], object out_schema) except +
+    cdef c_string plan_to_string(unique_ptr[CLogicalOperator], c_bool graphviz_format) except +
+    cdef vector[int] get_projection_pushed_down_columns(unique_ptr[CLogicalOperator] proj) except +
+    cdef int planCountNodes(unique_ptr[CLogicalOperator] root) except +
+    cdef void set_table_meta_from_arrow(int64_t table_pointer, object arrow_schema) except +
 
 
 def join_type_to_string(CJoinType join_type):

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -445,12 +445,12 @@ cdef unique_ptr[CExpression] make_expr(val):
     cdef c_string val_cstr
 
     if isinstance(val, int):
-        return make_const_int_expr(val)
+        return move(make_const_int_expr(val))
     elif isinstance(val, float):
-        return make_const_float_expr(val)
+        return move(make_const_float_expr(val))
     elif isinstance(val, str):
         val_cstr = val.encode()
-        return make_const_string_expr(val_cstr)
+        return move(make_const_string_expr(val_cstr))
     else:
         raise ValueError("Unknown expr type in make_expr " + str(type(val)))
 

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -442,7 +442,6 @@ cdef unique_ptr[CExpression] make_expr(val):
     """Convert a filter expression tree from Cython wrappers
        to duckdb.
     """
-    cdef LogicalOperator source
     cdef c_string val_cstr
 
     if isinstance(val, int):

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -142,7 +142,12 @@ def get_overloads(cls_name):
 
 
 def check_args_fallback(
-    unsupported=None, supported=None, package_name="pandas", fn_str=None, module_name=""
+    unsupported=None,
+    supported=None,
+    package_name="pandas",
+    fn_str=None,
+    module_name="",
+    disable=False,
 ):
     """Decorator to apply to dataframe or series member functions that handles
     argument checking, falling back to JIT compilation when it might work, and
@@ -166,6 +171,8 @@ def check_args_fallback(
         package_name - see bodo.utils.typing.check_unsupported_args_fallback
         fn_str - see bodo.utils.typing.check_unsupported_args_fallback
         module_name - see bodo.utils.typing.check_unsupported_args_fallback
+        disable - if True, falls back immediately to the Pandas implementation (used
+                in frontend methods that are not fully implemented yet)
     """
     assert (unsupported is None) ^ (supported is None), (
         "Exactly one of unsupported and supported must be specified."
@@ -175,7 +182,7 @@ def check_args_fallback(
         # See if function is top-level or not by looking for a . in
         # the full name.
         toplevel = "." not in func.__qualname__
-        if not bodo.dataframe_library_enabled:
+        if not bodo.dataframe_library_enabled or disable:
             # Dataframe library not enabled so just call the Pandas super class version.
             if toplevel:
                 py_pkg = importlib.import_module(package_name)

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -144,13 +144,13 @@ def get_overloads(cls_name):
 
 class BodoLibNotImplementedException(Exception):
     """Exception raised in the Bodo library when a functionality is not implemented yet
-    and we need to fall back to Pandas.
+    and we need to fall back to Pandas (captured by the fallback decorator).
     """
 
 
 class BodoLibFallbackWarning(Warning):
-    """Warning raised in the Bodo library when a functionality is not implemented yet
-    and we need to fall back to Pandas.
+    """Warning raised in the Bodo library in the fallback decorator when some
+    functionality is not implemented yet and we need to fall back to Pandas.
     """
 
 

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -172,14 +172,6 @@ def check_args_fallback(
     )
 
     def decorator(func):
-        def to_bodo(val):
-            if isinstance(val, pd.DataFrame):
-                return bodo.pandas.DataFrame(val)
-            elif isinstance(val, pd.Series):
-                return bodo.pandas.Series(val)
-            else:
-                assert False, f"Unexpected val type {type(val)}"
-
         # See if function is top-level or not by looking for a . in
         # the full name.
         toplevel = "." not in func.__qualname__
@@ -191,16 +183,14 @@ def check_args_fallback(
                 @functools.wraps(func)
                 def wrapper(*args, **kwargs):
                     # Call the same method in the base class.
-                    return to_bodo(getattr(py_pkg, func.__name__)(*args, **kwargs))
+                    return getattr(py_pkg, func.__name__)(*args, **kwargs)
             else:
 
                 @functools.wraps(func)
                 def wrapper(self, *args, **kwargs):
                     # Call the same method in the base class.
-                    return to_bodo(
-                        getattr(self.__class__.__bases__[0], func.__name__)(
-                            self, *args, **kwargs
-                        )
+                    return getattr(self.__class__.__bases__[0], func.__name__)(
+                        self, *args, **kwargs
                     )
         else:
             signature = inspect.signature(func)
@@ -259,7 +249,7 @@ def check_args_fallback(
                         # Can we do a top-level override check?
 
                         # Fallback to Python. Call the same method in the base class.
-                        return to_bodo(getattr(py_pkg, func.__name__)(*args, **kwargs))
+                        return getattr(py_pkg, func.__name__)(*args, **kwargs)
                     else:
                         result = func(*args, **kwargs)
                     return result
@@ -292,10 +282,8 @@ def check_args_fallback(
                             pass
 
                         # Fallback to Python. Call the same method in the base class.
-                        return to_bodo(
-                            getattr(self.__class__.__bases__[0], func.__name__)(
-                                self, *args, **kwargs
-                            )
+                        return getattr(self.__class__.__bases__[0], func.__name__)(
+                            self, *args, **kwargs
                         )
                     else:
                         result = func(self, *args, **kwargs)

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -265,22 +265,24 @@ def check_args_fallback(
                         module_name=module_name,
                         raise_on_error=(BODO_PANDAS_FALLBACK == 0),
                     )
+                    except_msg = ""
                     if not error:
                         try:
                             return func(*args, **kwargs)
-                        except BodoLibNotImplementedException:
+                        except BodoLibNotImplementedException as e:
                             # Fall back to Pandas below
-                            pass
+                            except_msg = str(e)
                     # Can we do a top-level override check?
 
                     # Fallback to Python. Call the same method in the base class.
-                    warnings.warn(
-                        BodoLibFallbackWarning(
-                            f"{func.__name__} is not "
-                            "implemented in Bodo dataframe library yet. "
-                            "Falling back to Pandas which may be slow or run out of memory."
-                        )
+                    msg = (
+                        f"{func.__name__} is not "
+                        "implemented in Bodo dataframe library for the specified arguments yet. "
+                        "Falling back to Pandas (may be slow or run out of memory."
                     )
+                    if except_msg:
+                        msg += f"\n Exception: {except_msg}"
+                    warnings.warn(BodoLibFallbackWarning(msg))
                     return getattr(py_pkg, func.__name__)(*args, **kwargs)
             else:
 
@@ -299,12 +301,13 @@ def check_args_fallback(
                         module_name=module_name,
                         raise_on_error=(BODO_PANDAS_FALLBACK == 0),
                     )
+                    except_msg = ""
                     if not error:
                         try:
                             return func(self, *args, **kwargs)
-                        except BodoLibNotImplementedException:
+                        except BodoLibNotImplementedException as e:
                             # Fall back to Pandas below
-                            pass
+                            except_msg = str(e)
 
                     # The dataframe library must not support some specified option.
                     # Get overloaded functions for this dataframe/series in JIT mode.
@@ -318,13 +321,14 @@ def check_args_fallback(
 
                     # Fallback to Python. Call the same method in the base class.
                     base_class = self.__class__.__bases__[0]
-                    warnings.warn(
-                        BodoLibFallbackWarning(
-                            f"{base_class.__name__}.{func.__name__} is not "
-                            "implemented in Bodo dataframe library yet. "
-                            "Falling back to Pandas which may be slow or run out of memory."
-                        )
+                    msg = (
+                        f"{base_class.__name__}.{func.__name__} is not "
+                        "implemented in Bodo dataframe library for the specified arguments yet. "
+                        "Falling back to Pandas (may be slow or run out of memory)."
                     )
+                    if except_msg:
+                        msg += f"\n Exception: {except_msg}"
+                    warnings.warn(BodoLibFallbackWarning(msg))
                     return getattr(base_class, func.__name__)(self, *args, **kwargs)
 
         return wrapper

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -281,7 +281,7 @@ def check_args_fallback(
                         "Falling back to Pandas (may be slow or run out of memory."
                     )
                     if except_msg:
-                        msg += f"\n Exception: {except_msg}"
+                        msg += f"\nException: {except_msg}"
                     warnings.warn(BodoLibFallbackWarning(msg))
                     return getattr(py_pkg, func.__name__)(*args, **kwargs)
             else:
@@ -327,7 +327,7 @@ def check_args_fallback(
                         "Falling back to Pandas (may be slow or run out of memory)."
                     )
                     if except_msg:
-                        msg += f"\n Exception: {except_msg}"
+                        msg += f"\nException: {except_msg}"
                     warnings.warn(BodoLibFallbackWarning(msg))
                     return getattr(base_class, func.__name__)(self, *args, **kwargs)
 

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -5,6 +5,7 @@ Tests dataframe library frontend (no triggering of execution).
 import pytest
 
 import bodo.pandas as pd
+from bodo.pandas.utils import BodoLibFallbackWarning
 
 
 @pytest.mark.skip("disabled for release until merge is implemented")
@@ -14,3 +15,16 @@ def test_read_join_filter_proj(datapath):
     df3 = df1.merge(df2, on="A")
     df3 = df3[df3.A > 3]
     df3[["B", "C"]]
+
+
+def test_df_getitem_fallback_warning():
+    """Make sure DataFrame.__getitem__() raises a warning when falling back to Pandas."""
+    df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3], "Int64"),
+            "B": ["A1", "B1", "C1"],
+        },
+    )
+    bdf = pd.from_pandas(df)
+    with pytest.warns(BodoLibFallbackWarning):
+        bdf[:]

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -2,9 +2,12 @@
 Tests dataframe library frontend (no triggering of execution).
 """
 
+import pytest
+
 import bodo.pandas as pd
 
 
+@pytest.mark.skip("disabled for release until merge is implemented")
 def test_read_join_filter_proj(datapath):
     df1 = pd.read_parquet(datapath("dataframe_library/df1.parquet"))
     df2 = pd.read_parquet(datapath("dataframe_library/df2.parquet"))

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -28,3 +28,16 @@ def test_df_getitem_fallback_warning():
     bdf = pd.from_pandas(df)
     with pytest.warns(BodoLibFallbackWarning):
         bdf[:]
+
+
+def test_df_apply_fallback_warning():
+    """Make sure DataFrame.apply() raises a warning when falling back to Pandas."""
+    df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3], "Int64"),
+            "B": ["A1", "B1", "C1"],
+        },
+    )
+    bdf = pd.from_pandas(df)
+    with pytest.warns(BodoLibFallbackWarning):
+        bdf.apply(lambda a: pd.Series([1, 2]), axis=1)

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -30,6 +30,18 @@ def test_df_getitem_fallback_warning():
         bdf[:]
 
 
+def test_df_setitem_fallback_warning():
+    """Make sure DataFrame.__setitem__() raises a warning when falling back to Pandas."""
+    df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3], "Int64"),
+        },
+    )
+    bdf = pd.from_pandas(df)
+    with pytest.warns(BodoLibFallbackWarning):
+        bdf[:] = 1
+
+
 def test_df_apply_fallback_warning():
     """Make sure DataFrame.apply() raises a warning when falling back to Pandas."""
     df = pd.DataFrame(


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for raising an exception in frontend APIs that triggers fallback to Pandas. Updates dataframe methods (Series methods is future work) and adds unit tests.
Also fixes catching C++ exceptions in Python and a small fix in managers.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
New unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Improved fallbacks.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.