### PR TITLE
Avoid extra count query for print

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -201,6 +201,13 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             case ExecState.COLLECTED:
                 return super().__len__()
 
+    def __repr__(self):
+        # Pandas repr implementation calls len() first which will execute an extra
+        # count query before the actual plan which is unnecessary.
+        if self._exec_state == ExecState.PLAN:
+            self.execute_plan()
+        return super().__repr__()
+
     @property
     def index(self):
         self.execute_plan()

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -424,6 +424,13 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             case ExecState.COLLECTED:
                 return super().__len__()
 
+    def __repr__(self):
+        # Pandas repr implementation calls len() first which will execute an extra
+        # count query before the actual plan which is unnecessary.
+        if self._exec_state == ExecState.PLAN:
+            self.execute_plan()
+        return super().__repr__()
+
     @property
     def index(self):
         self.execute_plan()


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Pandas repr implementation calls len() first which will execute an extra count query before the actual plan which is unnecessary. This change avoids it.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing CI.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.