### PR TITLE
Support `to_strip` arg in Series.str.strip and update docs.

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -359,7 +359,6 @@ class BodoStringMethods:
             self._series._plan, new_metadata, "str.lower", (), {}
         )
 
-    @check_args_fallback(supported=[])
     def strip(self, to_strip=None):
         index = self._series.head(0).index
         new_metadata = pd.Series(
@@ -368,7 +367,7 @@ class BodoStringMethods:
             index=index,
         )
         return _get_series_python_func_plan(
-            self._series._plan, new_metadata, "str.strip", (), {}
+            self._series._plan, new_metadata, "str.strip", (to_strip,), {}
         )
 
     @check_args_fallback(unsupported="none")

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -348,6 +348,7 @@ class BodoStringMethods:
     def __init__(self, series):
         self._series = series
 
+    @check_args_fallback(unsupported="none")
     def lower(self):
         index = self._series.head(0).index
         new_metadata = pd.Series(
@@ -359,6 +360,7 @@ class BodoStringMethods:
             self._series._plan, new_metadata, "str.lower", (), {}
         )
 
+    @check_args_fallback(unsupported="none")
     def strip(self, to_strip=None):
         index = self._series.head(0).index
         new_metadata = pd.Series(

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -497,7 +497,7 @@ def test_str_lower(datapath, index_val):
 
 
 @pytest.mark.parametrize(
-    "to_strip", [pytest.param(None, id="default"), pytest.param("AB", id="strip-AB")]
+    "to_strip", [pytest.param(None, id="default"), pytest.param("A B", id="strip-AB")]
 )
 def test_str_strip(datapath, index_val, to_strip):
     """Very simple test for Series.str.strip() for sanity checking."""

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -496,7 +496,10 @@ def test_str_lower(datapath, index_val):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
-def test_str_strip(datapath, index_val):
+@pytest.mark.parametrize(
+    "to_strip", [pytest.param(None, id="default"), pytest.param("AB", id="strip-AB")]
+)
+def test_str_strip(datapath, index_val, to_strip):
     """Very simple test for Series.str.strip() for sanity checking."""
     df = pd.DataFrame(
         {
@@ -507,8 +510,8 @@ def test_str_strip(datapath, index_val):
     )
     df.index = index_val[: len(df)]
     bdf = bd.from_pandas(df)
-    out_pd = df.B.str.strip()
-    out_bodo = bdf.B.str.strip()
+    out_pd = df.B.str.strip(to_strip=to_strip)
+    out_bodo = bdf.B.str.strip(to_strip=to_strip)
     assert out_bodo.is_lazy_plan()
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 

--- a/docs/docs/api_docs/dataframe_lib.md
+++ b/docs/docs/api_docs/dataframe_lib.md
@@ -509,9 +509,7 @@ Equivalent to [`str.strip()`](https://docs.python.org/3/library/stdtypes.html#st
 
 <p class="api-header">Parameters</p>
 
-: __to_strip:__
-Will fall back to [`pandas.Series.str.strip`](https://pandas.pydata.org/docs/reference/api/pandas.Series.str.strip.html#pandas.Series.str.strip) if a value other than None is provided.
-
+: __to_strip: *str or None, default None*__ Specifying the set of characters to be removed. All combinations of this set of characters will be stripped. If None then whitespaces are removed.
 <p class="api-header">Returns</p>
 
 : __BodoSeries__


### PR DESCRIPTION
## Changes included in this PR
Add support for `to_strip` arg in `BodoSeries.str.strip`.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
`to_strip` no longer falls back to Pandas
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.