### PR TITLE
[BSE-4828] Merge on Multi-Character Key Bug Fix

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -880,8 +880,8 @@ def _get_set_column_plan(
     return _add_proj_expr_to_plan(df_plan, value_plan, key)
 
 
-# If string input, turn into singleton list
 def maybe_make_list(obj):
+    """If string input, turn into singleton list"""
     if obj is None:
         return []
     elif not isinstance(obj, (tuple, list)):

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -542,10 +542,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 on = []
         elif not isinstance(on, list):
             on = (on,)
-        if left_on is None:
-            left_on = []
-        if right_on is None:
-            right_on = []
+
+        left_on, right_on = maybe_make_list(left_on), maybe_make_list(right_on)
 
         key_indices = [
             (self.columns.get_loc(c), right.columns.get_loc(c)) for c in on
@@ -880,3 +878,12 @@ def _get_set_column_plan(
         return None
 
     return _add_proj_expr_to_plan(df_plan, value_plan, key)
+
+
+# If string input, turn into singleton list
+def maybe_make_list(obj):
+    if obj is None:
+        return []
+    elif not isinstance(obj, (tuple, list)):
+        return [obj]
+    return obj

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -811,6 +811,29 @@ def test_merge():
         reset_index=True,
     )
 
+    # Checks DataFrames with multi-character string keys
+    df4 = pd.DataFrame(
+        {
+            "cat": pd.array([2, 3, 8], "Int64"),
+            "dog": ["a1", "b222", "c33"],
+        },
+    )
+
+    bdf4 = bd.from_pandas(df4)
+
+    df5 = df1.merge(df4, how="inner", left_on=["A"], right_on=["cat"])
+    bdf5 = bdf1.merge(bdf4, how="inner", left_on=["A"], right_on=["cat"])
+    # Make sure bdf5 is unevaluated at this point.
+    assert bdf5.is_lazy_plan()
+
+    _test_equal(
+        bdf5.copy(),
+        df5,
+        check_pandas_types=False,
+        sort_output=True,
+        reset_index=True,
+    )
+
 
 def test_merge_swith_side():
     """Test merge with left table smaller than right table so DuckDB reorders the input

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -790,45 +790,22 @@ def test_merge():
     )
     df2 = pd.DataFrame(
         {
-            "C": pd.array([2, 3, 8], "Int64"),
-            "D": ["a1", "b222", "c33"],
+            "Cat": pd.array([2, 3, 8], "Int64"),
+            "Dog": ["a1", "b222", "c33"],
         },
     )
 
     bdf1 = bd.from_pandas(df1)
     bdf2 = bd.from_pandas(df2)
 
-    df3 = df1.merge(df2, how="inner", left_on=["A"], right_on=["C"])
-    bdf3 = bdf1.merge(bdf2, how="inner", left_on=["A"], right_on=["C"])
+    df3 = df1.merge(df2, how="inner", left_on=["A"], right_on=["Cat"])
+    bdf3 = bdf1.merge(bdf2, how="inner", left_on=["A"], right_on=["Cat"])
     # Make sure bdf3 is unevaluated at this point.
     assert bdf3.is_lazy_plan()
 
     _test_equal(
         bdf3.copy(),
         df3,
-        check_pandas_types=False,
-        sort_output=True,
-        reset_index=True,
-    )
-
-    # Checks DataFrames with multi-character string keys
-    df4 = pd.DataFrame(
-        {
-            "cat": pd.array([2, 3, 8], "Int64"),
-            "dog": ["a1", "b222", "c33"],
-        },
-    )
-
-    bdf4 = bd.from_pandas(df4)
-
-    df5 = df1.merge(df4, how="inner", left_on=["A"], right_on=["cat"])
-    bdf5 = bdf1.merge(bdf4, how="inner", left_on=["A"], right_on=["cat"])
-    # Make sure bdf5 is unevaluated at this point.
-    assert bdf5.is_lazy_plan()
-
-    _test_equal(
-        bdf5.copy(),
-        df5,
         check_pandas_types=False,
         sort_output=True,
         reset_index=True,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Addresses/fixes bug in which running merge on DataFrame with multi-charactered strings for column names (keys) raises a KeyError. Implements a function "maybe_make_list" used in Pandas API to convert single string on-arguments to lists. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, adds tests on multi-charactered DataFrame onto end_to_end testing file.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Aforementioned bug fixed, merge correctly works on multi-character string keys. 

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.