### PR TITLE
[BSE-4827] Read all-null columns

### DIFF
--- a/bodo/libs/_array.cpp
+++ b/bodo/libs/_array.cpp
@@ -414,6 +414,7 @@ void info_to_numpy_array(array_info* info, uint64_t* n_items, char** data,
 void info_to_null_array(array_info* info, uint64_t* n_items) {
     // TODO[BSE-433]: Replace with proper null array requirements once
     // they are integrated into C++.
+    // Arrow NA type is converted to arr_type STRING.
     if (info->arr_type != bodo_array_type::NULLABLE_INT_BOOL &&
         info->arr_type != bodo_array_type::STRING) {
         PyErr_SetString(PyExc_RuntimeError,

--- a/bodo/libs/_array.cpp
+++ b/bodo/libs/_array.cpp
@@ -414,13 +414,6 @@ void info_to_numpy_array(array_info* info, uint64_t* n_items, char** data,
 void info_to_null_array(array_info* info, uint64_t* n_items) {
     // TODO[BSE-433]: Replace with proper null array requirements once
     // they are integrated into C++.
-    std::cout << "got: " << GetArrType_as_string(info->arr_type) << std::endl;
-    // if (info->arr_type != bodo_array_type::NULLABLE_INT_BOOL) {
-    //     PyErr_SetString(PyExc_RuntimeError,
-    //                     "_array.cpp:: info_to_null_array: "
-    //                     "info_to_null_array requires nullable input");
-    //     return;
-    // }
     *n_items = info->length;
 }
 

--- a/bodo/libs/_array.cpp
+++ b/bodo/libs/_array.cpp
@@ -414,12 +414,13 @@ void info_to_numpy_array(array_info* info, uint64_t* n_items, char** data,
 void info_to_null_array(array_info* info, uint64_t* n_items) {
     // TODO[BSE-433]: Replace with proper null array requirements once
     // they are integrated into C++.
-    if (info->arr_type != bodo_array_type::NULLABLE_INT_BOOL) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "_array.cpp:: info_to_null_array: "
-                        "info_to_null_array requires nullable input");
-        return;
-    }
+    std::cout << "got: " << GetArrType_as_string(info->arr_type) << std::endl;
+    // if (info->arr_type != bodo_array_type::NULLABLE_INT_BOOL) {
+    //     PyErr_SetString(PyExc_RuntimeError,
+    //                     "_array.cpp:: info_to_null_array: "
+    //                     "info_to_null_array requires nullable input");
+    //     return;
+    // }
     *n_items = info->length;
 }
 

--- a/bodo/libs/_array.cpp
+++ b/bodo/libs/_array.cpp
@@ -414,6 +414,13 @@ void info_to_numpy_array(array_info* info, uint64_t* n_items, char** data,
 void info_to_null_array(array_info* info, uint64_t* n_items) {
     // TODO[BSE-433]: Replace with proper null array requirements once
     // they are integrated into C++.
+    if (info->arr_type != bodo_array_type::NULLABLE_INT_BOOL &&
+        info->arr_type != bodo_array_type::STRING) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "_array.cpp:: info_to_null_array: "
+                        "info_to_null_array requires nullable input");
+        return;
+    }
     *n_items = info->length;
 }
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -504,6 +504,10 @@ std::pair<duckdb::string, duckdb::LogicalType> arrow_field_to_duckdb(
     duckdb::LogicalType duckdb_type;
     const std::shared_ptr<arrow::DataType> &arrow_type = field->type();
     switch (arrow_type->id()) {
+        case arrow::Type::NA: {
+            duckdb_type = duckdb::LogicalType::SQLNULL;
+            break;
+        }
         case arrow::Type::STRING:
         case arrow::Type::LARGE_STRING: {
             duckdb_type = duckdb::LogicalType::VARCHAR;

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -206,10 +206,10 @@ def test_pd_datetime_arr_load_from_arrow(memory_leak_check):
         check_func(test_impl2, (), only_seq=True)
 
 
-@pytest.mark.skipif(
-    bodo.test_dataframe_library_enabled,
-    reason="[BSE-4766] All null columns not supported yet.",
-)
+# @pytest.mark.skipif(
+#     bodo.test_dataframe_library_enabled,
+#     reason="[BSE-4766] All null columns not supported yet.",
+# )
 @pytest.mark.parametrize(
     "fname",
     [

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -206,10 +206,6 @@ def test_pd_datetime_arr_load_from_arrow(memory_leak_check):
         check_func(test_impl2, (), only_seq=True)
 
 
-# @pytest.mark.skipif(
-#     bodo.test_dataframe_library_enabled,
-#     reason="[BSE-4766] All null columns not supported yet.",
-# )
 @pytest.mark.parametrize(
     "fname",
     [
@@ -2118,7 +2114,7 @@ def test_read_parquet_partitioned_read_as_dict(memory_leak_check):
 # ---------------------------- Test Additional Args ---------------------------- #
 @pytest.mark.skipif(
     bodo.test_dataframe_library_enabled,
-    reason="[BSE-4766] All null columns not supported yet.",
+    reason="[BSE-4770] Support the columns argument for read_parquet.",
 )
 @pytest.mark.parametrize(
     "col_subset",
@@ -2694,7 +2690,7 @@ def test_pq_schema(datapath, memory_leak_check):
 
 @pytest.mark.skipif(
     bodo.test_dataframe_library_enabled,
-    reason="[BSE-4766] requires Null column support.",
+    reason="[BSE-4831] Unify null columns in schema.",
 )
 def test_unify_null_column(memory_leak_check):
     """


### PR DESCRIPTION
## Changes included in this PR
Allow reading all-null columns in Parquet reader.

## Testing strategy
Existing unit tests, PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Users can read all-null columns.
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.