### PR TITLE
BSE-4790: Fix parallel get data scope

### DIFF
--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1,5 +1,6 @@
 #include "_plan.h"
 #include <arrow/python/pyarrow.h>
+#include <fmt/format.h>
 #include <utility>
 
 #include "_executor.h"
@@ -634,13 +635,13 @@ BodoDataFrameParallelScanFunctionData::CreatePhysicalOperator(
     // bodo.spawn.worker creates a new module with new empty registry.
 
     // Import Python sys module
-    PyObject *sys_module = PyImport_ImportModule("sys");
+    PyObjectPtr sys_module = PyImport_ImportModule("sys");
     if (!sys_module) {
         throw std::runtime_error("Failed to import sys module");
     }
 
     // Get sys.modules dictionary
-    PyObject *modules_dict = PyObject_GetAttrString(sys_module, "modules");
+    PyObjectPtr modules_dict = PyObject_GetAttrString(sys_module, "modules");
     if (!modules_dict) {
         Py_DECREF(sys_module);
         throw std::runtime_error("Failed to get sys.modules");
@@ -649,21 +650,17 @@ BodoDataFrameParallelScanFunctionData::CreatePhysicalOperator(
     // Get __main__ module
     PyObject *main_module = PyDict_GetItemString(modules_dict, "__main__");
     if (!main_module) {
-        Py_DECREF(modules_dict);
-        Py_DECREF(sys_module);
         throw std::runtime_error("Failed to get __main__ module");
     }
 
     // Get RESULT_REGISTRY[result_id]
-    PyObject *result_registry =
+    PyObjectPtr result_registry =
         PyObject_GetAttrString(main_module, "RESULT_REGISTRY");
     PyObject *df = PyDict_GetItemString(result_registry, result_id.c_str());
     if (!df) {
-        throw std::runtime_error("Result ID not found in result registry");
+        throw std::runtime_error(fmt::format(
+            "Result ID {} not found in result registry", result_id.c_str()));
     }
-    Py_DECREF(result_registry);
-    Py_DECREF(modules_dict);
-    Py_DECREF(sys_module);
 
     return std::make_shared<PhysicalReadPandas>(df, selected_columns);
 }

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -31,9 +31,9 @@ def from_pandas(df):
     res_id = None
     if bodo.dataframe_library_run_parallel:
         res_id = bodo.spawn.utils.scatter_data(df)
-        plan = LazyPlan("LogicalGetPandasReadParallel", empty_df, [], res_id)
+        plan = LazyPlan("LogicalGetPandasReadParallel", empty_df, res_id)
     else:
-        plan = LazyPlan("LogicalGetPandasReadSeq", empty_df, [], df)
+        plan = LazyPlan("LogicalGetPandasReadSeq", empty_df, df)
 
     return wrap_plan(plan=plan, nrows=n_rows, res_id=res_id)
 
@@ -68,7 +68,7 @@ def read_parquet(
 
     empty_df = arrow_to_empty_df(arrow_schema)
 
-    plan = LazyPlan("LogicalGetParquetRead", empty_df, [], path, storage_options)
+    plan = LazyPlan("LogicalGetParquetRead", empty_df, path, storage_options)
     return wrap_plan(plan=plan)
 
 

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -7,6 +7,7 @@ from bodo.pandas.series import BodoSeries
 from bodo.pandas.utils import (
     BODO_NONE_DUMMY,
     LazyPlan,
+    LazyPlanDistributedArg,
     arrow_to_empty_df,
     check_args_fallback,
     wrap_plan,
@@ -32,7 +33,11 @@ def from_pandas(df):
     res_id = None
     if bodo.dataframe_library_run_parallel:
         res_id = bodo.spawn.utils.scatter_data(df)
-        plan = LazyPlan("LogicalGetPandasReadParallel", empty_df, res_id)
+        plan = LazyPlan(
+            "LogicalGetPandasReadParallel",
+            empty_df,
+            LazyPlanDistributedArg(None, res_id),
+        )
     else:
         plan = LazyPlan("LogicalGetPandasReadSeq", empty_df, df)
 

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -31,9 +31,9 @@ def from_pandas(df):
     res_id = None
     if bodo.dataframe_library_run_parallel:
         res_id = bodo.spawn.utils.scatter_data(df)
-        plan = LazyPlan("LogicalGetPandasReadParallel", empty_df, res_id)
+        plan = LazyPlan("LogicalGetPandasReadParallel", empty_df, [], res_id)
     else:
-        plan = LazyPlan("LogicalGetPandasReadSeq", empty_df, df)
+        plan = LazyPlan("LogicalGetPandasReadSeq", empty_df, [], df)
 
     return wrap_plan(plan=plan, nrows=n_rows, res_id=res_id)
 
@@ -68,7 +68,7 @@ def read_parquet(
 
     empty_df = arrow_to_empty_df(arrow_schema)
 
-    plan = LazyPlan("LogicalGetParquetRead", empty_df, path, storage_options)
+    plan = LazyPlan("LogicalGetParquetRead", empty_df, [], path, storage_options)
     return wrap_plan(plan=plan)
 
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -69,11 +69,16 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                     # so we need to re-distribute the results.
                     res_id = bodo.spawn.utils.scatter_data(self)
                 self._source_plan = LazyPlan(
-                    "LogicalGetPandasReadParallel", empty_data, res_id
+                    "LogicalGetPandasReadParallel",
+                    empty_data,
+                    # Mark our manager as a dependency so the results won't be deleted from the workers
+                    # if this object goes out of scope.
+                    [self._mgr],
+                    res_id,
                 )
             else:
                 self._source_plan = LazyPlan(
-                    "LogicalGetPandasReadSeq", empty_data, self
+                    "LogicalGetPandasReadSeq", empty_data, [], self
                 )
 
             return self._source_plan
@@ -158,11 +163,13 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 planLimit = LazyPlan(
                     "LogicalLimit",
                     _empty_like(self),
+                    [],
                     self._plan,
                     n,
                 )
 
                 return wrap_plan(planLimit)
+
             else:
                 return super().head(n)
         else:
@@ -538,6 +545,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         planComparisonJoin = LazyPlan(
             "LogicalComparisonJoin",
             empty_data,
+            [],
             self._plan,
             right._plan,
             plan_optimizer.CJoinType.INNER,
@@ -580,7 +588,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             zero_size_key = _empty_like(key)
             empty_data = zero_size_self.__getitem__(zero_size_key)
             return wrap_plan(
-                plan=LazyPlan("LogicalFilter", empty_data, self._plan, key_plan),
+                plan=LazyPlan("LogicalFilter", empty_data, [], self._plan, key_plan),
             )
         else:
             """ This is selecting one or more columns. Be a bit more
@@ -609,6 +617,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 plan=LazyPlan(
                     "LogicalProjection",
                     empty_data,
+                    [],
                     self._plan,
                     exprs,
                 ),
@@ -687,6 +696,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         udf_arg = LazyPlan(
             "PythonScalarFuncExpression",
             empty_series,
+            [],
             self._plan,
             (
                 "apply",
@@ -709,6 +719,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         plan = LazyPlan(
             "LogicalProjection",
             empty_series,
+            [],
             self._plan,
             (udf_arg,) + index_col_refs,
         )
@@ -746,6 +757,7 @@ def _update_func_expr_source(
     expr = LazyPlan(
         "PythonScalarFuncExpression",
         func_expr.empty_data,
+        [],
         new_source_plan,
         func_expr.args[1],
         (in_col_ind + col_index_offset,) + index_cols,
@@ -798,6 +810,7 @@ def _add_proj_expr_to_plan(
     new_plan = LazyPlan(
         "LogicalProjection",
         empty_data,
+        [],
         df_plan,
         tuple(data_cols + index_cols),
     )

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -16,6 +16,7 @@ from bodo.pandas.series import BodoSeries
 from bodo.pandas.utils import (
     BodoLibNotImplementedException,
     LazyPlan,
+    LazyPlanDistributedArg,
     arrow_to_empty_df,
     check_args_fallback,
     get_lazy_manager_class,
@@ -64,12 +65,16 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                     # If the plan has been executed but the results are still
                     # distributed then re-use those results as is.
                     res_id = self._mgr._md_result_id
+                    mgr = self._mgr
                 else:
                     # The data has been collected and is no longer distributed
                     # so we need to re-distribute the results.
                     res_id = bodo.spawn.utils.scatter_data(self)
+                    mgr = None
                 self._source_plan = LazyPlan(
-                    "LogicalGetPandasReadParallel", empty_data, res_id
+                    "LogicalGetPandasReadParallel",
+                    empty_data,
+                    LazyPlanDistributedArg(mgr, res_id),
                 )
             else:
                 self._source_plan = LazyPlan(

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -63,22 +63,17 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 if getattr(self._mgr, "_md_result_id", None) is not None:
                     # If the plan has been executed but the results are still
                     # distributed then re-use those results as is.
-                    res_id = self._mgr._md_result_id
+                    pass
                 else:
                     # The data has been collected and is no longer distributed
                     # so we need to re-distribute the results.
-                    res_id = bodo.spawn.utils.scatter_data(self)
+                    bodo.spawn.utils.scatter_data(self)
                 self._source_plan = LazyPlan(
-                    "LogicalGetPandasReadParallel",
-                    empty_data,
-                    # Mark our manager as a dependency so the results won't be deleted from the workers
-                    # if this object goes out of scope.
-                    [self._mgr],
-                    res_id,
+                    "LogicalGetPandasReadParallel", empty_data, self._mgr
                 )
             else:
                 self._source_plan = LazyPlan(
-                    "LogicalGetPandasReadSeq", empty_data, [], self
+                    "LogicalGetPandasReadSeq", empty_data, self
                 )
 
             return self._source_plan
@@ -163,13 +158,11 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 planLimit = LazyPlan(
                     "LogicalLimit",
                     _empty_like(self),
-                    [],
                     self._plan,
                     n,
                 )
 
                 return wrap_plan(planLimit)
-
             else:
                 return super().head(n)
         else:
@@ -545,7 +538,6 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         planComparisonJoin = LazyPlan(
             "LogicalComparisonJoin",
             empty_data,
-            [],
             self._plan,
             right._plan,
             plan_optimizer.CJoinType.INNER,
@@ -588,7 +580,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             zero_size_key = _empty_like(key)
             empty_data = zero_size_self.__getitem__(zero_size_key)
             return wrap_plan(
-                plan=LazyPlan("LogicalFilter", empty_data, [], self._plan, key_plan),
+                plan=LazyPlan("LogicalFilter", empty_data, self._plan, key_plan),
             )
         else:
             """ This is selecting one or more columns. Be a bit more
@@ -617,7 +609,6 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 plan=LazyPlan(
                     "LogicalProjection",
                     empty_data,
-                    [],
                     self._plan,
                     exprs,
                 ),
@@ -696,7 +687,6 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         udf_arg = LazyPlan(
             "PythonScalarFuncExpression",
             empty_series,
-            [],
             self._plan,
             (
                 "apply",
@@ -719,7 +709,6 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         plan = LazyPlan(
             "LogicalProjection",
             empty_series,
-            [],
             self._plan,
             (udf_arg,) + index_col_refs,
         )
@@ -757,7 +746,6 @@ def _update_func_expr_source(
     expr = LazyPlan(
         "PythonScalarFuncExpression",
         func_expr.empty_data,
-        [],
         new_source_plan,
         func_expr.args[1],
         (in_col_ind + col_index_offset,) + index_cols,
@@ -810,7 +798,6 @@ def _add_proj_expr_to_plan(
     new_plan = LazyPlan(
         "LogicalProjection",
         empty_data,
-        [],
         df_plan,
         tuple(data_cols + index_cols),
     )

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -38,7 +38,18 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             if self._mgr._plan is not None:
                 return self._mgr._plan
             else:
-                return plan_optimizer.LogicalGetSeriesRead(self._mgr._md_result_id)
+                from bodo.pandas.base import _empty_like
+
+                empty_data = _empty_like(self)
+
+                return LazyPlan(
+                    "LogicalGetSeriesRead",
+                    empty_data,
+                    # Mark our manager as a dependency so the results won't be deleted from the workers
+                    # if this object goes out of scope.
+                    [self._mgr],
+                    self._mgr._md_result_id,
+                )
 
         raise NotImplementedError(
             "Plan not available for this manager, recreate this series with from_pandas"
@@ -65,11 +76,12 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan("BinaryOpExpression", empty_data, lhs, rhs, op)
+        expr = LazyPlan("BinaryOpExpression", empty_data, [], lhs, rhs, op)
 
         plan = LazyPlan(
             "LogicalProjection",
             empty_data,
+            [],
             # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
@@ -109,11 +121,12 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan("ConjunctionOpExpression", empty_data, lhs, rhs, op)
+        expr = LazyPlan("ConjunctionOpExpression", empty_data, [], lhs, rhs, op)
 
         plan = LazyPlan(
             "LogicalProjection",
             empty_data,
+            [],
             # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
@@ -148,7 +161,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         assert isinstance(empty_data, pd.Series), "Series expected"
         return wrap_plan(
-            plan=LazyPlan("LogicalUnaryOp", empty_data, self._plan, "__invert__"),
+            plan=LazyPlan("LogicalUnaryOp", empty_data, [], self._plan, "__invert__"),
         )
 
     @staticmethod
@@ -243,6 +256,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 planLimit = LazyPlan(
                     "LogicalLimit",
                     _empty_like(self),
+                    [],
                     self._plan,
                     n,
                 )
@@ -367,6 +381,7 @@ def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwarg
     expr = LazyPlan(
         "PythonScalarFuncExpression",
         empty_data,
+        [],
         source_data,
         (
             func_name,
@@ -383,6 +398,7 @@ def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwarg
         plan=LazyPlan(
             "LogicalProjection",
             empty_data,
+            [],
             source_data,
             (expr,) + index_col_refs,
         ),

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -42,14 +42,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
                 empty_data = _empty_like(self)
 
-                return LazyPlan(
-                    "LogicalGetSeriesRead",
-                    empty_data,
-                    # Mark our manager as a dependency so the results won't be deleted from the workers
-                    # if this object goes out of scope.
-                    [self._mgr],
-                    self._mgr._md_result_id,
-                )
+                return LazyPlan("LogicalGetSeriesRead", empty_data, self._mgr)
 
         raise NotImplementedError(
             "Plan not available for this manager, recreate this series with from_pandas"
@@ -76,12 +69,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan("BinaryOpExpression", empty_data, [], lhs, rhs, op)
+        expr = LazyPlan("BinaryOpExpression", empty_data, lhs, rhs, op)
 
         plan = LazyPlan(
             "LogicalProjection",
             empty_data,
-            [],
             # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
@@ -121,12 +113,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan("ConjunctionOpExpression", empty_data, [], lhs, rhs, op)
+        expr = LazyPlan("ConjunctionOpExpression", empty_data, lhs, rhs, op)
 
         plan = LazyPlan(
             "LogicalProjection",
             empty_data,
-            [],
             # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
@@ -161,7 +152,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         assert isinstance(empty_data, pd.Series), "Series expected"
         return wrap_plan(
-            plan=LazyPlan("LogicalUnaryOp", empty_data, [], self._plan, "__invert__"),
+            plan=LazyPlan("LogicalUnaryOp", empty_data, self._plan, "__invert__"),
         )
 
     @staticmethod
@@ -256,7 +247,6 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 planLimit = LazyPlan(
                     "LogicalLimit",
                     _empty_like(self),
-                    [],
                     self._plan,
                     n,
                 )
@@ -381,7 +371,6 @@ def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwarg
     expr = LazyPlan(
         "PythonScalarFuncExpression",
         empty_data,
-        [],
         source_data,
         (
             func_name,
@@ -398,7 +387,6 @@ def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwarg
         plan=LazyPlan(
             "LogicalProjection",
             empty_data,
-            [],
             source_data,
             (expr,) + index_col_refs,
         ),

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -14,6 +14,7 @@ from bodo.pandas.managers import LazyMetadataMixin, LazySingleBlockManager
 from bodo.pandas.utils import (
     BodoLibFallbackWarning,
     LazyPlan,
+    LazyPlanDistributedArg,
     arrow_to_empty_df,
     check_args_fallback,
     get_lazy_single_manager_class,
@@ -57,12 +58,16 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                         # If the plan has been executed but the results are still
                         # distributed then re-use those results as is.
                         res_id = self._mgr._md_result_id
+                        mgr = self._mgr
                     else:
                         # The data has been collected and is no longer distributed
                         # so we need to re-distribute the results.
                         res_id = bodo.spawn.utils.scatter_data(self)
+                        mgr = None
                     self._source_plan = LazyPlan(
-                        "LogicalGetPandasReadParallel", empty_data, res_id
+                        "LogicalGetPandasReadParallel",
+                        empty_data,
+                        LazyPlanDistributedArg(mgr, res_id),
                     )
                 else:
                     self._source_plan = LazyPlan(

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -38,18 +38,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             if self._mgr._plan is not None:
                 return self._mgr._plan
             else:
-                from bodo.pandas.base import _empty_like
-
-                empty_data = _empty_like(self)
-
-                return LazyPlan(
-                    "LogicalGetSeriesRead",
-                    empty_data,
-                    # Mark our manager as a dependency so the results won't be deleted from the workers
-                    # if this object goes out of scope.
-                    [self._mgr],
-                    self._mgr._md_result_id,
-                )
+                return plan_optimizer.LogicalGetSeriesRead(self._mgr._md_result_id)
 
         raise NotImplementedError(
             "Plan not available for this manager, recreate this series with from_pandas"
@@ -76,12 +65,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan("BinaryOpExpression", empty_data, [], lhs, rhs, op)
+        expr = LazyPlan("BinaryOpExpression", empty_data, lhs, rhs, op)
 
         plan = LazyPlan(
             "LogicalProjection",
             empty_data,
-            [],
             # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
@@ -121,12 +109,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan("ConjunctionOpExpression", empty_data, [], lhs, rhs, op)
+        expr = LazyPlan("ConjunctionOpExpression", empty_data, lhs, rhs, op)
 
         plan = LazyPlan(
             "LogicalProjection",
             empty_data,
-            [],
             # Use the original table without the Series projection node.
             self._plan.args[0],
             (expr,),
@@ -161,7 +148,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         assert isinstance(empty_data, pd.Series), "Series expected"
         return wrap_plan(
-            plan=LazyPlan("LogicalUnaryOp", empty_data, [], self._plan, "__invert__"),
+            plan=LazyPlan("LogicalUnaryOp", empty_data, self._plan, "__invert__"),
         )
 
     @staticmethod
@@ -256,7 +243,6 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 planLimit = LazyPlan(
                     "LogicalLimit",
                     _empty_like(self),
-                    [],
                     self._plan,
                     n,
                 )
@@ -381,7 +367,6 @@ def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwarg
     expr = LazyPlan(
         "PythonScalarFuncExpression",
         empty_data,
-        [],
         source_data,
         (
             func_name,
@@ -398,7 +383,6 @@ def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwarg
         plan=LazyPlan(
             "LogicalProjection",
             empty_data,
-            [],
             source_data,
             (expr,) + index_col_refs,
         ),

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -343,12 +343,7 @@ class LazyPlan:
     can be used to convert to an isolated set of DuckDB objects for execution.
     """
 
-    def __init__(self, plan_class, empty_data, source_data, *args, **kwargs):
-        """
-        args:
-            source_data: list, any objects that this plan is dependent on and need to be
-                kept alive
-        """
+    def __init__(self, plan_class, empty_data, *args, **kwargs):
         self.plan_class = plan_class
         self.args = args
         self.kwargs = kwargs
@@ -362,7 +357,6 @@ class LazyPlan:
             # that is replaced with None in wrap_plan
             name = BODO_NONE_DUMMY if empty_data.name is None else empty_data.name
             self.empty_data = empty_data.to_frame(name=name)
-        self.source_data = source_data
 
     def __str__(self):
         out = f"{self.plan_class}: \n"
@@ -410,24 +404,31 @@ class LazyPlan:
         cache[id(self)] = ret
         return ret
 
-    def _pop_source_data(self):
-        """Recursively remove source data from plans and return it"""
-        popped_source_data = []
-        popped_source_data.extend(self.source_data)
-        self.source_data = []
+    def _exract_managers(self):
+        """
+        Extract all LazyManagers from the plan and convert them to their result id.
+        Managers can't be sent to workers without triggering collection and all the workers
+        need is the result id and for the data to still exist. If we keep the managers in scope
+        until the plan is executed the data will remain valid. That means the list returned by this function
+        should be kept in scope until the plan is executed.
+        """
+        managers = []
+        self.args = list(self.args)
+        for i, arg in enumerate(self.args):
+            if isinstance(arg, (LazyArrayManager, LazyBlockManager)):
+                managers.append(arg)
+                self.args[i] = arg._md_result_id
+            elif isinstance(arg, LazyPlan):
+                managers.extend(arg._exract_managers())
 
-        def recursive_check(x):
-            if isinstance(x, LazyPlan):
-                popped_source_data.extend(x._pop_source_data())
-            elif isinstance(x, (tuple, list)):
-                type(x)(recursive_check(i) for i in x)
-
-        for arg in self.args:
-            recursive_check(arg)
-        for kwarg in self.kwargs.values():
-            recursive_check(kwarg)
-
-        return popped_source_data
+        for k, v in self.kwargs.items():
+            if isinstance(v, (LazyArrayManager, LazyBlockManager)):
+                managers.append(v)
+                self.kwargs[k] = v._md_result_id
+            elif isinstance(v, LazyPlan):
+                managers.extend(v._exract_managers())
+        self.args = tuple(self.args)
+        return managers
 
 
 def execute_plan(plan: LazyPlan):
@@ -469,11 +470,9 @@ def execute_plan(plan: LazyPlan):
     if bodo.dataframe_library_run_parallel:
         import bodo.spawn.spawner
 
-        # We only need to keep source_data alive on the spawner, sending them
-        # to the workers can create issues. We still need to keep a reference
-        # until the plan has executed. This was tried with LazyPlan.__reduce__ first but
-        # that also created issues
-        source_data = plan._pop_source_data()  # noqa
+        # We need to keep the managers in scope until the plan is executed
+        # but we can't send them to the workers without triggering collection.
+        managers = plan._exract_managers()  # noqa
 
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
@@ -708,7 +707,7 @@ def make_col_ref_exprs(key_indices, src_plan):
         # Using Arrow schema instead of zero_size_self.iloc to handle Index
         # columns correctly.
         empty_data = arrow_to_empty_df(pa.schema([pa_schema[k]]))
-        p = LazyPlan("ColRefExpression", empty_data, [], src_plan, k)
+        p = LazyPlan("ColRefExpression", empty_data, src_plan, k)
         exprs.append(p)
 
     return exprs

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -763,3 +763,21 @@ def arrow_to_empty_df(arrow_schema):
         {field.name: _empty_pd_array(field.type) for field in arrow_schema}
     )
     return _reconstruct_pandas_index(empty_df, arrow_schema)
+
+
+class LazyPlanDistributedArg:
+    """
+    Class to hold the arguments for a LazyPlan that are distributed on the workers.
+    """
+
+    def __init__(self, mgr, res_id: str):
+        self.mgr = mgr
+        self.res_id = res_id
+
+    def __reduce__(self):
+        """
+        This method is used to serialize the object for distribution.
+        We can't send the manager to the workers without triggering collection
+        so we just send the result ID instead.
+        """
+        return (str, (self.res_id,))

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -343,12 +343,7 @@ class LazyPlan:
     can be used to convert to an isolated set of DuckDB objects for execution.
     """
 
-    def __init__(self, plan_class, empty_data, source_data, *args, **kwargs):
-        """
-        args:
-            source_data: list, any objects that this plan is dependent on and need to be
-                kept alive
-        """
+    def __init__(self, plan_class, empty_data, *args, **kwargs):
         self.plan_class = plan_class
         self.args = args
         self.kwargs = kwargs
@@ -362,7 +357,6 @@ class LazyPlan:
             # that is replaced with None in wrap_plan
             name = BODO_NONE_DUMMY if empty_data.name is None else empty_data.name
             self.empty_data = empty_data.to_frame(name=name)
-        self.source_data = source_data
 
     def __str__(self):
         out = f"{self.plan_class}: \n"
@@ -410,25 +404,6 @@ class LazyPlan:
         cache[id(self)] = ret
         return ret
 
-    def _pop_source_data(self):
-        """Recursively remove source data from plans and return it"""
-        popped_source_data = []
-        popped_source_data.extend(self.source_data)
-        self.source_data = []
-
-        def recursive_check(x):
-            if isinstance(x, LazyPlan):
-                popped_source_data.extend(x._pop_source_data())
-            elif isinstance(x, (tuple, list)):
-                type(x)(recursive_check(i) for i in x)
-
-        for arg in self.args:
-            recursive_check(arg)
-        for kwarg in self.kwargs.values():
-            recursive_check(kwarg)
-
-        return popped_source_data
-
 
 def execute_plan(plan: LazyPlan):
     """Execute a dataframe plan using Bodo's execution engine.
@@ -468,12 +443,6 @@ def execute_plan(plan: LazyPlan):
 
     if bodo.dataframe_library_run_parallel:
         import bodo.spawn.spawner
-
-        # We only need to keep source_data alive on the spawner, sending them
-        # to the workers can create issues. We still need to keep a reference
-        # until the plan has executed. This was tried with LazyPlan.__reduce__ first but
-        # that also created issues
-        source_data = plan._pop_source_data()  # noqa
 
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
@@ -708,7 +677,7 @@ def make_col_ref_exprs(key_indices, src_plan):
         # Using Arrow schema instead of zero_size_self.iloc to handle Index
         # columns correctly.
         empty_data = arrow_to_empty_df(pa.schema([pa_schema[k]]))
-        p = LazyPlan("ColRefExpression", empty_data, [], src_plan, k)
+        p = LazyPlan("ColRefExpression", empty_data, src_plan, k)
         exprs.append(p)
 
     return exprs

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -343,7 +343,12 @@ class LazyPlan:
     can be used to convert to an isolated set of DuckDB objects for execution.
     """
 
-    def __init__(self, plan_class, empty_data, *args, **kwargs):
+    def __init__(self, plan_class, empty_data, source_data, *args, **kwargs):
+        """
+        args:
+            source_data: list, any objects that this plan is dependent on and need to be
+                kept alive
+        """
         self.plan_class = plan_class
         self.args = args
         self.kwargs = kwargs
@@ -357,6 +362,7 @@ class LazyPlan:
             # that is replaced with None in wrap_plan
             name = BODO_NONE_DUMMY if empty_data.name is None else empty_data.name
             self.empty_data = empty_data.to_frame(name=name)
+        self.source_data = source_data
 
     def __str__(self):
         out = f"{self.plan_class}: \n"
@@ -404,6 +410,25 @@ class LazyPlan:
         cache[id(self)] = ret
         return ret
 
+    def _pop_source_data(self):
+        """Recursively remove source data from plans and return it"""
+        popped_source_data = []
+        popped_source_data.extend(self.source_data)
+        self.source_data = []
+
+        def recursive_check(x):
+            if isinstance(x, LazyPlan):
+                popped_source_data.extend(x.pop_source_data())
+            elif isinstance(x, (tuple, list)):
+                type(x)(recursive_check(i) for i in x)
+
+        for arg in self.args:
+            recursive_check(arg)
+        for kwarg in self.kwargs.values():
+            recursive_check(kwarg)
+
+        return popped_source_data
+
 
 def execute_plan(plan: LazyPlan):
     """Execute a dataframe plan using Bodo's execution engine.
@@ -443,6 +468,12 @@ def execute_plan(plan: LazyPlan):
 
     if bodo.dataframe_library_run_parallel:
         import bodo.spawn.spawner
+
+        # We only need to keep source_data alive on the spawner, sending them
+        # to the workers can create issues. We still need to keep a reference
+        # until the plan has executed. This was tried with LazyPlan.__reduce__ first but
+        # that also created issues
+        plan._pop_source_data()
 
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
@@ -677,7 +708,7 @@ def make_col_ref_exprs(key_indices, src_plan):
         # Using Arrow schema instead of zero_size_self.iloc to handle Index
         # columns correctly.
         empty_data = arrow_to_empty_df(pa.schema([pa_schema[k]]))
-        p = LazyPlan("ColRefExpression", empty_data, src_plan, k)
+        p = LazyPlan("ColRefExpression", empty_data, [], src_plan, k)
         exprs.append(p)
 
     return exprs

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -418,7 +418,7 @@ class LazyPlan:
 
         def recursive_check(x):
             if isinstance(x, LazyPlan):
-                popped_source_data.extend(x.pop_source_data())
+                popped_source_data.extend(x._pop_source_data())
             elif isinstance(x, (tuple, list)):
                 type(x)(recursive_check(i) for i in x)
 

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -473,7 +473,7 @@ def execute_plan(plan: LazyPlan):
         # to the workers can create issues. We still need to keep a reference
         # until the plan has executed. This was tried with LazyPlan.__reduce__ first but
         # that also created issues
-        plan._pop_source_data()
+        source_data = plan._pop_source_data()  # noqa
 
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 

--- a/bodo/tests/iceberg_database_helpers/utils.py
+++ b/bodo/tests/iceberg_database_helpers/utils.py
@@ -160,8 +160,6 @@ def get_spark(
             "spark.sql.extensions",
             "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
         )
-        builder.master("local[*]")
-        builder.config("spark.driver.bindAddress", "127.0.0.1")
 
         for catalog in spark_catalogs:
             add_catalog(builder, catalog)

--- a/bodo/tests/iceberg_database_helpers/utils.py
+++ b/bodo/tests/iceberg_database_helpers/utils.py
@@ -160,6 +160,8 @@ def get_spark(
             "spark.sql.extensions",
             "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
         )
+        builder.master("local[*]")
+        builder.config("spark.driver.bindAddress", "127.0.0.1")
 
         for catalog in spark_catalogs:
             add_catalog(builder, catalog)

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -636,3 +636,24 @@ def test_parquet_read_partitioned_filter(datapath, set_stream_batch_size_three):
         bodo_out,
         py_out,
     )
+
+
+def test_parquet_read_shape_head(datapath):
+    """
+    Test to catch a case where the original manager goes out of scope
+    causing the parallel get to become invalid.
+    """
+    path = datapath("dataframe_library/df1.parquet")
+
+    def bodo_impl():
+        df = bd.read_parquet(path)
+        return df.shape, df.head(4)
+
+    def pd_impl():
+        df = pd.read_parquet(path)
+        return df.shape, df.head(4)
+
+    bdf_shape, bdf_head = bodo_impl()
+    pdf_shape, pdf_head = pd_impl()
+    assert bdf_shape == pdf_shape
+    _test_equal(bdf_head, pdf_head)

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -1625,6 +1625,10 @@ def test_filter_pushdown_past_column_filters():
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    bodo.test_dataframe_library_enabled,
+    reason="[BSE-4764] Dictionary columns with non-string value type not supported yet.",
+)
 def test_read_pq_head_only(datapath, memory_leak_check):
     """
     test reading only shape and/or head from Parquet file if possible

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -1625,9 +1625,6 @@ def test_filter_pushdown_past_column_filters():
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    bodo.test_dataframe_library_enabled, reason="TODO [BSE-4790]: Fix limit pushdown."
-)
 def test_read_pq_head_only(datapath, memory_leak_check):
     """
     test reading only shape and/or head from Parquet file if possible


### PR DESCRIPTION
## Changes included in this PR
Fixes an issue where parallel gets could try to read an entry from the result registry that's already been deleted. Resolved by attaching the source lazymanager to the lazy plan. This introduced some complications in sending the plan to the workers because the managers need to be removed first so collection isn't triggered.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Unittests locally/PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Fix the title bug
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.