### PR TITLE
[BSE-4831] Unify parquet schemas

### DIFF
--- a/bodo/io/parquet_pio.py
+++ b/bodo/io/parquet_pio.py
@@ -661,7 +661,8 @@ def unify_fragment_schema(dataset: ParquetDataset, piece: ParquetPiece, frag):
     """Unifies schema of *dataset* with incoming piece/fragment.
 
     Args:
-        dataset (ParquetDataset): The Parquet dataset with schema to unify.
+        dataset (ParquetDataset): The Parquet dataset to update with the unified
+            schema.
         piece (ParquetPiece): Piece corresponding to the fragment being unified.
         frag (pa.Dataset.Fragment): Fragment of the dataset to unify.
 
@@ -1567,6 +1568,8 @@ def get_dataset_unify_nulls(
     the common case where the first file opened contains some null columns which have
     non-null values in other files.
     """
+    # Get FileSystem and create ParquetDataset object similar to
+    # https://github.com/bodo-ai/Bodo/blob/294d0ea13ebba84f07d8e6ebfe297449c1e0b77b/bodo/io/parquet_pio.py#L916
     fpath, parsed_url, protocol = parse_fpath(fpath)
     fs = getfs(fpath, protocol, storage_options, parallel=False)
 
@@ -1589,6 +1592,8 @@ def get_dataset_unify_nulls(
     if not any(pa.types.is_null(typ) for typ in dataset.schema.types):
         return dataset
 
+    # Open the dataset similar to
+    # https://github.com/bodo-ai/Bodo/blob/294d0ea13ebba84f07d8e6ebfe297449c1e0b77b/bodo/io/parquet_pio.py#L717
     pieces = dataset.pieces
     fpaths = [p.path for p in dataset.pieces]
     dataset_ = ds.dataset(

--- a/bodo/io/parquet_pio.py
+++ b/bodo/io/parquet_pio.py
@@ -657,6 +657,39 @@ def unify_schemas_across_ranks(dataset: ParquetDataset, total_rows_chunk: int):
     ev.finalize()
 
 
+def unify_fragment_schema(dataset: ParquetDataset, piece: ParquetPiece, frag):
+    """Unifies schema of *dataset* with incoming piece/fragment.
+
+    Args:
+        dataset (ParquetDataset): The Parquet dataset with schema to unify.
+        piece (ParquetPiece): Piece corresponding to the fragment being unified.
+        frag (pa.Dataset.Fragment): Fragment of the dataset to unify.
+
+    Raises:
+        BodoError: If the schemas cannot be unified
+    """
+    # Two files are compatible if arrow can unify their schemas.
+    file_schema = frag.metadata.schema.to_arrow_schema()
+    fileset_schema_names = set(file_schema.names)
+    # Check the names are the same because pa.unify_schemas
+    # will unify a schema where a column is in 1 file but not
+    # another.
+    dataset_schema_names = set(dataset.schema.names) - set(dataset.partition_names)
+    # File schema can only be a (potentially) more restrictive
+    # version of the starting schema, therefore, the file shouldn't
+    # have extra columns. Any columns that are expected but are
+    # missing from the file will be filled with nulls at read time.
+    added_columns = fileset_schema_names - dataset_schema_names
+    if added_columns:
+        msg = f"Schema in {piece} was different. File contains column(s) {added_columns} not expected in the dataset.\n"
+        raise BodoError(msg)
+    try:
+        dataset.schema = unify_schemas([dataset.schema, file_schema], "permissive")
+    except Exception as e:
+        msg = f"Schema in {piece} was different.\n{str(e)}"
+        raise BodoError(msg)
+
+
 def populate_row_counts_in_pq_dataset_pieces(
     dataset: ParquetDataset,
     fpath: str | list[str],
@@ -741,30 +774,7 @@ def populate_row_counts_in_pq_dataset_pieces(
             # file schema doesn't match the dataset schema exactly.
             # Currently this is only applicable for Iceberg reads.
             if validate_schema:
-                # Two files are compatible if arrow can unify their schemas.
-                file_schema = frag.metadata.schema.to_arrow_schema()
-                fileset_schema_names = set(file_schema.names)
-                # Check the names are the same because pa.unify_schemas
-                # will unify a schema where a column is in 1 file but not
-                # another.
-                dataset_schema_names = set(dataset.schema.names) - set(
-                    dataset.partition_names
-                )
-                # File schema can only be a (potentially) more restrictive
-                # version of the starting schema, therefore, the file shouldn't
-                # have extra columns. Any columns that are expected but are
-                # missing from the file will be filled with nulls at read time.
-                added_columns = fileset_schema_names - dataset_schema_names
-                if added_columns:
-                    msg = f"Schema in {piece} was different. File contains column(s) {added_columns} not expected in the dataset.\n"
-                    raise BodoError(msg)
-                try:
-                    dataset.schema = unify_schemas(
-                        [dataset.schema, file_schema], "permissive"
-                    )
-                except Exception as e:
-                    msg = f"Schema in {piece} was different.\n{str(e)}"
-                    raise BodoError(msg)
+                unify_fragment_schema(dataset, piece, frag)
 
             t0 = time.time()
             # We use the expected schema instead of the file schema. This schema
@@ -1545,3 +1555,53 @@ def _get_partition_cat_dtype(dictionary):
     else:
         cat_dtype = PDCategoricalDtype(tuple(S), elem_type, False)
     return CategoricalArrayType(cat_dtype)
+
+
+def get_dataset_unify_nulls(
+    fpath, storage_options: dict, partitioning: str | None
+) -> ParquetDataset:
+    """
+    Gets the ParquetDataset from fpath, unifying types of null columns if present.
+
+    NOTE: This function must be called on the spawner and is intended to handle
+    the common case where the first file opened contains some null columns which have
+    non-null values in other files.
+    """
+    fpath, parsed_url, protocol = parse_fpath(fpath)
+    fs = getfs(fpath, protocol, storage_options, parallel=False)
+
+    dataset_or_err = get_bodo_pq_dataset_from_fpath(
+        fpath,
+        protocol,
+        parsed_url,
+        fs,
+        partitioning=partitioning,
+        filters=None,
+        typing_pa_schema=None,
+    )
+
+    if isinstance(dataset_or_err, Exception):  # pragma: no cover
+        error = dataset_or_err
+        raise error
+    dataset = pt.cast(ParquetDataset, dataset_or_err)
+    dataset.set_fs(fs)
+    # If there are no null columns, skip unify step.
+    if not any(pa.types.is_null(typ) for typ in dataset.schema.types):
+        return dataset
+
+    pieces = dataset.pieces
+    fpaths = [p.path for p in dataset.pieces]
+    dataset_ = ds.dataset(
+        fpaths,
+        filesystem=dataset.filesystem,
+        partitioning=dataset.partitioning,
+    )
+
+    # If there are nulls in the schema, inspect the fragments
+    # until the null columns can be resolved to a non-null type.
+    for piece, frag in zip(pieces, dataset_.get_fragments()):
+        unify_fragment_schema(dataset, piece, frag)
+        if not any(pa.types.is_null(typ) for typ in dataset.schema.types):
+            break
+
+    return dataset

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -63,12 +63,14 @@ def read_parquet(
     filters=None,
     **kwargs,
 ):
+    from bodo.io.parquet_pio import get_dataset_unify_nulls
+
     if storage_options is None:
         storage_options = {}
 
     # Read Parquet schema
     use_hive = True
-    pq_dataset = _get_dataset_unify_nulls(
+    pq_dataset = get_dataset_unify_nulls(
         path,
         storage_options,
         "hive" if use_hive else None,
@@ -136,67 +138,3 @@ def read_iceberg(
 
     plan = LazyPlan("LogicalGetIcebergRead", empty_df, table_identifier, catalog)
     return wrap_plan(plan=plan)
-
-
-def _get_dataset_unify_nulls(fpath, storage_options, paritioning):
-    import pyarrow.dataset as ds
-
-    from bodo.io.fs_io import getfs, parse_fpath
-    from bodo.io.parquet_pio import (
-        ParquetDataset,
-        get_bodo_pq_dataset_from_fpath,
-        unify_schemas,
-    )
-    from bodo.utils.typing import BodoError
-
-    fpath, parsed_url, protocol = parse_fpath(fpath)
-    fs = getfs(fpath, protocol, storage_options, parallel=False)
-
-    dataset_or_err = get_bodo_pq_dataset_from_fpath(
-        fpath,
-        protocol,
-        parsed_url,
-        fs,
-        partitioning=paritioning,
-        filters=None,
-        typing_pa_schema=None,
-    )
-
-    if isinstance(dataset_or_err, Exception):  # pragma: no cover
-        error = dataset_or_err
-        raise error
-    dataset = pt.cast(ParquetDataset, dataset_or_err)
-    dataset.set_fs(fs)
-
-    pieces = dataset.pieces
-    fpaths = [p.path for p in dataset.pieces]
-    dataset_ = ds.dataset(
-        fpaths,
-        filesystem=dataset.filesystem,
-        partitioning=dataset.partitioning,
-    )
-    piece_framents = zip(pieces, dataset_.get_fragments())
-    while any(pa.types.is_null(typ) for typ in dataset.schema.types):
-        piece, frag = next(piece_framents)
-        # Two files are compatible if arrow can unify their schemas.
-        file_schema = frag.metadata.schema.to_arrow_schema()
-        fileset_schema_names = set(file_schema.names)
-        # Check the names are the same because pa.unify_schemas
-        # will unify a schema where a column is in 1 file but not
-        # another.
-        dataset_schema_names = set(dataset.schema.names) - set(dataset.partition_names)
-        # File schema can only be a (potentially) more restrictive
-        # version of the starting schema, therefore, the file shouldn't
-        # have extra columns. Any columns that are expected but are
-        # missing from the file will be filled with nulls at read time.
-        added_columns = fileset_schema_names - dataset_schema_names
-        if added_columns:
-            msg = f"Schema in {piece} was different. File contains column(s) {added_columns} not expected in the dataset.\n"
-            raise BodoError(msg)
-        try:
-            dataset.schema = unify_schemas([dataset.schema, file_schema], "permissive")
-        except Exception as e:
-            msg = f"Schema in {piece} was different.\n{str(e)}"
-            raise BodoError(msg)
-
-    return dataset

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -1741,7 +1741,7 @@ def test_read_pq_trailing_sep(datapath, memory_leak_check):
 
 @pytest.mark.skipif(
     bodo.test_dataframe_library_enabled,
-    reason="[BSE-XXX] Fix glob support.",
+    reason="[BSE-4848] Fix glob support.",
 )
 def test_read_parquet_glob(datapath, memory_leak_check):
     def test_impl(filename):

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -1739,6 +1739,10 @@ def test_read_pq_trailing_sep(datapath, memory_leak_check):
     check_func(impl, ())
 
 
+@pytest.mark.skipif(
+    bodo.test_dataframe_library_enabled,
+    reason="[BSE-XXX] Fix glob support.",
+)
 def test_read_parquet_glob(datapath, memory_leak_check):
     def test_impl(filename):
         df = pd.read_parquet(filename)

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -2688,23 +2688,19 @@ def test_pq_schema(datapath, memory_leak_check):
     )
 
 
-@pytest.mark.skipif(
-    bodo.test_dataframe_library_enabled,
-    reason="[BSE-4831] Unify null columns in schema.",
-)
 def test_unify_null_column(memory_leak_check):
     """
     Tests reading from parquet with a null column in the first
     file unifies properly.
     """
-    if bodo.get_rank() == 0:
-        os.mkdir("temp_parquet_test")
-        df1 = pd.DataFrame({"A": np.arange(10), "B": [None] * 10})
-        df1.to_parquet("temp_parquet_test/f1.pq")
-        df2 = pd.DataFrame({"A": np.arange(10, 16), "B": [None, "A"] * 3})
-        df2.to_parquet("temp_parquet_test/f2.pq")
-    bodo.barrier()
-    try:
+    with ensure_clean2("temp_parquet_test"):
+        if bodo.get_rank() == 0:
+            os.mkdir("temp_parquet_test")
+            df1 = pd.DataFrame({"A": np.arange(10), "B": [None] * 10})
+            df1.to_parquet("temp_parquet_test/f1.pq")
+            df2 = pd.DataFrame({"A": np.arange(10, 16), "B": [None, "A"] * 3})
+            df2.to_parquet("temp_parquet_test/f2.pq")
+        bodo.barrier()
 
         def impl():
             return pd.read_parquet("temp_parquet_test")
@@ -2716,10 +2712,6 @@ def test_unify_null_column(memory_leak_check):
         )
 
         check_func(impl, (), py_output=py_output)
-    finally:
-        bodo.barrier()
-        if bodo.get_rank() == 0:
-            shutil.rmtree("temp_parquet_test")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Changes included in this PR

Unify parquet schemas when `read_parquet` is called to make sure the schemas are correct. This is also a bug in our compiler so ideally we can fix in both places.

Experimenting with a couple different options for a solution:
1. Call get_pq_dataset with count_rows=True. The advantage of this approach is that we can call in parallel, and possibly store the result so we don't have to also call at runtime? Disadvantage is we could end up filtering out a lot of these files at runtime so would probably have to recompute anyways.

2. For the most common case where the schema is null in the first file for some of the columns, we could just iterate over fragments in the dataset until the null columns are resolved. In the worst case, we would have to iterate over all the files which could be really slow especially if we can't process the files in parallel.

This PR goes with approach 2.

On the NYC taxi example (averaged 3 runs):
Getting the dataset the buggy way (main): ~0.39s
Getting the dataset until all null columns are resolved (this branch): ~1.14s
Getting the dataset entire dataset using `get_row_counts=True`:  ~7.700s (NOTE run on the spawner, could potentially be faster if we ran on workers?)

``` py
import time
import bodo.pandas as bd

times = []
for _ in range(3):
    start = time.time()
    df = bd.read_parquet("s3://bodo-example-data/nyc-taxi/fhvhv_tripdata/")
    end = time.time()
    times.append(end-start)
    print(end-start)

print(f"avg creating parquet read lazy plan took {sum(times)/len(times):2f}s")
```
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
PR CI, perf testing on the NYC taxi example, which has a null column (airport_fee) which is Null in the first 6 files and then double + null in the remaining 56 files.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Slight decrease in initial `read_parquet` time if a null column is present, but more robust to the case where there is a null in the first file but non-null values after.
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.