### PR TITLE
[BSE-4836] Expand on validation in merge

### DIFF
--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -142,9 +142,9 @@ def test_merge_validation_checks():
 
     # TODO[BSE-4810]: support "on" argument, which requires removing extra copy of
     # key columns with the same names from output
-    # With "on" argument support, below test cases should work
 
-    # bdf1.merge(bdf3, how="inner")
-    # with pytest.raises(ValueError):
-    #     bdf1.merge(bdf2, how="inner", on=["A", "C"])
-    # bdf1.merge(bdf1, how="inner", on=["A", "B", "E"])
+    bdf1.merge(bdf1, how="inner")
+    with pytest.raises(KeyError):
+        bdf1.merge(bdf2, how="inner", on=["A", "C"])
+
+    bdf1.merge(bdf1, how="inner", on=["A", "B", "E"])


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds validation logic to existing merge argument validation. Collects common columns and raises ValueError if there are no common columns. 

** Would like reviewers to review minor code change in merge: 
`validate_merge_spec` processes and returns `left_on, right_on` and `on=None` is passed into `empty_data` creation.
Refer to inline comments in code snippet below. 

```
# Returns processed on-argument values
left_on, right_on = validate_merge_spec(self, right, on, left_on, right_on)

        zero_size_self = _empty_like(self)
        zero_size_right = _empty_like(right)
        empty_data = zero_size_self.merge(
            zero_size_right,
            how=how,
            on=None,  # None is passed to avoid exception of having on, left_on, right_on at once
            left_on=left_on,
            right_on=right_on,
            left_index=left_index,
            right_index=right_index,
            sort=sort,
            suffixes=suffixes,
        )

        key_indices = [
            (self.columns.get_loc(a), right.columns.get_loc(b))
            for a, b in zip(left_on, right_on)
        ]
```

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

PR CI, adds tests with no on, left_on, right_on values. 

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

Invalid on-arguments are caught early. 

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.