### PR TITLE
Support basic groupby

### DIFF
--- a/bodo/libs/streaming/_groupby.cpp
+++ b/bodo/libs/streaming/_groupby.cpp
@@ -4646,7 +4646,7 @@ void end_union_consume_pipeline_py_entry(GroupbyState* groupby_state) {
 
 /**
  * @brief Function to produce an output table called directly from
- * Python. This is handles all the functionality separately for exception
+ * Python. This handles all the functionality separately for exception
  * handling with grouping sets.
  *
  * @param groupby_state groupby state pointer

--- a/bodo/libs/streaming/_groupby.h
+++ b/bodo/libs/streaming/_groupby.h
@@ -1612,3 +1612,38 @@ class GroupingSetsState {
     // Dictionary builders that are shared between all group by states.
     std::vector<std::shared_ptr<DictionaryBuilder>> key_dict_builders;
 };
+
+/**
+ * @brief Logic to consume a build table batch. This is called
+ * directly by groupby_build_consume_batch_py_entry to avoid
+ * complex exception handling with grouping sets.
+ *
+ * @param groupby_state groupby state pointer
+ * @param in_table build table batch
+ * @param is_last is last batch (in this pipeline) locally
+ * @param is_final_pipeline Is this the final pipeline. Only relevant for the
+ * Union-Distinct case where this is called in multiple pipelines. For regular
+ * groupby, this should always be true. We only call FinalizeBuild in the last
+ * pipeline.
+ * @param[out] request_input whether to request input rows from preceding
+ * operators.
+ * @return updated global is_last with possibility of false negatives due to
+ * iterations between syncs
+ */
+bool groupby_build_consume_batch(GroupbyState* groupby_state,
+                                 std::shared_ptr<table_info> input_table,
+                                 bool is_last, const bool is_final_pipeline,
+                                 bool* request_input);
+
+/**
+ * @brief Function to produce an output table called directly from
+ * Python. This is handles all the functionality separately for exception
+ * handling with grouping sets.
+ *
+ * @param groupby_state groupby state pointer
+ * @param[out] out_is_last is last batch
+ * @param produce_output whether to produce output
+ * @return table_info* output table batch
+ */
+std::shared_ptr<table_info> groupby_produce_output_batch_wrapper(
+    GroupbyState* groupby_state, bool* out_is_last, bool produce_output);

--- a/bodo/libs/streaming/_groupby.h
+++ b/bodo/libs/streaming/_groupby.h
@@ -1637,7 +1637,7 @@ bool groupby_build_consume_batch(GroupbyState* groupby_state,
 
 /**
  * @brief Function to produce an output table called directly from
- * Python. This is handles all the functionality separately for exception
+ * Python. This handles all the functionality separately for exception
  * handling with grouping sets.
  *
  * @param groupby_state groupby state pointer

--- a/bodo/libs/streaming/_groupby.h
+++ b/bodo/libs/streaming/_groupby.h
@@ -1055,10 +1055,10 @@ class GroupbyState {
     // f_in_cols is a list of physical column indices.
     // For example:
     //
-    // f_in_offsets = (0, 1, 5)
+    // f_in_offsets = (0, 1, 6)
     // f_in_cols = (0, 7, 1, 3, 4, 0)
     // The first function uses the columns in f_in_cols[0:1]. IE physical index
-    // 0 in the input table. The second function uses the column f_in_cols[1:5].
+    // 0 in the input table. The second function uses the column f_in_cols[1:6].
     // IE physical index 7, 1, 3, 4, 0 in the input table.
     const std::vector<int32_t> f_in_offsets;
     const std::vector<int32_t> f_in_cols;

--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -194,28 +194,24 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalAggregate& op) {
 
     const std::string& alias = op.expressions[0]->GetAlias();
 
-    if (alias.empty()) {
-        throw std::runtime_error(
-            "PhysicalPlanBuilder::Visit(LogicalAggregate) expr alias cannot be "
-            "empty");
+    if (alias == "count_star()") {
+        auto physical_op = std::make_shared<PhysicalCountStar>();
+        // Finish the pipeline at this point so that Finalize can run
+        // to reduce the number of collected rows to the desired amount.
+        finished_pipelines.emplace_back(
+            this->active_pipeline->Build(physical_op));
+        // The same operator will exist in both pipelines.  The sink of the
+        // previous pipeline and the source of the next one.
+        // We record the pipeline dependency between these two pipelines.
+        this->active_pipeline = std::make_shared<PipelineBuilder>(physical_op);
     } else {
-        if (alias == "count_star()") {
-            auto physical_op = std::make_shared<PhysicalCountStar>();
-            // Finish the pipeline at this point so that Finalize can run
-            // to reduce the number of collected rows to the desired amount.
-            finished_pipelines.emplace_back(
-                this->active_pipeline->Build(physical_op));
-            // The same operator will exist in both pipelines.  The sink of the
-            // previous pipeline and the source of the next one.
-            // We record the pipeline dependency between these two pipelines.
-            this->active_pipeline =
-                std::make_shared<PipelineBuilder>(physical_op);
-        } else {
-            throw std::runtime_error(
-                "PhysicalPlanBuilder::Visit(LogicalAggregate) unsupported "
-                "aggregate " +
-                alias);
-        }
+        auto physical_agg = std::make_shared<PhysicalAggregate>(
+            in_table_schema, op.expressions, op.groups);
+        // Finish the current pipeline with groupby build sink
+        finished_pipelines.emplace_back(
+            this->active_pipeline->Build(physical_agg));
+        // Create a new pipeline with groupby output as source
+        this->active_pipeline = std::make_shared<PipelineBuilder>(physical_agg);
     }
 }
 

--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -202,8 +202,8 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalAggregate& op) {
         // We record the pipeline dependency between these two pipelines.
         this->active_pipeline = std::make_shared<PipelineBuilder>(physical_op);
     } else {
-        auto physical_agg = std::make_shared<PhysicalAggregate>(
-            in_table_schema, op.expressions, op.groups);
+        auto physical_agg =
+            std::make_shared<PhysicalAggregate>(in_table_schema, op);
         // Finish the current pipeline with groupby build sink
         finished_pipelines.emplace_back(
             this->active_pipeline->Build(physical_agg));

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1,6 +1,7 @@
 #include "_plan.h"
 #include <arrow/python/pyarrow.h>
 #include <fmt/format.h>
+#include <cstddef>
 #include <utility>
 
 #include "../io/arrow_compat.h"
@@ -126,7 +127,7 @@ duckdb::unique_ptr<duckdb::Expression> make_agg_expr(
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
     duckdb::vector<duckdb::LogicalType> arg_types;
     for (int col_idx : input_column_indices) {
-        if (col_idx < 0 || col_idx >= source_cols.size()) {
+        if (col_idx < 0 || static_cast<size_t>(col_idx) >= source_cols.size()) {
             throw std::runtime_error(
                 fmt::format("make_agg_expr: Column index {} out of bounds for "
                             "source columns",
@@ -322,7 +323,7 @@ duckdb::unique_ptr<duckdb::LogicalAggregate> make_aggregate(
 
     std::vector<duckdb::unique_ptr<duckdb::Expression>> group_exprs;
     for (int key_idx : key_indices) {
-        if (key_idx < 0 || key_idx >= source_cols.size()) {
+        if (key_idx < 0 || static_cast<size_t>(key_idx) >= source_cols.size()) {
             throw std::runtime_error(
                 fmt::format("make_aggregate: Key index {} out of bounds for "
                             "source columns",

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -216,7 +216,7 @@ duckdb::unique_ptr<duckdb::Expression> make_unary_expr(
     switch (etype) {
         case duckdb::ExpressionType::OPERATOR_NOT: {
             auto ret = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
-                etype, duckdb::LogicalType::BOOLEAN);
+                etype, duckdb::LogicalType(duckdb::LogicalTypeId::BOOLEAN));
             ret->children.push_back(std::move(lhs_duck));
             return ret;
         } break;

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -148,18 +148,6 @@ duckdb::unique_ptr<duckdb::Expression> make_agg_expr(
         duckdb::AggregateType::NON_DISTINCT);
 }
 
-duckdb::unique_ptr<duckdb::Expression> make_function_expr(
-    std::string function_name) {
-    if (function_name == "count_star()") {
-        return duckdb::make_uniq<duckdb::BoundColumnRefExpression>(
-            "count_star()", duckdb::LogicalType::BIGINT,
-            duckdb::ColumnBinding(-1, 0), 0);
-    } else {
-        throw std::runtime_error("make_function_expr unsupported function " +
-                                 function_name);
-    }
-}
-
 /**
  * @brief Change the type of a constant to match the type of the other side
  *        of a binary op expr.

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -161,15 +161,6 @@ duckdb::unique_ptr<duckdb::Expression> make_agg_expr(
     std::string function_name, std::vector<int> input_column_indices);
 
 /**
- * @brief Create an expression for a given function name.
- *
- * @param function_name - the function name to create expression for
- * @return duckdb::unique_ptr<duckdb::Expression> - the function expression
- */
-duckdb::unique_ptr<duckdb::Expression> make_function_expr(
-    std::string function_name);
-
-/**
  * @brief Create an expression from two sources and an operator.
  *
  * @param lhs - the left-hand side of the expression

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -71,8 +71,8 @@ duckdb::unique_ptr<duckdb::LogicalProjection> make_projection(
  * @return duckdb::unique_ptr<duckdb::LogicalAggregate> output node
  */
 duckdb::unique_ptr<duckdb::LogicalAggregate> make_aggregate(
-    std::unique_ptr<duckdb::LogicalOperator> &source, duckdb::idx_t group_index,
-    duckdb::idx_t aggregate_index,
+    std::unique_ptr<duckdb::LogicalOperator> &source,
+    std::vector<int> &key_indices,
     std::vector<std::unique_ptr<duckdb::Expression>> &expr_vec,
     PyObject *out_schema_py);
 

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -148,6 +148,21 @@ duckdb::unique_ptr<duckdb::Expression> make_col_ref_expr(
     int col_idx);
 
 /**
+ * @brief Create an aggregate expression for a given function name and input
+ * source node
+ *
+ * @param source input source node to aggregate
+ * @param field_py output field type for the aggregate function
+ * @param function_name function name for matching in backend
+ * @param input_column_indices argument column indices for the input source
+ * @return duckdb::unique_ptr<duckdb::Expression> new BoundAggregateExpression
+ * object
+ */
+duckdb::unique_ptr<duckdb::Expression> make_agg_expr(
+    std::unique_ptr<duckdb::LogicalOperator> &source, PyObject *field_py,
+    std::string function_name, std::vector<int> input_column_indices);
+
+/**
  * @brief Create an expression for a given function name.
  *
  * @param function_name - the function name to create expression for

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -64,8 +64,7 @@ duckdb::unique_ptr<duckdb::LogicalProjection> make_projection(
  * @brief Creates a LogicalAggregate node.
  *
  * @param source - the data source to aggregate
- * @param group_index - the group index for the aggregate
- * @param aggregate_index - the aggregate index for the aggregate
+ * @param key_indices - key column indices to group by
  * @param exprs - vector of aggregate exprs
  * @param out_schema_py - the schema of data coming out of the aggregate
  * @return duckdb::unique_ptr<duckdb::LogicalAggregate> output node

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -54,3 +54,16 @@ std::string schemaColumnNamesToString(
     }
     return ret;
 }
+
+void initInputColumnMapping(std::vector<int64_t>& col_inds,
+                            std::vector<uint64_t>& keys, uint64_t ncols) {
+    for (uint64_t i : keys) {
+        col_inds.push_back(i);
+    }
+    for (uint64_t i = 0; i < ncols; i++) {
+        if (std::find(keys.begin(), keys.end(), i) != keys.end()) {
+            continue;
+        }
+        col_inds.push_back(i);
+    }
+}

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -67,3 +67,13 @@ void initInputColumnMapping(std::vector<int64_t>& col_inds,
         col_inds.push_back(i);
     }
 }
+
+std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> getColRefMap(
+    std::vector<duckdb::ColumnBinding> source_cols) {
+    std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> col_ref_map;
+    for (size_t i = 0; i < source_cols.size(); i++) {
+        duckdb::ColumnBinding& col = source_cols[i];
+        col_ref_map[{col.table_index, col.column_index}] = i;
+    }
+    return col_ref_map;
+}

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -45,3 +45,14 @@ duckdb::unique_ptr<Derived> dynamic_cast_unique_ptr(
     // If the cast fails, return a nullptr unique_ptr
     return nullptr;
 }
+
+/**
+ * @brief Initialize mapping of input column orders so that keys are in the
+ * beginning of build/probe tables to match streaming join APIs. See
+ * https://github.com/bodo-ai/Bodo/blob/905664de2c37741d804615cdbb3fb437621ff0bd/bodo/libs/streaming/join.py#L189
+ * @param col_inds input mapping to fill
+ * @param keys key column indices
+ * @param ncols number of columns in the table
+ */
+void initInputColumnMapping(std::vector<int64_t> &col_inds,
+                            std::vector<uint64_t> &keys, uint64_t ncols);

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -2,8 +2,10 @@
 
 #include <arrow/api.h>
 #include <cstdint>
+#include <map>
 #include <variant>
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/planner/column_binding.hpp"
 
 /**
  * @brief Convert duckdb value to C++ variant.
@@ -56,3 +58,13 @@ duckdb::unique_ptr<Derived> dynamic_cast_unique_ptr(
  */
 void initInputColumnMapping(std::vector<int64_t> &col_inds,
                             std::vector<uint64_t> &keys, uint64_t ncols);
+
+/**
+ * @brief Create a map of column bindings to column indices in physical input
+ * table
+ *
+ * @param source_cols column bindings in source table
+ * @return std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>
+ */
+std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> getColRefMap(
+    std::vector<duckdb::ColumnBinding> source_cols);

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -624,6 +624,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         Provides support for groupby similar to Pandas:
         https://github.com/pandas-dev/pandas/blob/0691c5cf90477d3503834d983f69350f250a6ff7/pandas/core/frame.py#L9148
         """
+        if isinstance(by, str):
+            by = [by]
         return DataFrameGroupBy(self, by)
 
     @check_args_fallback("all")

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -633,6 +633,13 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         """
         if isinstance(by, str):
             by = [by]
+
+        # Only list of string column names for keys is supported for now.
+        if not isinstance(by, (list, tuple)) or not all(isinstance(b, str) for b in by):
+            raise BodoLibNotImplementedException(
+                "groupby: only string keys are supported"
+            )
+
         return DataFrameGroupBy(self, by)
 
     @check_args_fallback("all")

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -3,11 +3,20 @@ from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 
 import pandas as pd
-from pandas._typing import AnyArrayLike, IndexLabel, MergeHow, MergeValidate, Suffixes
+from pandas._libs import lib
+from pandas._typing import (
+    AnyArrayLike,
+    Axis,
+    IndexLabel,
+    MergeHow,
+    MergeValidate,
+    Suffixes,
+)
 
 import bodo
 from bodo.ext import plan_optimizer
 from bodo.pandas.array_manager import LazyArrayManager
+from bodo.pandas.groupby import DataFrameGroupBy
 from bodo.pandas.lazy_metadata import LazyMetadata
 from bodo.pandas.lazy_wrapper import BodoLazyWrapper, ExecState
 from bodo.pandas.managers import LazyBlockManager, LazyMetadataMixin
@@ -598,6 +607,24 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         )
 
         return wrap_plan(proj_plan)
+
+    @check_args_fallback(supported=["by"])
+    def groupby(
+        self,
+        by=None,
+        axis: Axis | lib.NoDefault = lib.no_default,
+        level: IndexLabel | None = None,
+        as_index: bool = True,
+        sort: bool = True,
+        group_keys: bool = True,
+        observed: bool | lib.NoDefault = lib.no_default,
+        dropna: bool = True,
+    ) -> DataFrameGroupBy:
+        """
+        Provides support for groupby similar to Pandas:
+        https://github.com/pandas-dev/pandas/blob/0691c5cf90477d3503834d983f69350f250a6ff7/pandas/core/frame.py#L9148
+        """
+        return DataFrameGroupBy(self, by)
 
     @check_args_fallback("all")
     def __getitem__(self, key):

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -25,7 +25,9 @@ class DataFrameGroupBy:
     https://github.com/pandas-dev/pandas/blob/0691c5cf90477d3503834d983f69350f250a6ff7/pandas/core/groupby/generic.py#L1329
     """
 
-    def __init__(self, obj, keys, selection=None):
+    def __init__(
+        self, obj: pd.DataFrame, keys: list[str], selection: list[str] | None = None
+    ):
         self._obj = obj
         self._keys = keys
         self._selection = selection
@@ -63,7 +65,7 @@ class SeriesGroupBy:
     Similar to pandas SeriesGroupBy.
     """
 
-    def __init__(self, obj, keys, selection):
+    def __init__(self, obj: pd.DataFrame, keys: list[str], selection: list[str]):
         self._obj = obj
         self._keys = keys
         self._selection = selection

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -132,7 +132,7 @@ class SeriesGroupBy:
             return object.__getattribute__(self, name)
         except AttributeError:
             msg = (
-                f"DataFrameGroupBy.{name} is not "
+                f"SeriesGroupBy.{name} is not "
                 "implemented in Bodo dataframe library yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -2,6 +2,8 @@
 Provides a Bodo implementation of the pandas groupby API.
 """
 
+from __future__ import annotations
+
 from typing import Literal
 
 from bodo.pandas.utils import BodoLibNotImplementedException, check_args_fallback
@@ -18,7 +20,7 @@ class DataFrameGroupBy:
         self._keys = keys
         self._selection = selection
 
-    def __getitem__(self, key) -> "DataFrameGroupBy" | "SeriesGroupBy":
+    def __getitem__(self, key) -> DataFrameGroupBy | SeriesGroupBy:
         """
         Return a DataFrameGroupBy or SeriesGroupBy for the selected data columns.
         """

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -1,0 +1,19 @@
+"""
+Provides a Bodo implementation of the pandas groupby API.
+"""
+
+
+class DataFrameGroupBy:
+    """
+    Similar to pandas DataFrameGroupBy. See Pandas code for reference:
+    https://github.com/pandas-dev/pandas/blob/0691c5cf90477d3503834d983f69350f250a6ff7/pandas/core/groupby/generic.py#L1329
+    """
+
+    def __init__(self, obj, keys):
+        self._obj = obj
+        self._keys = keys
+
+    def sum(self):
+        """
+        Compute the sum of each group.
+        """

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -2,6 +2,10 @@
 Provides a Bodo implementation of the pandas groupby API.
 """
 
+from typing import Literal
+
+from bodo.pandas.utils import BodoLibNotImplementedException, check_args_fallback
+
 
 class DataFrameGroupBy:
     """
@@ -9,11 +13,41 @@ class DataFrameGroupBy:
     https://github.com/pandas-dev/pandas/blob/0691c5cf90477d3503834d983f69350f250a6ff7/pandas/core/groupby/generic.py#L1329
     """
 
-    def __init__(self, obj, keys):
+    def __init__(self, obj, keys, selection=None):
         self._obj = obj
         self._keys = keys
+        self._selection = selection
 
-    def sum(self):
+    def __getitem__(self, key) -> "DataFrameGroupBy" | "SeriesGroupBy":
+        """
+        Return a DataFrameGroupBy or SeriesGroupBy for the selected data columns.
+        """
+        if isinstance(key, str):
+            return SeriesGroupBy(self._obj, self._keys, key)
+        else:
+            raise BodoLibNotImplementedException(
+                f"DataFrameGroupBy: Invalid key type: {type(key)}"
+            )
+
+
+class SeriesGroupBy:
+    """
+    Similar to pandas SeriesGroupBy.
+    """
+
+    def __init__(self, obj, keys, selection):
+        self._obj = obj
+        self._keys = keys
+        self._selection = selection
+
+    @check_args_fallback(supported="none")
+    def sum(
+        self,
+        numeric_only: bool = False,
+        min_count: int = 0,
+        engine: Literal["cython", "numba"] | None = None,
+        engine_kwargs: dict[str, bool] | None = None,
+    ):
         """
         Compute the sum of each group.
         """

--- a/bodo/pandas/physical/aggregate.h
+++ b/bodo/pandas/physical/aggregate.h
@@ -22,16 +22,8 @@ class PhysicalAggregate : public PhysicalSource, public PhysicalSink {
    public:
     explicit PhysicalAggregate(std::shared_ptr<bodo::Schema> in_table_schema,
                                duckdb::LogicalAggregate& op) {
-        std::vector<duckdb::ColumnBinding> source_cols =
-            op.children[0]->GetColumnBindings();
-        // Map of column bindings to column indices in physical input table
-        std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> col_ref_map;
-        // Initialize map of column bindings to column indices in physical input
-        // table.
-        for (size_t i = 0; i < source_cols.size(); i++) {
-            duckdb::ColumnBinding& col = source_cols[i];
-            col_ref_map[{col.table_index, col.column_index}] = i;
-        }
+        std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> col_ref_map =
+            getColRefMap(op.children[0]->GetColumnBindings());
 
         for (const auto& expr : op.groups) {
             if (expr->type != duckdb::ExpressionType::BOUND_COLUMN_REF) {

--- a/bodo/pandas/physical/aggregate.h
+++ b/bodo/pandas/physical/aggregate.h
@@ -43,6 +43,9 @@ class PhysicalAggregate : public PhysicalSource, public PhysicalSink {
             if (in_table_schema_reordered->column_names.size() > 0) {
                 this->output_schema->column_names.push_back(
                     in_table_schema_reordered->column_names[i]);
+            } else {
+                this->output_schema->column_names.push_back("key_" +
+                                                            std::to_string(i));
             }
         }
         this->output_schema->metadata = std::make_shared<TableMetadata>(
@@ -94,6 +97,7 @@ class PhysicalAggregate : public PhysicalSource, public PhysicalSink {
 
             this->output_schema->append_column(std::make_unique<bodo::DataType>(
                 std::get<0>(out_arr_type), std::get<1>(out_arr_type)));
+            this->output_schema->column_names.push_back(agg_expr.function.name);
         }
 
         // Offsets for the input data columns, which are trivial since we have a

--- a/bodo/pandas/physical/aggregate.h
+++ b/bodo/pandas/physical/aggregate.h
@@ -40,8 +40,10 @@ class PhysicalAggregate : public PhysicalSource, public PhysicalSink {
         for (size_t i = 0; i < this->keys.size(); i++) {
             this->output_schema->append_column(
                 in_table_schema_reordered->column_types[i]->copy());
-            this->output_schema->column_names.push_back(
-                in_table_schema_reordered->column_names[i]);
+            if (in_table_schema_reordered->column_names.size() > 0) {
+                this->output_schema->column_names.push_back(
+                    in_table_schema_reordered->column_names[i]);
+            }
         }
         this->output_schema->metadata = std::make_shared<TableMetadata>(
             std::vector<std::string>({}), std::vector<std::string>({}));

--- a/bodo/pandas/physical/aggregate.h
+++ b/bodo/pandas/physical/aggregate.h
@@ -5,8 +5,101 @@
 #include "../io/arrow_reader.h"
 #include "../libs/_array_utils.h"
 #include "../libs/_utils.h"
+#include "../libs/groupby/_groupby_ftypes.h"
+#include "../libs/streaming/_groupby.h"
 #include "expression.h"
 #include "operator.h"
+
+/**
+ * @brief Physical node for groupby aggregation
+ *
+ */
+class PhysicalAggregate : public PhysicalSource, public PhysicalSink {
+   public:
+    explicit PhysicalAggregate(
+        std::shared_ptr<bodo::Schema> in_table_schema,
+        std::vector<duckdb::unique_ptr<duckdb::Expression>>& agg_exprs,
+        std::vector<duckdb::unique_ptr<duckdb::Expression>>& group_exprs) {
+        std::vector<bool> cols_to_keep_vec(in_table_schema->ncols(), true);
+
+        // TODO: handle keys properly
+        uint64_t n_keys = 1;
+
+        this->groupby_state = std::make_unique<GroupbyState>(
+            std::make_unique<bodo::Schema>(*in_table_schema),
+            // TODO
+            std::vector<int32_t>({Bodo_FTypes::sum}),  // ftypes
+            std::vector<int32_t>(),
+            // TODO
+            std::vector<int32_t>({0, 1}),  // f_in_offsets
+            // TODO
+            std::vector<int32_t>({1}),  // f_in_cols
+            n_keys, std::vector<bool>(), std::vector<bool>(), cols_to_keep_vec,
+            nullptr, get_streaming_batch_size(), true, -1, -1, -1);
+
+        // TODO
+        this->output_schema = std::make_shared<bodo::Schema>();
+        output_schema->append_column(in_table_schema->column_types[0]->copy());
+        output_schema->append_column(in_table_schema->column_types[1]->copy());
+        output_schema->metadata = in_table_schema->metadata;
+        output_schema->column_names = in_table_schema->column_names;
+    }
+
+    virtual ~PhysicalAggregate() = default;
+
+    void Finalize() override {}
+
+    /**
+     * @brief process input tables to groupby build (populate the build
+     * table)
+     *
+     * @return OperatorResult
+     */
+    OperatorResult ConsumeBatch(std::shared_ptr<table_info> input_batch,
+                                OperatorResult prev_op_result) override {
+        bool local_is_last = prev_op_result == OperatorResult::FINISHED;
+        bool request_input = true;
+        bool global_is_last =
+            groupby_build_consume_batch(this->groupby_state.get(), input_batch,
+                                        local_is_last, true, &request_input);
+
+        if (global_is_last) {
+            return OperatorResult::FINISHED;
+        }
+        return request_input ? OperatorResult::NEED_MORE_INPUT
+                             : OperatorResult::HAVE_MORE_OUTPUT;
+    }
+
+    std::pair<std::shared_ptr<table_info>, OperatorResult> ProduceBatch()
+        override {
+        bool out_is_last = false;
+        std::shared_ptr<table_info> next_batch =
+            groupby_produce_output_batch_wrapper(this->groupby_state.get(),
+                                                 &out_is_last, true);
+        return {next_batch, out_is_last ? OperatorResult::FINISHED
+                                        : OperatorResult::HAVE_MORE_OUTPUT};
+    }
+
+    /**
+     * @brief GetResult - just for API compatability but should never be called
+     */
+    std::shared_ptr<table_info> GetResult() override {
+        throw std::runtime_error("GetResult called on an aggregate node.");
+    }
+
+    /**
+     * @brief Get the output schema of groupby aggregation
+     *
+     * @return std::shared_ptr<bodo::Schema>
+     */
+    const std::shared_ptr<bodo::Schema> getOutputSchema() override {
+        return output_schema;
+    }
+
+   private:
+    std::shared_ptr<GroupbyState> groupby_state;
+    std::shared_ptr<bodo::Schema> output_schema;
+};
 
 /**
  * @brief Physical node for count_star().

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -175,7 +175,7 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
         if (global_is_last) {
             return OperatorResult::FINISHED;
         }
-        return !join_state->build_shuffle_state.BuffersFull()
+        return join_state->build_shuffle_state.BuffersFull()
                    ? OperatorResult::HAVE_MORE_OUTPUT
                    : OperatorResult::NEED_MORE_INPUT;
     }

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -259,28 +259,6 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
 
    private:
     /**
-     * @brief Initialize mapping of input column orders so that keys are in the
-     * beginning of build/probe tables to match streaming join APIs. See
-     * https://github.com/bodo-ai/Bodo/blob/905664de2c37741d804615cdbb3fb437621ff0bd/bodo/libs/streaming/join.py#L189
-     * @param col_inds input mapping to fill
-     * @param keys key column indices
-     * @param ncols number of columns in the table
-     */
-    static void initInputColumnMapping(std::vector<int64_t>& col_inds,
-                                       std::vector<uint64_t>& keys,
-                                       uint64_t ncols) {
-        for (uint64_t i : keys) {
-            col_inds.push_back(i);
-        }
-        for (uint64_t i = 0; i < ncols; i++) {
-            if (std::find(keys.begin(), keys.end(), i) != keys.end()) {
-                continue;
-            }
-            col_inds.push_back(i);
-        }
-    }
-
-    /**
      * @brief  Initialize mapping of output column orders to reorder keys that
      * were moved to the beginning of of build/probe tables to match streaming
      * join APIs. See

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include "../../libs/streaming/_join.h"
+#include "../_util.h"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "operator.h"

--- a/bodo/pandas/physical/project.h
+++ b/bodo/pandas/physical/project.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include "../_util.h"
 #include "../libs/_array_utils.h"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
@@ -45,12 +46,7 @@ class PhysicalProjection : public PhysicalSourceSink {
         duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> exprs,
         std::shared_ptr<bodo::Schema> input_schema)
         : exprs(std::move(exprs)) {
-        // Initialize map of column bindings to column indices in physical input
-        // table.
-        for (size_t i = 0; i < source_cols.size(); i++) {
-            duckdb::ColumnBinding& col = source_cols[i];
-            col_ref_map[{col.table_index, col.column_index}] = i;
-        }
+        col_ref_map = getColRefMap(source_cols);
 
         // Create the output schema from expressions
         this->output_schema = std::make_shared<bodo::Schema>();

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -294,7 +294,6 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_const_timestamp_ns_expr(int64_t val) except +
     cdef unique_ptr[CExpression] make_const_string_expr(c_string val) except +
     cdef unique_ptr[CExpression] make_col_ref_expr(unique_ptr[CLogicalOperator] source, object field, int col_idx) except +
-    cdef unique_ptr[CExpression] make_function_expr(c_string function_name) except +
     cdef unique_ptr[CExpression] make_agg_expr(unique_ptr[CLogicalOperator] source, object field, c_string function_name, vector[int] input_column_indices) except +
     cdef unique_ptr[CLogicalLimit] make_limit(unique_ptr[CLogicalOperator] source, int n) except +
     cdef unique_ptr[CLogicalSample] make_sample(unique_ptr[CLogicalOperator] source, int n) except +
@@ -459,18 +458,6 @@ cdef class ColRefExpression(Expression):
 
     def __str__(self):
         return f"ColRefExpression({self.out_schema})"
-
-
-cdef class FunctionExpression(Expression):
-    """Wrapper around DuckDB's FunctionExpression to provide access in Python.
-    """
-
-    def __cinit__(self, object out_schema, str function_name):
-        self.out_schema = out_schema
-        self.c_expression = make_function_expr(function_name.encode())
-
-    def __str__(self):
-        return f"FunctionExpression({self.function_name})"
 
 
 cdef class AggregateExpression(Expression):

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -895,7 +895,7 @@ def count_plan(self):
 
     # Can't be known statically so create count plan on top of
     # existing plan.
-    count_star_schema = pd.Series(dtype="uint64", name="count_star()")
+    count_star_schema = pd.Series(dtype="uint64", name="count_star")
     aggregate_plan = LazyPlan(
         "LogicalAggregate",
         count_star_schema,

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -895,14 +895,17 @@ def count_plan(self):
 
     # Can't be known statically so create count plan on top of
     # existing plan.
-    count_star_schema = pd.Series(dtype="uint64", name="count_star()")
+    count_star_schema = pd.Series(dtype="uint64", name="count_star")
     aggregate_plan = LazyPlan(
         "LogicalAggregate",
         count_star_schema,
         self._plan,
-        0,
-        0,
-        [LazyPlan("FunctionExpression", count_star_schema, "count_star()")],
+        [],
+        [
+            LazyPlan(
+                "AggregateExpression", count_star_schema, self._plan, "count_star", []
+            )
+        ],
     )
     projection_plan = LazyPlan(
         "LogicalProjection",

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -895,7 +895,7 @@ def count_plan(self):
 
     # Can't be known statically so create count plan on top of
     # existing plan.
-    count_star_schema = pd.Series(dtype="uint64", name="count_star")
+    count_star_schema = pd.Series(dtype="uint64", name="count_star()")
     aggregate_plan = LazyPlan(
         "LogicalAggregate",
         count_star_schema,
@@ -903,7 +903,13 @@ def count_plan(self):
         [],
         [
             LazyPlan(
-                "AggregateExpression", count_star_schema, self._plan, "count_star", []
+                "AggregateExpression",
+                count_star_schema,
+                self._plan,
+                "count_star",
+                # Adding column 0 as input to avoid deleting all input by the optimizer
+                # TODO: avoid materializing the input column
+                [0],
             )
         ],
     )

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -830,3 +830,29 @@ def test_dataframe_copy(index_val):
     pdf_from_bodo = pd.DataFrame(bdf)
 
     _test_equal(df1, pdf_from_bodo, sort_output=True)
+
+
+def test_basic_groupby():
+    """
+    Test a simple groupby operation.
+    """
+    df1 = pd.DataFrame(
+        {
+            "B": ["a1", "b11", "c111"] * 2,
+            "E": [1.1, 2.2, 13.3] * 2,
+            "A": pd.array([2, 2, 3] * 2, "Int64"),
+        },
+        index=[0, 41, 2] * 2,
+    )
+
+    bdf1 = bd.from_pandas(df1)
+    bdf2 = bdf1.groupby("A")["E"].sum()
+    assert bdf2.is_lazy_plan()
+
+    df2 = df1.groupby("A")["E"].sum()
+
+    _test_equal(
+        bdf2,
+        df2,
+        sort_output=True,
+    )


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Adds initial support for groupby for the single column sum case. Also updates count(*) to use some similar code paths. Will open a bunch of issues for follow ups.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
groupby for the single column sum case is supported now.


## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.