### PR TITLE
[BSE-4844] Include Series.str methods in documentation

### DIFF
--- a/docs/docs/api_docs/dataframe_lib/dataframe.md
+++ b/docs/docs/api_docs/dataframe_lib/dataframe.md
@@ -1,0 +1,177 @@
+# DataFrame API
+
+## bodo.pandas.BodoDataFrame.apply
+``` py
+BodoDataFrame.apply(
+        func,
+        axis=0,
+        raw=False,
+        result_type=None,
+        args=(),
+        by_row="compat",
+        engine="python",
+        engine_kwargs=None,
+        **kwargs,
+    ) -> BodoSeries
+```
+
+Apply a function along an axis of the BodoDataFrame.
+
+Currently only supports applying a function that returns a scalar value for each row (i.e. `axis=1`).
+All other uses will fall back to Pandas.
+See [`pandas.DataFrame.apply`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.apply.html#pandas.DataFrame.apply) for more details.
+
+!!! note
+    Calling `BodoDataFrame.apply` will immediately execute a plan to generate a small sample of the BodoDataFrame
+    and then call `pandas.DataFrame.apply` on the sample to infer output types
+    before proceeding with lazy evaluation.
+
+<p class="api-header">Parameters</p>
+
+: __func : *function*:__ Function to apply to each row.
+
+: __axis : *{0 or 1}, default 0*:__ The axis to apply the function over. `axis=0` will fall back to [`pandas.DataFrame.apply`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.apply.html#pandas.DataFrame.apply).
+
+: __args : *tuple*:__ Additional positional arguments to pass to *func*.
+
+: __\*\*kwargs:__ Additional keyword arguments to pass as keyword arguments to *func*.
+
+
+: All other parameters will trigger a fallback to [`pandas.DataFrame.apply`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.apply.html#pandas.DataFrame.apply) if a non-default value is provided.
+
+<p class="api-header">Returns</p>
+: __BodoSeries:__ The result of applying *func* to each row in the BodoDataFrame.
+
+<p class="api-header">Example</p>
+
+``` py
+import pandas as pd
+import bodo.pandas as bodo_pd
+
+df = pd.DataFrame(
+        {
+            "a": pd.array([1, 2, 3] * 4, "Int64"),
+            "b": pd.array([4, 5, 6] * 4, "Int64"),
+            "c": ["a", "b", "c"] * 4,
+        },
+    )
+bdf = bodo_pd.from_pandas(df)
+out_bodo = bdf.apply(lambda x: x["a"] + 1, axis=1)
+
+print(type(out_bodo))
+print(out_bodo)
+```
+
+Output:
+```
+<class 'bodo.pandas.series.BodoSeries'>
+0     2
+1     3
+2     4
+3     2
+4     3
+5     4
+6     2
+7     3
+8     4
+9     2
+10    3
+11    4
+dtype: int64[pyarrow]
+```
+
+---
+
+### bodo.pandas.BodoDataFrame.head
+``` py
+BodoDataFrame.head(n=5) -> BodoDataFrame
+```
+
+Returns the first *n* rows of the BodoDataFrame.
+
+<p class="api-header">Parameters</p>
+
+: __n : *int, default 5*:__ Number of rows to select.
+
+<p class="api-header">Returns</p>
+
+: __BodoDataFrame__
+
+<p class="api-header">Example</p>
+
+``` py
+import bodo
+import bodo.pandas as bodo_pd
+import pandas as pd
+
+original_df = pd.DataFrame(
+    {"foo": range(15), "bar": range(15, 30)}
+   )
+
+@bodo.jit
+def write_parquet(df):
+    df.to_parquet("example.pq")
+
+write_parquet(original_df)
+
+restored_df = bodo_pd.read_parquet("example.pq")
+restored_df_head = restored_df.head(2)
+print(type(restored_df_head))
+print(restored_df_head)
+```
+
+Output:
+```
+<class 'bodo.pandas.frame.BodoDataFrame'>
+   foo  bar
+0    0   15
+1    1   16
+```
+
+---
+
+### Setting BodoDataFrame Columns
+
+BodoDataFrames support setting columns lazily when the value is a projection from the same DataFrame.
+Other cases will fallback to Pandas.
+
+<p class="api-header">Example</p>
+
+``` py
+import bodo.pandas as bodo_pd
+import pandas as pd
+
+df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3, 7] * 3, "Int64"),
+            "B": ["A1", "B1 ", "C1", "Abc"] * 3,
+            "C": pd.array([4, 5, 6, -1] * 3, "Int64"),
+        }
+    )
+
+bdf = bodo_pd.from_pandas(df)
+
+bdf["D"] = bdf["B"].str.lower()
+print(type(bdf))
+print(bdf.D)
+```
+
+Output:
+```
+<class 'bodo.pandas.frame.BodoDataFrame'>
+0      a1
+1     b1
+2      c1
+3     abc
+4      a1
+5     b1
+6      c1
+7     abc
+8      a1
+9     b1
+10     c1
+11    abc
+Name: D, dtype: string
+```
+
+---

--- a/docs/docs/api_docs/dataframe_lib/general_functions.md
+++ b/docs/docs/api_docs/dataframe_lib/general_functions.md
@@ -1,0 +1,55 @@
+# General Functions
+
+## bodo.pandas.from_pandas
+
+``` py
+bodo.pandas.from_pandas(df: pandas.DataFrame) -> BodoDataFrame
+```
+
+Converts a Pandas DataFrame into an equivalent BodoDataFrame.
+
+<p class="api-header">Parameters</p>
+
+: __df : *pandas.DataFrame*:__ The Pandas DataFrame to use as data source.
+
+<p class="api-header">Returns</p>
+: __BodoDataFrame__
+
+<p class="api-header">Example</p>
+
+``` py
+import pandas as pd
+import bodo.pandas as bodo_pd
+
+df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 7] * 3,
+            "b": [4, 5, 6, 8] * 3,
+            "c": ["a", "b", None, "abc"] * 3,
+        },
+    )
+
+bdf = bodo_pd.from_pandas(df)
+print(type(bdf))
+print(bdf)
+```
+
+Output:
+```
+<class 'bodo.pandas.frame.BodoDataFrame'>
+    a  b     c
+0   1  4     a
+1   2  5     b
+2   3  6  <NA>
+3   7  8   abc
+4   1  4     a
+5   2  5     b
+6   3  6  <NA>
+7   7  8   abc
+8   1  4     a
+9   2  5     b
+10  3  6  <NA>
+11  7  8   abc
+```
+
+---

--- a/docs/docs/api_docs/dataframe_lib/index.md
+++ b/docs/docs/api_docs/dataframe_lib/index.md
@@ -1,0 +1,61 @@
+# Bodo Pandas API (Bodo DataFrame Library) {#dataframe-lib}
+
+The Bodo DataFrame Library is designed to accelerate and scale Pandas workflows with just a one-line change — simply replace:
+
+``` py
+import pandas as pd
+```
+
+with
+
+``` py
+import bodo.pandas as pd
+```
+
+and your existing code can immediately take advantage of high-performance, scalable execution.
+
+Key features include:
+
+- __Full Pandas compatibility__ with a transparent fallback mechanism to native Pandas,
+ensuring that your workflows continue uninterrupted even if a feature is not yet supported.
+
+- __Advanced query optimization__ such as
+ filter pushdown, column pruning and join reordering behind the scenes.
+
+- __Scalable MPI-based execution__, leveraging High-Performance Computing (HPC) techniques for efficient parallelism;
+whether you're working on a laptop or running jobs across a large cloud cluster.
+
+- __Vectorized execution__ with streaming and spill-to-disk capabilities,
+making it possible to process datasets larger than memory reliably.
+
+!!! warning
+    Bodo DataFrame Library is under active development and is currently considered experimental.
+    Some features and APIs may not yet be fully supported.
+    We welcome your feedback — please join our community [Slack](https://bodocommunity.slack.com/join/shared_invite/zt-qwdc8fad-6rZ8a1RmkkJ6eOX1X__knA#/shared-invite/email) or open an issue on [our GitHub](https://github.com/bodo-ai/Bodo)
+    if you encounter any problems!
+
+## Lazy Evaluation and Fallback to Pandas
+
+Bodo DataFrame Library operates with lazy evaluation to allow query optimization, meaning operations are recorded into a query plan rather than executed immediately.
+Execution is automatically triggered only when results are actually needed, such as when displaying a DataFrame `df` with `print(df)`.
+
+If the user code encounters an unsupported Pandas API or an unsupported parameter, Bodo DataFrame library gracefully falls back to native Pandas.
+When this happens, the current query plan of the DataFrame is immediately executed, the resulting data is collected onto a single core and converted to a Pandas DataFrame, and further operations proceed using Pandas.
+
+!!! warning
+    Fallback to Pandas may lead to degraded performance and increase the risk of out-of-memory (OOM) errors, especially for large datasets.
+
+<div class="grid cards" markdown>
+
+- [General Functions][general-functions]
+- [Dataframe API][dataframe]
+- [Input/Output][inout]
+- [Series API][series]
+
+</div>
+
+
+[general-functions]: ../dataframe_lib/general_functions.md
+[dataframe]: ../dataframe_lib/dataframe.md
+[series]: ../dataframe_lib/series/index.md
+[inout]: ../dataframe_lib/io.md

--- a/docs/docs/api_docs/dataframe_lib/io.md
+++ b/docs/docs/api_docs/dataframe_lib/io.md
@@ -1,0 +1,65 @@
+# Input/Output
+
+## bodo.pandas.read_parquet
+``` py
+bodo.pandas.read_parquet(
+    path,
+    engine="auto",
+    columns=None,
+    storage_options=None,
+    use_nullable_dtypes=lib.no_default,
+    dtype_backend=lib.no_default,
+    filesystem=None,
+    filters=None,
+    **kwargs,
+) -> BodoDataFrame
+```
+
+Creates a BodoDataFrame object for reading from parquet file(s) lazily.
+
+<p class="api-header">Parameters</p>
+
+: __path : *str, list[str]*:__ Location of the parquet file(s) to read.
+Refer to [`pandas.read_parquet`](https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html#pandas.read_parquet) for more details.
+The type of this argument differs from Pandas.
+
+: All other parameters will trigger a fallback to [`pandas.read_parquet`](https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html#pandas.read_parquet) if a non-default value is provided.
+
+<p class="api-header">Returns</p>
+: __BodoDataFrame__
+
+<p class="api-header">Example</p>
+
+``` py
+import bodo
+import bodo.pandas as bodo_pd
+import pandas as pd
+
+original_df = pd.DataFrame(
+    {"foo": range(15), "bar": range(15, 30)}
+   )
+
+@bodo.jit
+def write_parquet(df):
+    df.to_parquet("example.pq")
+
+write_parquet(original_df)
+
+restored_df = bodo_pd.read_parquet("example.pq")
+print(type(restored_df))
+print(restored_df.head())
+```
+
+Output:
+
+```
+<class 'bodo.pandas.frame.BodoDataFrame'>
+   foo  bar
+0    0   15
+1    1   16
+2    2   17
+3    3   18
+4    4   19
+```
+
+---

--- a/docs/docs/api_docs/dataframe_lib/series/head.md
+++ b/docs/docs/api_docs/dataframe_lib/series/head.md
@@ -1,0 +1,44 @@
+# bodo.pandas.BodoSeries.head
+```
+BodoSeries.head(n=5) -> BodoSeries
+```
+
+Returns the first *n* rows of the BodoSeries.
+
+<p class="api-header">Parameters</p>
+
+: __n : *int, default 5*:__ Number of elements to select.
+
+<p class="api-header">Returns</p>
+
+: __BodoSeries__
+
+<p class="api-header">Example</p>
+
+``` py
+import bodo.pandas as bodo_pd
+import pandas as pd
+
+df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3, 7] * 3, "Int64"),
+        }
+    )
+
+bdf = bodo_pd.from_pandas(df)
+bodo_ser_head = bdf.A.head(3)
+print(type(bodo_ser_head))
+print(bodo_ser_head)
+```
+
+Output:
+
+```
+<class 'pandas.core.series.Series'>
+0    1
+1    2
+2    3
+Name: A, dtype: Int64
+```
+
+---

--- a/docs/docs/api_docs/dataframe_lib/series/index.md
+++ b/docs/docs/api_docs/dataframe_lib/series/index.md
@@ -1,0 +1,104 @@
+# Series API
+### Function application
+- [`bodo.pandas.BodoSeries.map`][bodoseriesmap]
+
+### Selection
+
+- [`bodo.pandas.BodoSeries.head`][bodoserieshead]
+
+### String handling
+
+- [`bodo.pandas.BodoSeries.str.capitalize`][bodoseriesstrcapitalize]
+- [`bodo.pandas.BodoSeries.str.casefold`][bodoseriesstrcasefold]
+- [`bodo.pandas.BodoSeries.str.center`][bodoseriesstrcenter]
+- [`bodo.pandas.BodoSeries.str.contains`][bodoseriesstrcontains]
+- [`bodo.pandas.BodoSeries.str.count`][bodoseriesstrcount]
+- [`bodo.pandas.BodoSeries.str.endswith`][bodoseriesstrendswith]
+- [`bodo.pandas.BodoSeries.str.find`][bodoseriesstrfind]
+- [`bodo.pandas.BodoSeries.str.findall`][bodoseriesstrfindall]
+- [`bodo.pandas.BodoSeries.str.fullmatch`][bodoseriesstrfullmatch]
+- [`bodo.pandas.BodoSeries.str.get`][bodoseriesstrget]
+- [`bodo.pandas.BodoSeries.str.index`][bodoseriesstrindex]
+- [`bodo.pandas.BodoSeries.str.isalnum`][bodoseriesstrisalnum]
+- [`bodo.pandas.BodoSeries.str.isalpha`][bodoseriesstrisalpha]
+- [`bodo.pandas.BodoSeries.str.isdecimal`][bodoseriesstrisdecimal]
+- [`bodo.pandas.BodoSeries.str.isdigit`][bodoseriesstrisdigit]
+- [`bodo.pandas.BodoSeries.str.islower`][bodoseriesstrislower]
+- [`bodo.pandas.BodoSeries.str.isnumeric`][bodoseriesstrisnumeric]
+- [`bodo.pandas.BodoSeries.str.isspace`][bodoseriesstrisspace]
+- [`bodo.pandas.BodoSeries.str.istitle`][bodoseriesstristitle]
+- [`bodo.pandas.BodoSeries.str.isupper`][bodoseriesstrisupper]
+- [`bodo.pandas.BodoSeries.str.len`][bodoseriesstrlen]
+- [`bodo.pandas.BodoSeries.str.ljust`][bodoseriesstrljust]
+- [`bodo.pandas.BodoSeries.str.lower`][bodoseriesstrlower]
+- [`bodo.pandas.BodoSeries.str.lstrip`][bodoseriesstrlstrip]
+- [`bodo.pandas.BodoSeries.str.match`][bodoseriesstrmatch]
+- [`bodo.pandas.BodoSeries.str.pad`][bodoseriesstrpad]
+- [`bodo.pandas.BodoSeries.str.removeprefix`][bodoseriesstrremoveprefix]
+- [`bodo.pandas.BodoSeries.str.removesuffix`][bodoseriesstrremovesuffix]
+- [`bodo.pandas.BodoSeries.str.repeat`][bodoseriesstrrepeat]
+- [`bodo.pandas.BodoSeries.str.replace`][bodoseriesstrreplace]
+- [`bodo.pandas.BodoSeries.str.rfind`][bodoseriesstrrfind]
+- [`bodo.pandas.BodoSeries.str.rindex`][bodoseriesstrrindex]
+- [`bodo.pandas.BodoSeries.str.rjust`][bodoseriesstrrjust]
+- [`bodo.pandas.BodoSeries.str.rstrip`][bodoseriesstrrstrip]
+- [`bodo.pandas.BodoSeries.str.slice`][bodoseriesstrslice]
+- [`bodo.pandas.BodoSeries.str.slice_replace`][bodoseriesstrslicereplace]
+- [`bodo.pandas.BodoSeries.str.startswith`][bodoseriesstrstartswith]
+- [`bodo.pandas.BodoSeries.str.strip`][bodoseriesstrstrip]
+- [`bodo.pandas.BodoSeries.str.swapcase`][bodoseriesstrswapcase]
+- [`bodo.pandas.BodoSeries.str.title`][bodoseriesstrtitle]
+- [`bodo.pandas.BodoSeries.str.translate`][bodoseriesstrtranslate]
+- [`bodo.pandas.BodoSeries.str.upper`][bodoseriesstrupper]
+- [`bodo.pandas.BodoSeries.str.wrap`][bodoseriesstrwrap]
+- [`bodo.pandas.BodoSeries.str.zfill`][bodoseriesstrzfill]
+
+
+
+[bodoserieshead]: ../series/head.md
+[bodoseriesmap]: ../series/map.md
+
+[bodoseriesstrcapitalize]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.capitalize.html
+[bodoseriesstrcasefold]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.casefold.html
+[bodoseriesstrcenter]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.center.html
+[bodoseriesstrcontains]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.contains.html
+[bodoseriesstrcount]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.count.html
+[bodoseriesstrendswith]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.endswith.html
+[bodoseriesstrfind]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.find.html
+[bodoseriesstrfindall]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.findall.html
+[bodoseriesstrfullmatch]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.fullmatch.html
+[bodoseriesstrget]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.get.html
+[bodoseriesstrindex]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.index.html
+[bodoseriesstrisalnum]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.isalnum.html
+[bodoseriesstrisalpha]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.isalpha.html
+[bodoseriesstrisdecimal]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.isdecimal.html
+[bodoseriesstrisdigit]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.isdigit.html
+[bodoseriesstrislower]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.islower.html
+[bodoseriesstrisnumeric]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.isnumeric.html
+[bodoseriesstrisspace]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.isspace.html
+[bodoseriesstristitle]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.istitle.html
+[bodoseriesstrisupper]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.isupper.html
+[bodoseriesstrlen]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.len.html
+[bodoseriesstrljust]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.ljust.html
+[bodoseriesstrlower]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.lower.html
+[bodoseriesstrlstrip]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.lstrip.html
+[bodoseriesstrmatch]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.match.html
+[bodoseriesstrpad]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.pad.html
+[bodoseriesstrremoveprefix]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.removeprefix.html
+[bodoseriesstrremovesuffix]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.removesuffix.html
+[bodoseriesstrrepeat]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.repeat.html
+[bodoseriesstrreplace]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.replace.html
+[bodoseriesstrrfind]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.rfind.html
+[bodoseriesstrrindex]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.rindex.html
+[bodoseriesstrrjust]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.rjust.html
+[bodoseriesstrrstrip]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.rstrip.html
+[bodoseriesstrslice]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.slice.html
+[bodoseriesstrslicereplace]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.slice_replace.html
+[bodoseriesstrstartswith]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.startswith.html
+[bodoseriesstrstrip]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.strip.html
+[bodoseriesstrswapcase]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.swapcase.html
+[bodoseriesstrtitle]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.title.html
+[bodoseriesstrtranslate]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.translate.html
+[bodoseriesstrupper]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.upper.html
+[bodoseriesstrwrap]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.wrap.html
+[bodoseriesstrzfill]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.zfill.html

--- a/docs/docs/api_docs/dataframe_lib/series/map.md
+++ b/docs/docs/api_docs/dataframe_lib/series/map.md
@@ -1,0 +1,60 @@
+# bodo.pandas.BodoSeries.map
+```
+BodoSeries.map(arg, na_action=None) -> BodoSeries
+```
+Map values of a BodoSeries according to a mapping.
+
+!!! note
+    Calling `BodoSeries.map` will immediately execute a plan to generate a small sample of the BodoSeries
+    and then call `pandas.Series.map` on the sample to infer output types
+    before proceeding with lazy evaluation.
+
+<p class="api-header">Parameters</p>
+
+: __arg : *function, collections.abc.Mapping subclass or Series*:__ Mapping correspondence.
+
+: __na_actions : *{None, ‘ignore’}, default None*:__ If 'ignore' then NaN values will be propagated without passing them to the mapping correspondence.
+
+<p class="api-header">Returns</p>
+
+: __BodoSeries__
+
+<p class="api-header">Example</p>
+
+``` py
+import bodo.pandas as bodo_pd
+import pandas as pd
+
+df = pd.DataFrame(
+    {
+        "A": pd.array([1, 2, 3, 7] * 3, "Int64"),
+        "B": ["A1", "B1", "C1", "Abc"] * 3,
+        "C": pd.array([4, 5, 6, -1] * 3, "Int64"),
+    }
+)
+
+bdf = bodo_pd.from_pandas(df)
+bodo_ser = bdf.A.map(lambda x: x ** 2)
+print(type(bodo_ser))
+print(bodo_ser)
+```
+
+Output:
+```
+<class 'bodo.pandas.series.BodoSeries'>
+0      1
+1      4
+2      9
+3     49
+4      1
+5      4
+6      9
+7     49
+8      1
+9      4
+10     9
+11    49
+Name: A, dtype: int64[pyarrow]
+```
+
+---

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -234,6 +234,11 @@ nav:
                 - Timestamp Functions: api_docs/sql/functions/timestamp
                 - Type Predicates: api_docs/sql/functions/type
       - Bodo Platform SDK Reference: api_docs/platform_sdk.md
-      - Bodo DataFrame Library API (Experimental): api_docs/dataframe_lib.md
+      - Bodo DataFrame Library API (Experimental): 
+          - api_docs/dataframe_lib/index.md
+          - General Functions: api_docs/dataframe_lib/general_functions.md
+          - DataFrame: api_docs/dataframe_lib/dataframe.md
+          - Input/Output: api_docs/dataframe_lib/io.md
+          - Series : api_docs/dataframe_lib/series
   - Release Notes: release_notes
   - FAQ: faq.md


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Reformats Bodo DataFrame Library API documentation into subcategories, includes a subsection of supported Series.str methods that contain hyperlinks to corresponding Pandas API. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

Docs changes, CI unnecessary

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Updated documentation to inform users of supported Series.str methods. 

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.