### PR TITLE
Enable dataframe library flag by default and fix CI

### DIFF
--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -119,7 +119,9 @@ jobs:
             BODO_TESTING_ONLY_RUN_1D_VAR: true
             PYTEST_MARKER: ${{ inputs.pytest-marker }}
             BODO_TEST_SPAWN_MODE: ${{ inputs.test-type == 'SPAWN' && '1' || '0' }}
-            BODO_ENABLE_DATAFRAME_LIBRARY: ${{ inputs.test-type == 'DF_LIB' && '1' || '0' }}
+            # Disabling the DataFrame library for spawn tests since some of the tests
+            # create Pandas manager states for testing that are not fully functional.
+            BODO_ENABLE_DATAFRAME_LIBRARY: ${{ inputs.test-type != 'SPAWN' && '1' || '0' }}
             BODO_ENABLE_TEST_DATAFRAME_LIBRARY: ${{ inputs.test-type == 'DF_LIB' && '1' || '0' }}
             BODOSQL_PY4J_GATEWAY_PORT: "auto"
             BODO_SPAWN_MODE: "0"

--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -182,7 +182,7 @@ sql_plan_cache_loc = os.environ.get("BODO_SQL_PLAN_CACHE_DIR")
 
 # Flag to enable bodo dataframe library (bodo.pandas). When disabled, these classes
 # will fallback to Pandas.
-dataframe_library_enabled = os.environ.get("BODO_ENABLE_DATAFRAME_LIBRARY", "0") != "0"
+dataframe_library_enabled = os.environ.get("BODO_ENABLE_DATAFRAME_LIBRARY", "1") != "0"
 
 # Run tests utilizing check_func in dataframe library mode (replaces)
 # 'import pandas as pd' with 'import bodo.pandas as pd' when running the func.

--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -394,7 +394,10 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             assert collect_func is not None
             assert del_func is not None
 
-            head_axis = head._axes[0]
+            # head may use a different manager (array vs block) if the workers have a
+            # different configuration than the spawner. BlockManager doesn't have _axes.
+            # See test_bodo_data_frame_pandas_manager
+            head_axis = head._axes[0] if hasattr(head, "_axes") else head.axes[0]
             new_axis = None
             # BSE-4099: Support other types of indexes
             match type(head_axis):

--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -394,10 +394,7 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             assert collect_func is not None
             assert del_func is not None
 
-            # head may use a different manager (array vs block) if the workers have a
-            # different configuration than the spawner. BlockManager doesn't have _axes.
-            # See test_bodo_data_frame_pandas_manager
-            head_axis = head._axes[0] if hasattr(head, "_axes") else head.axes[0]
+            head_axis = head._axes[0]
             new_axis = None
             # BSE-4099: Support other types of indexes
             match type(head_axis):

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -180,6 +180,11 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         return super().__len__()
 
     @property
+    def index(self):
+        self.execute_plan()
+        return super().index
+
+    @property
     def shape(self):
         self.execute_plan()
         if self._lazy:

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -180,6 +180,11 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         self.execute_plan()
         return super().index
 
+    @index.setter
+    def index(self, value):
+        self.execute_plan()
+        super()._set_axis(1, value)
+
     @property
     def shape(self):
         self.execute_plan()

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -146,14 +146,10 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # data is never required for head(0) so making a plan is never necessary.
         if n == 0:
             if self._exec_state == ExecState.COLLECTED:
-                return pd.DataFrame(index=self.index, columns=self.columns).astype(
-                    dict(zip(self.columns, self.dtypes))
-                )
+                return arrow_to_empty_df(pa.Schema.from_pandas(self))
             else:
                 assert self._head_df is not None
-                return pd.DataFrame(
-                    index=self._head_df.index, columns=self._head_df.columns
-                ).astype(dict(zip(self._head_df.columns, self._head_df.dtypes)))
+                return arrow_to_empty_df(pa.Schema.from_pandas(self._head_df))
 
         if (self._head_df is None) or (n > self._head_df.shape[0]):
             if bodo.dataframe_library_enabled:
@@ -692,14 +688,15 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 (func,),  # args
                 {"axis": 1},  # kwargs
             ),
-            tuple(range(len(self.columns) + get_n_index_arrays(self.index))),
+            tuple(range(len(self.columns) + get_n_index_arrays(self.head(0).index))),
         )
 
         # Select Index columns explicitly for output
         n_cols = len(self.columns)
         index_col_refs = tuple(
             make_col_ref_exprs(
-                range(n_cols, n_cols + get_n_index_arrays(self.index)), self._plan
+                range(n_cols, n_cols + get_n_index_arrays(self.head(0).index)),
+                self._plan,
             )
         )
         plan = LazyPlan(

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -146,10 +146,10 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # data is never required for head(0) so making a plan is never necessary.
         if n == 0:
             if self._exec_state == ExecState.COLLECTED:
-                return arrow_to_empty_df(pa.Schema.from_pandas(self))
+                return self.iloc[:0].copy()
             else:
                 assert self._head_df is not None
-                return arrow_to_empty_df(pa.Schema.from_pandas(self._head_df))
+                return self._head_df.head(0).copy()
 
         if (self._head_df is None) or (n > self._head_df.shape[0]):
             if bodo.dataframe_library_enabled:

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -258,6 +258,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             return self._mgr._md_nrows
         return super().__len__()
 
+    @property
+    def index(self):
+        self.execute_plan()
+        return super().index
+
     def _get_result_id(self) -> str | None:
         if isinstance(self._mgr, LazyMetadataMixin):
             return self._mgr._md_result_id

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -263,6 +263,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         self.execute_plan()
         return super().index
 
+    @index.setter
+    def index(self, value):
+        self.execute_plan()
+        super()._set_axis(0, value)
+
     def _get_result_id(self) -> str | None:
         if isinstance(self._mgr, LazyMetadataMixin):
             return self._mgr._md_result_id

--- a/bodo/tests/test_df_lib/conftest.py
+++ b/bodo/tests/test_df_lib/conftest.py
@@ -7,11 +7,11 @@ def pytest_collection_modifyitems(items):
     for item in items:
         # Add marker to all tests in this directory
         if "test_df_lib" in item.nodeid or "test_df_lib" in os.getcwd():
-            # skip if BODO_ENABLE_DATAFRAME_LIBRARY is not set
-            if os.getenv("BODO_ENABLE_DATAFRAME_LIBRARY", "0") == "0":
+            # skip if BODO_ENABLE_TEST_DATAFRAME_LIBRARY is not set
+            if os.getenv("BODO_ENABLE_TEST_DATAFRAME_LIBRARY", "0") == "0":
                 item.add_marker(
                     pytest.mark.skip(
-                        reason="BODO_ENABLE_DATAFRAME_LIBRARY is not set, this is required for df_lib tests"
+                        reason="BODO_ENABLE_TEST_DATAFRAME_LIBRARY is not set, this is required for df_lib tests"
                     )
                 )
             item.add_marker(pytest.mark.df_lib)

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -297,10 +297,11 @@ def test_bodo_data_frame_pandas_manager(pandas_managers):
     )
 
     agg_df = df.groupby("A0").size()
-    assert agg_df.equals(
+    _test_equal(
+        agg_df,
         pd.Series(
             [8, 8, 8, 8, 8], index=pd.Index([1, 2, 3, 4, 5], dtype="Int64", name="A0")
-        )
+        ),
     )
     assert df.describe().equals(
         pd.DataFrame(

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -291,10 +291,7 @@ def test_bodo_data_frame_pandas_manager(pandas_managers):
     assert df.shape == (40, 2)
     assert df.dtypes.equals(pd.Series(["Int64", "string[python]"], index=["A0", "B5"]))
 
-    # dtypes may be different since dataframe library computes the output
-    _test_equal(
-        base_df.head(5), df.head(5), check_dtype=False, check_pandas_types=False
-    )
+    _test_equal(base_df, df, check_dtype=False, check_pandas_types=False)
 
     agg_df = df.groupby("A0").size()
     _test_equal(

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -11,6 +11,7 @@ from bodo.tests.iceberg_database_helpers.utils import create_iceberg_table, get_
 from bodo.tests.test_lazy.utils import pandas_managers  # noqa
 from bodo.tests.utils import (
     _gather_output,
+    _test_equal,
     pytest_mark_spawn_mode,
 )
 from bodo.utils.testing import ensure_clean2
@@ -290,7 +291,10 @@ def test_bodo_data_frame_pandas_manager(pandas_managers):
     assert df.shape == (40, 2)
     assert df.dtypes.equals(pd.Series(["Int64", "string[python]"], index=["A0", "B5"]))
 
-    assert base_df.head(5).equals(df.head(5))
+    # dtypes may be different since dataframe library computes the output
+    _test_equal(
+        base_df.head(5), df.head(5), check_dtype=False, check_pandas_types=False
+    )
 
     agg_df = df.groupby("A0").size()
     assert agg_df.equals(

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -11,10 +11,12 @@ from bodo.tests.iceberg_database_helpers.utils import create_iceberg_table, get_
 from bodo.tests.test_lazy.utils import pandas_managers  # noqa
 from bodo.tests.utils import (
     _gather_output,
-    pytest_mark_spawn_mode,
+    pytest_spawn_mode,
 )
 from bodo.utils.testing import ensure_clean2
 from bodo.utils.utils import run_rank0
+
+pytestmark = pytest_spawn_mode
 
 
 @pytest.fixture
@@ -442,7 +444,6 @@ def test_slice(pandas_managers, head_df, collect_func):
     pd.testing.assert_frame_equal(lam_sliced_head_df, collect_func(0)[-3:])
 
 
-@pytest_mark_spawn_mode
 def test_parquet(collect_func):
     """Tests that to_parquet() writes the frame correctly and does not trigger data fetch"""
 
@@ -470,7 +471,6 @@ def test_parquet(collect_func):
     )
 
 
-@pytest_mark_spawn_mode
 def test_parquet_param(collect_func):
     """Tests that to_parquet() raises an error on unsupported parameters"""
 
@@ -495,7 +495,6 @@ def test_parquet_param(collect_func):
             bodo_df.to_parquet(fname, row_group_size="a")
 
 
-@pytest_mark_spawn_mode
 @pytest.mark.iceberg
 @run_rank0
 def test_sql(iceberg_database, iceberg_table_conn, collect_func):
@@ -534,7 +533,6 @@ def test_sql(iceberg_database, iceberg_table_conn, collect_func):
     )
 
 
-@pytest_mark_spawn_mode
 def test_csv(collect_func):
     """Tests that to_csv() writes the frame correctly and does not trigger data fetch"""
 
@@ -562,7 +560,6 @@ def test_csv(collect_func):
     )
 
 
-@pytest_mark_spawn_mode
 def test_csv_str(collect_func):
     """Tests that to_csv() with string output works properly (returns all string data to spawner)"""
 
@@ -576,7 +573,6 @@ def test_csv_str(collect_func):
     assert bodo_df._lazy
 
 
-@pytest_mark_spawn_mode
 def test_csv_param(collect_func):
     """Tests that to_csv() raises an error on unsupported parameters"""
 
@@ -606,7 +602,6 @@ def test_csv_param(collect_func):
             bodo_df.to_csv(fname, mode="r")
 
 
-@pytest_mark_spawn_mode
 def test_json(collect_func):
     """Tests that to_json() writes the frame correctly and does not trigger data fetch"""
 
@@ -640,7 +635,6 @@ def test_json(collect_func):
     )
 
 
-@pytest_mark_spawn_mode
 def test_json_str(collect_func):
     """Tests that to_json() with string output works properly (returns all string data to spawner)"""
 
@@ -656,7 +650,6 @@ def test_json_str(collect_func):
     assert bodo_df._lazy
 
 
-@pytest_mark_spawn_mode
 def test_map_partitions():
     """Test map_partitions on BodoDataFrame"""
 

--- a/bodo/tests/test_lazy/test_bodo_frame.py
+++ b/bodo/tests/test_lazy/test_bodo_frame.py
@@ -11,7 +11,6 @@ from bodo.tests.iceberg_database_helpers.utils import create_iceberg_table, get_
 from bodo.tests.test_lazy.utils import pandas_managers  # noqa
 from bodo.tests.utils import (
     _gather_output,
-    _test_equal,
     pytest_mark_spawn_mode,
 )
 from bodo.utils.testing import ensure_clean2
@@ -291,14 +290,13 @@ def test_bodo_data_frame_pandas_manager(pandas_managers):
     assert df.shape == (40, 2)
     assert df.dtypes.equals(pd.Series(["Int64", "string[python]"], index=["A0", "B5"]))
 
-    _test_equal(base_df, df, check_dtype=False, check_pandas_types=False)
+    assert base_df.head(5).equals(df.head(5))
 
     agg_df = df.groupby("A0").size()
-    _test_equal(
-        agg_df,
+    assert agg_df.equals(
         pd.Series(
             [8, 8, 8, 8, 8], index=pd.Index([1, 2, 3, 4, 5], dtype="Int64", name="A0")
-        ),
+        )
     )
     assert df.describe().equals(
         pd.DataFrame(

--- a/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
+++ b/buildscripts/bodo/azure/azure-test-conda-linux-macos.yml
@@ -136,11 +136,13 @@ jobs:
       if [[ "${{ parameters.test_type }}" == "CACHE" ]]; then
         pixi run -e azure python -m bodo.runtests_caching "${{ parameters.name }}" "$NP" bodo/tests/caching_tests
       elif [[ "${{ parameters.test_type }}" == "SPAWN" ]]; then
+        # Disabling the DataFrame library for spawn tests since some of the tests
+        # create Pandas manager states for testing that are not fully functional.
+        export BODO_ENABLE_DATAFRAME_LIBRARY=0
         export BODO_TEST_SPAWN_MODE=1
         export BODO_NUM_WORKERS="$NP"
         pixi run -e azure pytest -s -v -Wignore -m "$(PYTEST_MARKER)" bodo/tests --junitxml=pytest-report-spawn-mode.xml --test-run-title="${{ parameters.name }}"
       elif [[ "${{ parameters.test_type }}" == "DF_LIB" ]]; then
-        export BODO_ENABLE_DATAFRAME_LIBRARY=1
         export BODO_ENABLE_TEST_DATAFRAME_LIBRARY=1
         export BODO_NUM_WORKERS="$NP"
         pixi run -e azure pytest -s -v -Wignore -m "$(PYTEST_MARKER)" bodo/tests --junitxml=pytest-report-df-library.xml --test-run-title="${{ parameters.name }}"


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Enables dataframe library flag by default and updates the CI environment variables. Also includes fixes for Index handling to fix the issues I found.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Dataframe library is on by default.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.