### PR TITLE
Handle column bindings in join and projection properly

### DIFF
--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -40,7 +40,7 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalProjection& op) {
         this->active_pipeline->getPrevOpOutputSchema();
 
     auto physical_op = std::make_shared<PhysicalProjection>(
-        std::move(op.expressions), in_table_schema);
+        op.children[0], std::move(op.expressions), in_table_schema);
     this->active_pipeline->AddOperator(physical_op);
 }
 
@@ -218,7 +218,7 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalComparisonJoin& op) {
     // https://github.com/duckdb/duckdb/blob/d29a92f371179170688b4df394478f389bf7d1a6/src/execution/physical_operator.cpp#L196
     // https://github.com/duckdb/duckdb/blob/d29a92f371179170688b4df394478f389bf7d1a6/src/execution/operator/join/physical_join.cpp#L31
 
-    auto physical_join = std::make_shared<PhysicalJoin>(op.conditions);
+    auto physical_join = std::make_shared<PhysicalJoin>(op, op.conditions);
 
     // Create pipelines for the build side of the join (right child)
     PhysicalPlanBuilder rhs_builder;

--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -34,13 +34,20 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalGet& op) {
 }
 
 void PhysicalPlanBuilder::Visit(duckdb::LogicalProjection& op) {
+    // Getting source bindings before processing the source since there
+    // are destructive operations in the Visit function like
+    // std::move(op.expressions).
+    // TODO: avoid destructive operations in the Visit function.
+    std::vector<duckdb::ColumnBinding> source_cols =
+        op.children[0]->GetColumnBindings();
+
     // Process the source of this projection.
     this->Visit(*op.children[0]);
     std::shared_ptr<bodo::Schema> in_table_schema =
         this->active_pipeline->getPrevOpOutputSchema();
 
     auto physical_op = std::make_shared<PhysicalProjection>(
-        op.children[0], std::move(op.expressions), in_table_schema);
+        source_cols, std::move(op.expressions), in_table_schema);
     this->active_pipeline->AddOperator(physical_op);
 }
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -574,7 +574,19 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             key_indices,
         )
 
-        return wrap_plan(planComparisonJoin)
+        # Column indices in output that need to be selected
+        col_indices = list(range(len(self.columns) + len(right.columns)))
+
+        # Create column reference expressions for selected columns
+        exprs = make_col_ref_exprs(col_indices, planComparisonJoin)
+        proj_plan = LazyPlan(
+            "LogicalProjection",
+            empty_data,
+            planComparisonJoin,
+            exprs,
+        )
+
+        return wrap_plan(proj_plan)
 
     @check_args_fallback("all")
     def __getitem__(self, key):

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -564,9 +564,15 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             for a, b in zip(left_on, right_on)
         ]
 
+        # Dummy output with all probe/build columns with unique names to enable
+        # make_col_ref_exprs() below
+        empty_join_out = pd.concat([_empty_like(self), _empty_like(right)], axis=1)
+        empty_join_out.columns = [
+            c + str(i) for i, c in enumerate(empty_join_out.columns)
+        ]
         planComparisonJoin = LazyPlan(
             "LogicalComparisonJoin",
-            empty_data,
+            empty_join_out,
             self._plan,
             right._plan,
             plan_optimizer.CJoinType.INNER,

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -17,7 +17,7 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
         duckdb::LogicalComparisonJoin& logical_join,
         const duckdb::vector<duckdb::JoinCondition>& conditions) {
         // Initialize column indices in join build/probe that need to be
-        // produced accoding to join output bindings
+        // produced according to join output bindings
         duckdb::idx_t left_table_index = -1;
         duckdb::idx_t right_table_index = -1;
         std::vector<duckdb::ColumnBinding> left_findings =

--- a/bodo/pandas/physical/project.h
+++ b/bodo/pandas/physical/project.h
@@ -131,7 +131,9 @@ class PhysicalProjection : public PhysicalSourceSink {
                         auto& colref =
                             child_expr
                                 ->Cast<duckdb::BoundColumnRefExpression>();
-                        size_t col_idx = colref.binding.column_index;
+                        size_t col_idx =
+                            col_ref_map[{colref.binding.table_index,
+                                         colref.binding.column_index}];
                         selected_columns.emplace_back(col_idx);
                     } else {
                         throw std::runtime_error(

--- a/bodo/pandas/physical/project.h
+++ b/bodo/pandas/physical/project.h
@@ -41,14 +41,12 @@ struct BodoPythonScalarFunctionData : public duckdb::FunctionData {
 class PhysicalProjection : public PhysicalSourceSink {
    public:
     explicit PhysicalProjection(
-        duckdb::unique_ptr<duckdb::LogicalOperator>& source,
+        std::vector<duckdb::ColumnBinding>& source_cols,
         duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs,
         std::shared_ptr<bodo::Schema> input_schema)
         : exprs(std::move(exprs)) {
         // Initialize map of column bindings to column indices in physical input
         // table.
-        std::vector<duckdb::ColumnBinding> source_cols =
-            source->GetColumnBindings();
         for (size_t i = 0; i < source_cols.size(); i++) {
             duckdb::ColumnBinding& col = source_cols[i];
             col_ref_map[{col.table_index, col.column_index}] = i;

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -846,15 +846,15 @@ def test_merge_swith_side():
     )
     df2 = pd.DataFrame(
         {
-            "C": pd.array([2, 3, 8], "Int64"),
             "D": ["a1", "b222", "c33"],
+            "A": pd.array([2, 3, 8], "Int64"),
             "E": [1.1, 2.2, 3.3],
         },
     )
     bdf1 = bd.from_pandas(df1)
     bdf2 = bd.from_pandas(df2)
-    df3 = df1.merge(df2, how="inner", left_on=["A"], right_on=["C"])
-    bdf3 = bdf1.merge(bdf2, how="inner", left_on=["A"], right_on=["C"])
+    df3 = df1.merge(df2, how="inner", on=["A"])
+    bdf3 = bdf1.merge(bdf2, how="inner", on=["A"])
     # Make sure bdf3 is unevaluated at this point.
     assert bdf3.is_lazy_plan()
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Updates join and projection nodes to map column bindings to physical column index in data chunks properly. This is critical for join since it refers to both left and right tables in its bindings. This removes the column name checking and restrictions in result collector.

Also updates DataFrame.merge frontend to generate a projection for column selection to handle common keys and "on" argument properly.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
`merge` calls with common keys now work.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.