### PR TITLE
[BSE-4835] Support Series.dt accessors

### DIFF
--- a/bodo/libs/_bodo_common.cpp
+++ b/bodo/libs/_bodo_common.cpp
@@ -452,7 +452,7 @@ std::shared_ptr<::arrow::Field> DataType::ToArrowType(std::string& name) const {
             dtype = arrow::date32();
             break;
         case Bodo_CTypes::TIME:
-            dtype = arrow::time64(arrow::TimeUnit::SECOND);
+            dtype = arrow::time64(arrow::TimeUnit::NANO);
             break;
         // TODO: Is there a way to get timezone?
         case Bodo_CTypes::DATETIME:

--- a/bodo/libs/_bodo_common.cpp
+++ b/bodo/libs/_bodo_common.cpp
@@ -451,6 +451,7 @@ std::shared_ptr<::arrow::Field> DataType::ToArrowType(std::string& name) const {
         case Bodo_CTypes::DATE:
             dtype = arrow::date32();
             break;
+        // TODO: check precision
         case Bodo_CTypes::TIME:
             dtype = arrow::time64(arrow::TimeUnit::NANO);
             break;

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1,6 +1,5 @@
 #include "_plan.h"
 #include <arrow/python/pyarrow.h>
-#include <arrow/type.h>
 #include <fmt/format.h>
 #include <utility>
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1,5 +1,6 @@
 #include "_plan.h"
 #include <arrow/python/pyarrow.h>
+#include <arrow/type.h>
 #include <fmt/format.h>
 #include <utility>
 
@@ -749,6 +750,21 @@ std::pair<duckdb::string, duckdb::LogicalType> arrow_field_to_duckdb(
                 arrow::field("name", dict_type->value_type());
             auto [field_name, inner_type] = arrow_field_to_duckdb(value_field);
             duckdb_type = inner_type;
+            break;
+        }
+        case arrow::Type::TIME64: {
+            auto time64_type =
+                std::static_pointer_cast<arrow::Time64Type>(arrow_type);
+            switch (time64_type->unit()) {
+                case arrow::TimeUnit::MICRO:
+                    duckdb_type = duckdb::LogicalType::TIME;
+                    break;
+                case arrow::TimeUnit::NANO:
+                    duckdb_type = duckdb::LogicalType::TIME;
+                    break;
+                default:
+                    throw std::runtime_error("Unsupported Time64 unit");
+            }
             break;
         }
         default:

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -379,32 +379,6 @@ class BodoDateTimeMethods:
         # Add validation
         self._series = series
 
-    # @property
-    # def year(self):
-    #     index = self._series.head(0).index
-
-    #     new_metadata = pd.Series(
-    #         dtype=pd.ArrowDtype(pa.int64()),
-    #         name=self._series.name,
-    #         index=index,
-    #     )
-    #     return _get_series_python_func_plan(
-    #         self._series._plan, new_metadata, "dt.year", (), {}
-    #     )
-
-    # @property
-    # def date(self):
-    #     index = self._series.head(0).index
-
-    #     new_metadata = pd.Series(
-    #         dtype=pd.ArrowDtype(pa.date32()),
-    #         name=self._series.name,
-    #         index=index,
-    #     )
-    #     return _get_series_python_func_plan(
-    #         self._series._plan, new_metadata, "dt.date", (), {}
-    #     )
-
 
 def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwargs):
     """Create a plan for calling a Series method in Python. Creates a proper
@@ -511,7 +485,11 @@ def gen_str_method(name, rettype):
 
 
 def gen_dt_accessor(name, rettype):
+    """Generalized generator for Series.dt accessors"""
+
     def dt_accessor(self):
+        """Generalized template for Series.dt accessors"""
+
         index = self._series.head(0).index
         new_metadata = pd.Series(
             dtype=rettype,
@@ -601,12 +579,7 @@ series_str_methods = [
     ),
 ]
 
-# Generates Series.str methods
-for rettype_pair in series_str_methods:
-    for func_name in rettype_pair[0]:
-        func = gen_str_method(func_name, rettype_pair[1])
-        setattr(BodoStringMethods, func_name, func)
-
+# Maps Series.dt accessors to return types
 dt_accessors = [
     # idx = 0: Series(Int)
     (
@@ -618,6 +591,22 @@ dt_accessors = [
             "minute",
             "second",
             "microsecond",
+            "nanosecond",
+            "dayofweek",
+            "day_of_week",
+            "weekday",
+            "dayofyear",
+            "day_of_year",
+            "days_in_month",
+            "quarter",
+            "is_month_start",
+            "is_month_end",
+            "is_quarter_start",
+            "is_quarter_end",
+            "is_year_start",
+            "is_year_end",
+            "is_leap_year",
+            "daysinmonth",
         ],
         pd.ArrowDtype(pa.int64()),
     ),
@@ -626,10 +615,23 @@ dt_accessors = [
         ["date"],
         pd.ArrowDtype(pa.date32()),
     ),
+    # idx = 2: Series(Time)
+    (
+        [
+            "time",
+        ],
+        pd.ArrowDtype(pa.time64("ns")),
+    ),
 ]
 
+# Generates Series.str methods
+for rettype_pair in series_str_methods:
+    for func_name in rettype_pair[0]:
+        func = gen_str_method(func_name, rettype_pair[1])
+        setattr(BodoStringMethods, func_name, func)
+
+# Generates Series.dt accessors
 for accessor_pair in dt_accessors:
     for accessor_name in accessor_pair[0]:
         accessor = gen_dt_accessor(accessor_name, accessor_pair[1])
-        print(accessor_pair[1])
         setattr(BodoDateTimeMethods, accessor_name, property(accessor))

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1,4 +1,3 @@
-import datetime
 import inspect
 import typing as pt
 import warnings
@@ -381,8 +380,10 @@ class BodoStringMethods:
         self._series = series
 
         # Validates series type
-        if not isinstance(series, BodoSeries) or not all(
-            isinstance(elem, str) for elem in series
+        if not (
+            isinstance(series, BodoSeries)
+            and isinstance(series.dtype, pd.ArrowDtype)
+            and series.dtype.type is str
         ):
             raise AttributeError("Can only use .str accessor with string values!")
 
@@ -409,8 +410,11 @@ class BodoDatetimeProperties:
         self._series = series
 
         # Validates series type
-        if not isinstance(series, BodoSeries) or not all(
-            isinstance(elem, datetime.datetime) for elem in series
+        if not (
+            isinstance(series, BodoSeries)
+            and series.dtype
+            in (pd.ArrowDtype(pa.timestamp("ns")), pd.ArrowDtype(pa.date64())),
+            pd.ArrowDtype(pa.time64("ns")),
         ):
             raise AttributeError("Can only use .dt accessor with datetimelike values")
 
@@ -647,17 +651,10 @@ dt_accessors = [
             "day_of_year",
             "days_in_month",
             "quarter",
-            "is_month_start",
-            "is_month_end",
-            "is_quarter_start",
-            "is_quarter_end",
-            "is_year_start",
-            "is_year_end",
-            "is_leap_year",
             "daysinmonth",
             "days_in_month",
         ],
-        pd.ArrowDtype(pa.int64()),
+        pd.ArrowDtype(pa.int32()),
     ),
     # idx = 1: Series(Date)
     (
@@ -672,6 +669,19 @@ dt_accessors = [
             "time",
         ],
         pd.ArrowDtype(pa.time64("ns")),
+    ),
+    # idx = 3: Series(Boolean)
+    (
+        [
+            "is_month_start",
+            "is_month_end",
+            "is_quarter_start",
+            "is_quarter_end",
+            "is_year_start",
+            "is_year_end",
+            "is_leap_year",
+        ],
+        pd.ArrowDtype(pa.bool_()),
     ),
 ]
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -607,12 +607,15 @@ dt_accessors = [
             "is_year_end",
             "is_leap_year",
             "daysinmonth",
+            "days_in_month",
         ],
         pd.ArrowDtype(pa.int64()),
     ),
     # idx = 1: Series(Date)
     (
-        ["date"],
+        [
+            "date",
+        ],
         pd.ArrowDtype(pa.date32()),
     ),
     # idx = 2: Series(Time)
@@ -625,13 +628,13 @@ dt_accessors = [
 ]
 
 # Generates Series.str methods
-for rettype_pair in series_str_methods:
-    for func_name in rettype_pair[0]:
-        func = gen_str_method(func_name, rettype_pair[1])
+for str_pair in series_str_methods:
+    for func_name in str_pair[0]:
+        func = gen_str_method(func_name, str_pair[1])
         setattr(BodoStringMethods, func_name, func)
 
 # Generates Series.dt accessors
-for accessor_pair in dt_accessors:
-    for accessor_name in accessor_pair[0]:
-        accessor = gen_dt_accessor(accessor_name, accessor_pair[1])
+for dt_accessor_pair in dt_accessors:
+    for accessor_name in dt_accessor_pair[0]:
+        accessor = gen_dt_accessor(accessor_name, dt_accessor_pair[1])
         setattr(BodoDateTimeMethods, accessor_name, property(accessor))

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -355,6 +355,10 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
     def str(self):
         return BodoStringMethods(self)
 
+    @property
+    def dt(self):
+        return BodoDatetimeProperties(self)
+
     @check_args_fallback(unsupported="none")
     def map(self, arg, na_action=None):
         """
@@ -368,9 +372,21 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             self._plan, empty_series, "map", (arg, na_action), {}
         )
 
-    @property
-    def dt(self):
-        return BodoDatetimeProperties(self)
+    def isin(self, values):
+        """
+        Whether elements in Series are contained in values.
+
+        """
+
+        index = self.head(0).index
+        new_metadata = pd.Series(
+            dtype=pd.ArrowDtype(pa.bool_()),
+            name=self.name,
+            index=index,
+        )
+        return _get_series_python_func_plan(
+            self._plan, new_metadata, "isin", (values,), {}
+        )
 
 
 class BodoStringMethods:

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -584,17 +584,18 @@ def run_func_on_table(cpp_table, arrow_schema, result_type, in_args):
     return the result as a C++ table and column names.
     """
     input = cpp_table_to_df(cpp_table, arrow_schema)
-    func_path_str, is_series, is_method, args, kwargs = in_args
+    func_path_str, is_series, is_attr, args, kwargs = in_args
 
     if is_series:
         assert input.shape[1] == 1, "run_func_on_table: single column expected"
         input = input.iloc[:, 0]
 
-    if is_method:
+    if is_attr:
         func = input
         for atr in func_path_str.split("."):
             func = getattr(func, atr)
         if not callable(func):
+            # func is assumed to be an accessor
             out = func
         else:
             out = func(*args, **kwargs)

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -599,7 +599,6 @@ def run_func_on_table(cpp_table, arrow_schema, result_type, in_args):
     # astype can fail in some cases when input is empty
     if len(out):
         # TODO: verify this is correct for all possible result_type's
-        print(result_type)
         out_df = pd.DataFrame({"OUT": out.astype(pd.ArrowDtype(result_type))})
     else:
         out_df = pd.DataFrame({"OUT": _empty_pd_array(result_type)})

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -587,7 +587,10 @@ def run_func_on_table(cpp_table, arrow_schema, result_type, in_args):
         func = input
         for atr in func_path_str.split("."):
             func = getattr(func, atr)
-        out = func(*args, **kwargs)
+        if not callable(func):
+            out = func
+        else:
+            out = func(*args, **kwargs)
     else:
         # TODO: test this path
         func = _get_function_from_path(func_path_str)
@@ -596,6 +599,7 @@ def run_func_on_table(cpp_table, arrow_schema, result_type, in_args):
     # astype can fail in some cases when input is empty
     if len(out):
         # TODO: verify this is correct for all possible result_type's
+        print(result_type)
         out_df = pd.DataFrame({"OUT": out.astype(pd.ArrowDtype(result_type))})
     else:
         out_df = pd.DataFrame({"OUT": _empty_pd_array(result_type)})

--- a/bodo/tests/test_df_lib/test_datetime.py
+++ b/bodo/tests/test_df_lib/test_datetime.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+import bodo.pandas as bd
+from bodo.tests.utils import _test_equal
+
+
+def gen_dt_accessor_test(name):
+    """
+    Generates a parameterized test case for Series.str.<name> method.
+    """
+
+    def test_func():
+        date_m = pd.Series(pd.date_range("20130101 09:10:12", periods=10, freq="m"))
+        date_s = pd.Series(pd.date_range("20220101 09:10:12", periods=10, freq="s"))
+        date_y = pd.Series(pd.date_range("19990303 09:10:12", periods=10, freq="y"))
+
+        df = pd.DataFrame({"A": date_m, "B": date_s, "C": date_y})
+        bdf = bd.from_pandas(df)
+
+        keys = ["A", "B", "C"]
+
+        for key in keys:
+            pd_accessor = getattr(df.key.dt, name)
+            bodo_accessor = getattr(bdf.key.dt, name)
+
+        assert bodo_accessor.is_lazy_plan()
+        _test_equal(pd_accessor, bodo_accessor)
+
+    return test_func
+
+
+gen_dt_accessor_test("year")
+print("Success")

--- a/bodo/tests/test_df_lib/test_datetime.py
+++ b/bodo/tests/test_df_lib/test_datetime.py
@@ -1,18 +1,19 @@
 import pandas as pd
 
 import bodo.pandas as bd
+from bodo.pandas.series import dt_accessors
 from bodo.tests.utils import _test_equal
 
 
 def gen_dt_accessor_test(name):
     """
-    Generates a parameterized test case for Series.str.<name> method.
+    Generates a test case for Series.dt.<name> accessor.
     """
 
     def test_func():
-        date_m = pd.Series(pd.date_range("20130101 09:10:12", periods=10, freq="m"))
+        date_m = pd.Series(pd.date_range("20130101 09:10:12", periods=10, freq="MS"))
         date_s = pd.Series(pd.date_range("20220101 09:10:12", periods=10, freq="s"))
-        date_y = pd.Series(pd.date_range("19990303 09:10:12", periods=10, freq="y"))
+        date_y = pd.Series(pd.date_range("19990303 09:10:12", periods=10, freq="YE"))
 
         df = pd.DataFrame({"A": date_m, "B": date_s, "C": date_y})
         bdf = bd.from_pandas(df)
@@ -20,14 +21,17 @@ def gen_dt_accessor_test(name):
         keys = ["A", "B", "C"]
 
         for key in keys:
-            pd_accessor = getattr(df.key.dt, name)
-            bodo_accessor = getattr(bdf.key.dt, name)
-
-        assert bodo_accessor.is_lazy_plan()
-        _test_equal(pd_accessor, bodo_accessor)
+            a = getattr(df, key)
+            b = getattr(bdf, key)
+            pd_accessor = getattr(a.dt, name)
+            bodo_accessor = getattr(b.dt, name)
+            assert bodo_accessor.is_lazy_plan()
+            _test_equal(pd_accessor, bodo_accessor, check_pandas_types=False)
 
     return test_func
 
 
-gen_dt_accessor_test("year")
-print("Success")
+for accessor_pair in dt_accessors:
+    for accessor_name in accessor_pair[0]:
+        test = gen_dt_accessor_test(accessor_name)
+        globals()[f"test_dt_{accessor_name}"] = test

--- a/docs/docs/api_docs/dataframe_lib/series/index.md
+++ b/docs/docs/api_docs/dataframe_lib/series/index.md
@@ -1,4 +1,39 @@
 # Series API
+The Bodo DataFrame Library supports Pandas Series methods and accessors that are listed below. They can be accessed through `BodoSeries` and follow the same behavior as their Pandas equivalents. For details on usage, we link to the corresponding Pandas documentation.
+
+### DateTime accessors
+
+!!! note
+	Input must be a Series of `datetime64` data.
+
+- [`bodo.pandas.BodoSeries.dt.year`][bodoseriesdtyear] 
+- [`bodo.pandas.BodoSeries.dt.month`][bodoseriesdtmonth] 
+- [`bodo.pandas.BodoSeries.dt.day`][bodoseriesdtday] 
+- [`bodo.pandas.BodoSeries.dt.hour`][bodoseriesdthour] 
+- [`bodo.pandas.BodoSeries.dt.minute`][bodoseriesdtminute] 
+- [`bodo.pandas.BodoSeries.dt.second`][bodoseriesdtsecond] 
+- [`bodo.pandas.BodoSeries.dt.microsecond`][bodoseriesdtmicrosecond] 
+- [`bodo.pandas.BodoSeries.dt.nanosecond`][bodoseriesdtnanosecond] 
+- [`bodo.pandas.BodoSeries.dt.dayofweek`][bodoseriesdtdayofweek] 
+- [`bodo.pandas.BodoSeries.dt.day_of_week`][bodoseriesdtday_of_week] 
+- [`bodo.pandas.BodoSeries.dt.weekday`][bodoseriesdtweekday] 
+- [`bodo.pandas.BodoSeries.dt.dayofyear`][bodoseriesdtdayofyear] 
+- [`bodo.pandas.BodoSeries.dt.day_of_year`][bodoseriesdtday_of_year] 
+- [`bodo.pandas.BodoSeries.dt.days_in_month`][bodoseriesdtdays_in_month] 
+- [`bodo.pandas.BodoSeries.dt.quarter`][bodoseriesdtquarter]
+- [`bodo.pandas.BodoSeries.dt.is_month_start`][bodoseriesdtis_month_start] 
+- [`bodo.pandas.BodoSeries.dt.is_month_end`][bodoseriesdtis_month_end] 
+- [`bodo.pandas.BodoSeries.dt.is_quarter_start`][bodoseriesdtis_quarter_start] 
+- [`bodo.pandas.BodoSeries.dt.is_quarter_end`][bodoseriesdtis_quarter_end] 
+- [`bodo.pandas.BodoSeries.dt.is_year_start`][bodoseriesdtis_year_start] 
+- [`bodo.pandas.BodoSeries.dt.is_year_end`][bodoseriesdtis_year_end] 
+- [`bodo.pandas.BodoSeries.dt.is_leap_year`][bodoseriesdtis_leap_year] 
+- [`bodo.pandas.BodoSeries.dt.daysinmonth`][bodoseriesdtdaysinmonth] 
+- [`bodo.pandas.BodoSeries.dt.days_in_month`][bodoseriesdtdays_in_month] 
+- [`bodo.pandas.BodoSeries.dt.date`][bodoseriesdtdate] 
+- [`bodo.pandas.BodoSeries.dt.time`][bodoseriesdttime] 
+
+
 ### Function application
 - [`bodo.pandas.BodoSeries.map`][bodoseriesmap]
 
@@ -7,10 +42,6 @@
 - [`bodo.pandas.BodoSeries.head`][bodoserieshead]
 
 ### String handling
-
-
-Methods below are available through `BodoSeries.str` and follow the same behavior as their Pandas equivalents. For details on usage, we link to the corresponding Pandas documentation.
-
 
 - [`bodo.pandas.BodoSeries.str.capitalize`][bodoseriesstrcapitalize]
 - [`bodo.pandas.BodoSeries.str.casefold`][bodoseriesstrcasefold]
@@ -56,7 +87,6 @@ Methods below are available through `BodoSeries.str` and follow the same behavio
 - [`bodo.pandas.BodoSeries.str.upper`][bodoseriesstrupper]
 - [`bodo.pandas.BodoSeries.str.wrap`][bodoseriesstrwrap]
 - [`bodo.pandas.BodoSeries.str.zfill`][bodoseriesstrzfill]
-
 
 
 [bodoserieshead]: ../series/head.md
@@ -106,3 +136,31 @@ Methods below are available through `BodoSeries.str` and follow the same behavio
 [bodoseriesstrupper]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.upper.html
 [bodoseriesstrwrap]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.wrap.html
 [bodoseriesstrzfill]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.zfill.html
+
+
+[bodoseriesdtyear]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.year.html
+[bodoseriesdtmonth]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.month.html
+[bodoseriesdtday]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.day.html
+[bodoseriesdthour]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.hour.html
+[bodoseriesdtminute]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.minute.html
+[bodoseriesdtsecond]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.second.html
+[bodoseriesdtmicrosecond]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.microsecond.html
+[bodoseriesdtnanosecond]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.nanosecond.html
+[bodoseriesdtdayofweek]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.dayofweek.html
+[bodoseriesdtday_of_week]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.dayofweek.html
+[bodoseriesdtweekday]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.weekday.html
+[bodoseriesdtdayofyear]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.dayofyear.html
+[bodoseriesdtday_of_year]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.dayofyear.html
+[bodoseriesdtdays_in_month]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.days_in_month.html
+[bodoseriesdtquarter]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.quarter.html
+[bodoseriesdtis_month_start]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.is_month_start.html
+[bodoseriesdtis_month_end]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.is_month_end.html
+[bodoseriesdtis_quarter_start]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.is_quarter_start.html
+[bodoseriesdtis_quarter_end]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.is_quarter_end.html
+[bodoseriesdtis_year_start]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.is_year_start.html
+[bodoseriesdtis_year_end]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.is_year_end.html
+[bodoseriesdtis_leap_year]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.is_leap_year.html
+[bodoseriesdtdaysinmonth]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.daysinmonth.html
+[bodoseriesdtdays_in_month]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.days_in_month.html
+[bodoseriesdtdate]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.date.html
+[bodoseriesdttime]: https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.time.html

--- a/docs/docs/api_docs/dataframe_lib/series/index.md
+++ b/docs/docs/api_docs/dataframe_lib/series/index.md
@@ -1,6 +1,10 @@
 # Series API
 The Bodo DataFrame Library supports Pandas Series methods and accessors that are listed below. They can be accessed through `BodoSeries` and follow the same behavior as their Pandas equivalents. For details on usage, we link to the corresponding Pandas documentation.
 
+!!! note
+	If the user code encounters an unsupported Pandas API or an unsupported parameter, Bodo DataFrame library gracefully falls back to native Pandas. See [overview][overview] of the Bodo DataFrame Library for more info. 
+
+
 ### Datetime Properties
 
 !!! note
@@ -91,6 +95,8 @@ The Bodo DataFrame Library supports Pandas Series methods and accessors that are
 
 [bodoserieshead]: ../series/head.md
 [bodoseriesmap]: ../series/map.md
+
+[overview]: ../index.md/#lazy-evaluation-and-fallback-to-pandas
 
 [bodoseriesstrcapitalize]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.capitalize.html
 [bodoseriesstrcasefold]: https://pandas.pydata.org/docs/reference/api/pandas.Series.str.casefold.html

--- a/docs/docs/api_docs/dataframe_lib/series/index.md
+++ b/docs/docs/api_docs/dataframe_lib/series/index.md
@@ -1,7 +1,7 @@
 # Series API
 The Bodo DataFrame Library supports Pandas Series methods and accessors that are listed below. They can be accessed through `BodoSeries` and follow the same behavior as their Pandas equivalents. For details on usage, we link to the corresponding Pandas documentation.
 
-### DateTime accessors
+### Datetime Properties
 
 !!! note
 	Input must be a Series of `datetime64` data.

--- a/docs/docs/api_docs/dataframe_lib/series/index.md
+++ b/docs/docs/api_docs/dataframe_lib/series/index.md
@@ -8,7 +8,7 @@ The Bodo DataFrame Library supports Pandas Series methods and accessors that are
 ### Datetime Properties
 
 !!! note
-	Input must be a Series of `datetime64` data.
+	Input must be a Series of `datetime-like` data.
 
 - [`bodo.pandas.BodoSeries.dt.year`][bodoseriesdtyear] 
 - [`bodo.pandas.BodoSeries.dt.month`][bodoseriesdtmonth] 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Auto-generates a large subset of Series.dt accessors (excluding methods, which take in arguments).
Single unsupported accessor is `Series.dt.timetz`. 
Also adds validation in `BodoStringMethods` and `BodoDatetimeProperties` inside `__init__`, such that if `.str` or `.dt` accessors used on unmatching types, raises AttributeError identical to Pandas.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, automates simple unit tests for each accessor. 

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Support for majority of datetime accessors. 

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.