### PR TITLE
Support setting dataframe column using existing column

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -849,19 +849,31 @@ def _add_proj_expr_to_plan(
 
     # Get the function expression from the value plan to be added
     func_expr = value_plan.args[1][0]
-    if func_expr.plan_class != "PythonScalarFuncExpression":
-        return None
-    func_expr = (
-        _update_func_expr_source(func_expr, df_plan, ikey)
-        if replace_func_source
-        # Copy the function expression to avoid modifying the original one below
-        else LazyPlan(
-            "PythonScalarFuncExpression",
+
+    # Handle trivial cases like df["C"] = df["B"]
+    if func_expr.plan_class == "ColRefExpression":
+        # Copy since empty_data is changed below
+        func_expr = LazyPlan(
+            "ColRefExpression",
             func_expr.empty_data,
             *func_expr.args,
             **func_expr.kwargs,
         )
-    )
+    elif func_expr.plan_class == "PythonScalarFuncExpression":
+        func_expr = (
+            _update_func_expr_source(func_expr, df_plan, ikey)
+            if replace_func_source
+            # Copy the function expression to avoid modifying the original one below
+            else LazyPlan(
+                "PythonScalarFuncExpression",
+                func_expr.empty_data,
+                *func_expr.args,
+                **func_expr.kwargs,
+            )
+        )
+    else:
+        return None
+
     # Update output column name
     func_expr.empty_data = func_expr.empty_data.set_axis([key], axis=1)
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -655,6 +655,14 @@ def test_set_df_column(datapath, index_val):
     assert bdf.is_lazy_plan()
     _test_equal(bdf, pdf, check_pandas_types=False)
 
+    # Trivial case: set a column to existing column
+    bdf = bd.from_pandas(df)
+    bdf["D"] = bdf["B"]
+    pdf = df.copy()
+    pdf["D"] = pdf["B"]
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
 
 def test_parquet_read_partitioned(datapath):
     """Test reading a partitioned parquet dataset."""


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for trivial cases like `bdf["D"] = bdf["B"]`.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Codes like `bdf["D"] = bdf["B"]` working now.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.