### PR TITLE
Only create plan for head if manager is lazy

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -152,7 +152,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 return self._head_df.head(0).copy()
 
         if (self._head_df is None) or (n > self._head_df.shape[0]):
-            if bodo.dataframe_library_enabled:
+            if bodo.dataframe_library_enabled and isinstance(
+                self._mgr, (LazyMetadataMixin)
+            ):
                 from bodo.pandas.base import _empty_like
 
                 planLimit = LazyPlan(

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -153,7 +153,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
 
         if (self._head_df is None) or (n > self._head_df.shape[0]):
             if bodo.dataframe_library_enabled and isinstance(
-                self._mgr, (LazyMetadataMixin)
+                self._mgr, LazyMetadataMixin
             ):
                 from bodo.pandas.base import _empty_like
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -269,7 +269,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         if (self._head_s is None) or (n > self._head_s.shape[0]):
             if bodo.dataframe_library_enabled and isinstance(
-                self._mgr, (LazyMetadataMixin)
+                self._mgr, LazyMetadataMixin
             ):
                 from bodo.pandas.base import _empty_like
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -269,7 +269,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         if (self._head_s is None) or (n > self._head_s.shape[0]):
             if bodo.dataframe_library_enabled and isinstance(
-                self._mgr, (LazySingleBlockManager, LazySingleArrayManager)
+                self._mgr, (LazyMetadataMixin)
             ):
                 from bodo.pandas.base import _empty_like
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -268,7 +268,9 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 return self._head_s.head(0).copy()
 
         if (self._head_s is None) or (n > self._head_s.shape[0]):
-            if bodo.dataframe_library_enabled:
+            if bodo.dataframe_library_enabled and isinstance(
+                self._mgr, (LazySingleBlockManager, LazySingleArrayManager)
+            ):
                 from bodo.pandas.base import _empty_like
 
                 planLimit = LazyPlan(

--- a/bodo/tests/test_lazy/test_bodo_frame_pandas_manager.py
+++ b/bodo/tests/test_lazy/test_bodo_frame_pandas_manager.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from bodo.pandas.frame import BodoDataFrame
+from bodo.tests.test_lazy.utils import pandas_managers  # noqa
+
+
+def test_bodo_frame_pandas_manager(pandas_managers):
+    """
+    Test basic operations on a bodo frame using a pandas manager.
+    """
+    base_df = pd.DataFrame(
+        {
+            "a": pd.array(["a", "bc", "def", "ghij", "klmno"] * 8),
+            "b": pd.array([1, 2, 3, 10, None] * 8),
+        }
+    )
+
+    bodo_df = BodoDataFrame._from_mgr(base_df._mgr, [])
+    assert bodo_df.shape == base_df.shape
+    assert bodo_df.dtypes.equals(base_df.dtypes)
+
+    assert bodo_df.head(5).equals(bodo_df.head(5))

--- a/bodo/tests/test_lazy/test_bodo_series.py
+++ b/bodo/tests/test_lazy/test_bodo_series.py
@@ -4,7 +4,7 @@ from pandas.core.internals import SingleBlockManager
 from pandas.core.internals.array_manager import SingleArrayManager
 
 from bodo.pandas.series import BodoSeries
-from bodo.tests.utils import temp_config_override  # noqa
+from bodo.tests.test_lazy.utils import single_pandas_managers  # noqa
 
 
 @pytest.fixture
@@ -179,7 +179,6 @@ def test_bodo_series_pandas_manager(single_pandas_managers):
     """
     Test basic operations on a bodo series using a pandas manager.
     """
-    # with temp_config_override("dataframe_library_enabled", False):
     _, pandas_manager = single_pandas_managers
     base_s = pd.Series(pd.array(["a", "bc", "def", "ghij", "klmno"] * 8))
 

--- a/bodo/tests/test_lazy/test_bodo_series.py
+++ b/bodo/tests/test_lazy/test_bodo_series.py
@@ -4,7 +4,7 @@ from pandas.core.internals import SingleBlockManager
 from pandas.core.internals.array_manager import SingleArrayManager
 
 from bodo.pandas.series import BodoSeries
-from bodo.tests.test_lazy.utils import single_pandas_managers  # noqa
+from bodo.tests.utils import temp_config_override  # noqa
 
 
 @pytest.fixture
@@ -179,6 +179,7 @@ def test_bodo_series_pandas_manager(single_pandas_managers):
     """
     Test basic operations on a bodo series using a pandas manager.
     """
+    # with temp_config_override("dataframe_library_enabled", False):
     _, pandas_manager = single_pandas_managers
     base_s = pd.Series(pd.array(["a", "bc", "def", "ghij", "klmno"] * 8))
 


### PR DESCRIPTION
## Changes included in this PR
Checks the manager to determine whether it needs to create a plan for retrieving `head`. Creating a plan for `head` is not possible when the manager is not lazy. Similar checks are performed in other places.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
`test_bodo_series_pandas_manager`, equivalent test for the dataframe case added.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.