### PR TITLE
Support reordering join keys

### DIFF
--- a/bodo/libs/_bodo_common.cpp
+++ b/bodo/libs/_bodo_common.cpp
@@ -662,16 +662,18 @@ std::unique_ptr<Schema> Schema::Project(size_t first_n) const {
                                     this->metadata);
 }
 
+template <typename T>
+    requires(std::integral<T> && !std::same_as<T, bool>)
 std::unique_ptr<Schema> Schema::Project(
-    const std::vector<int>& column_indices) const {
+    const std::vector<T>& column_indices) const {
     std::vector<std::unique_ptr<DataType>> dtypes;
     std::vector<std::string> col_names;
     dtypes.reserve(column_indices.size());
     if (this->column_names.size() > 0) {
         col_names.reserve(column_indices.size());
     }
-    for (int64_t col_idx : column_indices) {
-        assert((size_t)col_idx < this->column_types.size());
+    for (T col_idx : column_indices) {
+        assert(static_cast<size_t>(col_idx) < this->column_types.size());
         dtypes.push_back(this->column_types[col_idx]->copy());
         if (this->column_names.size() > 0) {
             col_names.push_back(this->column_names[col_idx]);
@@ -680,6 +682,14 @@ std::unique_ptr<Schema> Schema::Project(
     return std::make_unique<Schema>(std::move(dtypes), std::move(col_names),
                                     this->metadata);
 }
+
+// Explicit template instantiations
+template std::unique_ptr<Schema> Schema::Project<int>(
+    const std::vector<int>& column_indices) const;
+template std::unique_ptr<Schema> Schema::Project<int64_t>(
+    const std::vector<int64_t>& column_indices) const;
+template std::unique_ptr<Schema> Schema::Project<uint64_t>(
+    const std::vector<uint64_t>& column_indices) const;
 
 std::shared_ptr<arrow::Schema> Schema::ToArrowSchema() const {
     if (this->column_names.size() == 0 && this->ncols() != 0) {

--- a/bodo/libs/_bodo_common.h
+++ b/bodo/libs/_bodo_common.h
@@ -819,11 +819,13 @@ struct Schema {
      * @brief Same as the previous, except it provides the column indices to
      * keep.
      *
+     * @tparam T Integer type for indices
      * @param column_indices Column indices to keep in the new schema.
      * @return std::unique_ptr<Schema> New schema.
      */
-    std::unique_ptr<Schema> Project(
-        const std::vector<int>& column_indices) const;
+    template <typename T>
+        requires(std::integral<T> && !std::same_as<T, bool>)
+    std::unique_ptr<Schema> Project(const std::vector<T>& column_indices) const;
 
     /// @brief Convert to an Arrow schema
     std::shared_ptr<::arrow::Schema> ToArrowSchema() const;

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -555,13 +555,6 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             for a, b in zip(left_on, right_on)
         ]
 
-        # TODO[BSE-4812]: support keys that are not in the beginning of the input tables
-        for i in range(len(key_indices)):
-            if key_indices[i] != (i, i):
-                raise BodoLibNotImplementedException(
-                    "Keys must be in the beginning of the input tables"
-                )
-
         planComparisonJoin = LazyPlan(
             "LogicalComparisonJoin",
             empty_data,

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -235,9 +235,10 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
      * @param keys key column indices
      * @param ncols number of columns in the table
      */
-    void initInputColumnMapping(std::vector<int64_t>& col_inds,
-                                std::vector<uint64_t>& keys, uint64_t ncols) {
-        for (uint64_t i : right_keys) {
+    static void initInputColumnMapping(std::vector<int64_t>& col_inds,
+                                       std::vector<uint64_t>& keys,
+                                       uint64_t ncols) {
+        for (uint64_t i : keys) {
             col_inds.push_back(i);
         }
         for (uint64_t i = 0; i < ncols; i++) {
@@ -257,8 +258,9 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
      * @param keys key column indices
      * @param ncols number of columns in the table
      */
-    void initOutputColumnMapping(std::vector<uint64_t>& col_inds,
-                                 std::vector<uint64_t>& keys, uint64_t ncols) {
+    static void initOutputColumnMapping(std::vector<uint64_t>& col_inds,
+                                        std::vector<uint64_t>& keys,
+                                        uint64_t ncols) {
         // Map key column index to its position in keys vector
         std::unordered_map<uint64_t, size_t> key_positions;
         for (size_t i = 0; i < keys.size(); ++i) {

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -62,7 +62,8 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
         bool probe_table_outer = false;
 
         this->join_state = std::make_shared<HashJoinState>(
-            build_table_schema, probe_table_schema, this->left_keys.size(),
+            build_table_schema->Project(build_col_inds),
+            probe_table_schema->Project(probe_col_inds), this->left_keys.size(),
             build_table_outer, probe_table_outer,
             // TODO: support forcing broadcast by the planner
             false, nullptr, true, true, get_streaming_batch_size(), -1,

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -52,10 +52,13 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
     void InitializeJoinState(
         const std::shared_ptr<bodo::Schema> build_table_schema,
         const std::shared_ptr<bodo::Schema> probe_table_schema) {
-        initInputColumnMapping(build_col_inds, right_keys,
-                               build_table_schema->ncols());
-        initInputColumnMapping(probe_col_inds, left_keys,
-                               probe_table_schema->ncols());
+        size_t n_build_cols = build_table_schema->ncols();
+        size_t n_probe_cols = probe_table_schema->ncols();
+
+        initInputColumnMapping(build_col_inds, right_keys, n_build_cols);
+        initInputColumnMapping(probe_col_inds, left_keys, n_probe_cols);
+        initOutputColumnMapping(build_kept_cols, right_keys, n_build_cols);
+        initOutputColumnMapping(probe_kept_cols, left_keys, n_probe_cols);
 
         // TODO[BSE-4813]: handle outer joins properly
         bool build_table_outer = false;
@@ -69,11 +72,6 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
             false, nullptr, true, true, get_streaming_batch_size(), -1,
             // TODO: support query profiling
             -1);
-
-        initOutputColumnMapping(build_kept_cols, right_keys,
-                                build_table_schema->ncols());
-        initOutputColumnMapping(probe_kept_cols, left_keys,
-                                probe_table_schema->ncols());
 
         // Create the probe output schema, same as here for consistency:
         // https://github.com/bodo-ai/Bodo/blob/a2e8bb7ba455dcba7372e6e92bd8488ed2b2d5cc/bodo/libs/streaming/_join.cpp#L1138

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -234,7 +234,7 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
    private:
     /**
      * @brief Initialize mapping of input column orders so that keys are in the
-     * beggining of build/probe tables to match streaming join APIs. See
+     * beginning of build/probe tables to match streaming join APIs. See
      * https://github.com/bodo-ai/Bodo/blob/905664de2c37741d804615cdbb3fb437621ff0bd/bodo/libs/streaming/join.py#L189
      * @param col_inds input mapping to fill
      * @param keys key column indices

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -52,26 +52,27 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
     void InitializeJoinState(
         const std::shared_ptr<bodo::Schema> build_table_schema,
         const std::shared_ptr<bodo::Schema> probe_table_schema) {
+        initInputColumnMapping(build_col_inds, right_keys,
+                               build_table_schema->ncols());
+        initInputColumnMapping(probe_col_inds, left_keys,
+                               probe_table_schema->ncols());
+
         // TODO[BSE-4813]: handle outer joins properly
         bool build_table_outer = false;
         bool probe_table_outer = false;
 
         this->join_state = std::make_shared<HashJoinState>(
-            build_table_schema, probe_table_schema,
-            // TODO[BSE-4812]: support keys that are not in the beginning of the
-            // input tables
-            this->left_keys.size(), build_table_outer, probe_table_outer,
+            build_table_schema, probe_table_schema, this->left_keys.size(),
+            build_table_outer, probe_table_outer,
             // TODO: support forcing broadcast by the planner
             false, nullptr, true, true, get_streaming_batch_size(), -1,
             // TODO: support query profiling
             -1);
 
-        this->build_kept_cols.resize(build_table_schema->ncols());
-        std::iota(this->build_kept_cols.begin(), this->build_kept_cols.end(),
-                  0);
-        this->probe_kept_cols.resize(probe_table_schema->ncols());
-        std::iota(this->probe_kept_cols.begin(), this->probe_kept_cols.end(),
-                  0);
+        initOutputColumnMapping(build_kept_cols, right_keys,
+                                build_table_schema->ncols());
+        initOutputColumnMapping(probe_kept_cols, left_keys,
+                                probe_table_schema->ncols());
 
         // Create the probe output schema, same as here for consistency:
         // https://github.com/bodo-ai/Bodo/blob/a2e8bb7ba455dcba7372e6e92bd8488ed2b2d5cc/bodo/libs/streaming/_join.cpp#L1138
@@ -133,9 +134,12 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
         // https://github.com/bodo-ai/Bodo/blob/967b62f1c943a3e8f8e00d5f9cdcb2865fb55cb0/bodo/libs/streaming/_join.cpp#L4018
         bool has_bloom_filter = join_state->global_bloom_filter != nullptr;
 
-        bool global_is_last =
-            join_build_consume_batch(this->join_state.get(), input_batch,
-                                     has_bloom_filter, local_is_last);
+        std::shared_ptr<table_info> input_batch_reordered =
+            ProjectTable(input_batch, this->build_col_inds);
+
+        bool global_is_last = join_build_consume_batch(
+            this->join_state.get(), input_batch_reordered, has_bloom_filter,
+            local_is_last);
 
         if (global_is_last) {
             return OperatorResult::FINISHED;
@@ -168,13 +172,16 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
 
         bool is_last = prev_op_result == OperatorResult::FINISHED;
 
+        std::shared_ptr<table_info> input_batch_reordered =
+            ProjectTable(input_batch, this->probe_col_inds);
+
         if (has_bloom_filter) {
             is_last = join_probe_consume_batch<false, false, false, true>(
-                this->join_state.get(), input_batch, build_kept_cols,
+                this->join_state.get(), input_batch_reordered, build_kept_cols,
                 probe_kept_cols, is_last);
         } else {
             is_last = join_probe_consume_batch<false, false, false, false>(
-                this->join_state.get(), input_batch, build_kept_cols,
+                this->join_state.get(), input_batch_reordered, build_kept_cols,
                 probe_kept_cols, is_last);
         }
 
@@ -220,10 +227,61 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
     }
 
    private:
+    /**
+     * @brief Initialize mapping of input column orders so that keys are in the
+     * beggining of build/probe tables to match streaming join APIs. See
+     * https://github.com/bodo-ai/Bodo/blob/905664de2c37741d804615cdbb3fb437621ff0bd/bodo/libs/streaming/join.py#L189
+     * @param col_inds input mapping to fill
+     * @param keys key column indices
+     * @param ncols number of columns in the table
+     */
+    void initInputColumnMapping(std::vector<int64_t>& col_inds,
+                                std::vector<uint64_t>& keys, uint64_t ncols) {
+        for (uint64_t i : right_keys) {
+            col_inds.push_back(i);
+        }
+        for (uint64_t i = 0; i < ncols; i++) {
+            if (std::find(keys.begin(), keys.end(), i) != keys.end()) {
+                continue;
+            }
+            col_inds.push_back(i);
+        }
+    }
+
+    /**
+     * @brief  Initialize mapping of output column orders to reorder keys that
+     * were moved to the beginning of of build/probe tables to match streaming
+     * join APIs. See
+     * https://github.com/bodo-ai/Bodo/blob/905664de2c37741d804615cdbb3fb437621ff0bd/bodo/libs/streaming/join.py#L746
+     * @param col_inds output mapping to fill
+     * @param keys key column indices
+     * @param ncols number of columns in the table
+     */
+    void initOutputColumnMapping(std::vector<uint64_t>& col_inds,
+                                 std::vector<uint64_t>& keys, uint64_t ncols) {
+        // Map key column index to its position in keys vector
+        std::unordered_map<uint64_t, size_t> key_positions;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            key_positions[keys[i]] = i;
+        }
+        uint64_t data_offset = keys.size();
+
+        for (uint64_t i = 0; i < ncols; i++) {
+            if (key_positions.find(i) != key_positions.end()) {
+                col_inds.push_back(key_positions[i]);
+            } else {
+                col_inds.push_back(data_offset++);
+            }
+        }
+    }
+
     std::shared_ptr<HashJoinState> join_state;
     std::vector<uint64_t> build_kept_cols;
     std::vector<uint64_t> probe_kept_cols;
     std::vector<uint64_t> left_keys;
     std::vector<uint64_t> right_keys;
     std::shared_ptr<bodo::Schema> output_schema;
+
+    std::vector<int64_t> build_col_inds;
+    std::vector<int64_t> probe_col_inds;
 };

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -759,15 +759,15 @@ def test_merge():
     """Simple test for DataFrame merge."""
     df1 = pd.DataFrame(
         {
-            "A": pd.array([2, 2, 3], "Int64"),
             "B": ["a1", "b11", "c111"],
             "E": [1.1, 2.2, 3.3],
+            "A": pd.array([2, 2, 3], "Int64"),
         },
     )
     df2 = pd.DataFrame(
         {
-            "C": pd.array([2, 3, 8], "Int64"),
             "D": ["a1", "b222", "c33"],
+            "C": pd.array([2, 3, 8], "Int64"),
         },
     )
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for key reordering when calling streaming join to allow key columns that are not in the beginning of dataframes.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
More join cases now work.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.