### PR TITLE
BSE-4817: Scatter catalog name and properties instead of object

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -147,7 +147,8 @@ def read_iceberg(
         "LogicalGetIcebergRead",
         empty_df,
         table_identifier,
-        catalog,
+        catalog_name,
+        catalog_properties,
         pyiceberg.expressions.AlwaysTrue(),
         __pa_schema=arrow_schema,
     )

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -651,7 +651,9 @@ cdef class LogicalGetIcebergRead(LogicalOperator):
     """
     cdef readonly str table_identifier
 
-    def __cinit__(self, object out_schema, str table_identifier, object catalog, object iceberg_filter):
+    def __cinit__(self, object out_schema, str table_identifier, object catalog_name, object catalog_properties, object iceberg_filter):
+        import pyiceberg.catalog
+        cdef object catalog = pyiceberg.catalog.load_catalog(catalog_name, **catalog_properties)
         self.out_schema = out_schema
         self.table_identifier = table_identifier
         cdef unique_ptr[CLogicalGet] c_logical_get = make_iceberg_get_node(out_schema, table_identifier.encode(), catalog, iceberg_filter)

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -448,7 +448,10 @@ def execute_plan(plan: LazyPlan):
 
         duckdb_plan = plan.generate_duckdb()
 
-        if bodo.dataframe_library_dump_plans:
+        if (
+            bodo.dataframe_library_dump_plans
+            and bodo.libs.distributed_api.get_rank() == 0
+        ):
             print(duckdb_plan.toString())
 
         # Print the plan before optimization
@@ -459,7 +462,10 @@ def execute_plan(plan: LazyPlan):
 
         optimized_plan = plan_optimizer.py_optimize_plan(duckdb_plan)
 
-        if bodo.dataframe_library_dump_plans:
+        if (
+            bodo.dataframe_library_dump_plans
+            and bodo.libs.distributed_api.get_rank() == 0
+        ):
             print(optimized_plan.toString())
 
         # Print the plan after optimization


### PR DESCRIPTION
## Changes included in this PR
This came up while testing s3 tables catalog for the demo, some catalogs have properties with locks which can't be pickled. To remedy this we just scatter the arguments to load_catalog so the workers can load their own catalog instead.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Manual testing and PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Catalogs containing locks will work
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.