### PR TITLE
BSE-4817: DuckDB TableFilter to PyIceberg Filter

### DIFF
--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -239,7 +239,7 @@ std::string expressionTypeToPyicebergclass(duckdb::ExpressionType expr_type) {
 PyObject *_duckdbFilterToPyicebergFilter(
     duckdb::unique_ptr<duckdb::TableFilter> tf, const std::string field_name,
     PyObjectPtr &pyiceberg_expression_mod) {
-    PyObject *py_expr;
+    PyObject *py_expr = nullptr;
     switch (tf->filter_type) {
         case duckdb::TableFilterType::CONSTANT_COMPARISON: {
             duckdb::unique_ptr<duckdb::ConstantFilter> constantFilter =

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -208,6 +208,7 @@ std::shared_ptr<arrow::Scalar> convertDuckdbValueToArrowScalar(
     }
     return scalar_res.ValueOrDie();
 }
+
 std::string expressionTypeToPyicebergclass(duckdb::ExpressionType expr_type) {
     switch (expr_type) {
         case duckdb::ExpressionType::COMPARE_EQUAL:

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -2,6 +2,7 @@
 #include <arrow/compute/api.h>
 #include <arrow/python/pyarrow.h>
 #include "../io/arrow_compat.h"
+#include "../libs/_utils.h"
 #include "duckdb/planner/filter/constant_filter.hpp"
 
 std::variant<int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t,
@@ -181,4 +182,20 @@ std::shared_ptr<arrow::DataType> duckdbTypeToArrow(
                 "duckdbTypeToArrow unsupported LogicalType conversion " +
                 std::to_string(static_cast<int>(type.id())));
     }
+}
+
+PyObject *duckdbFilterToPyicebergFilter(
+    duckdb::TableFilterSet &filters,
+    std::shared_ptr<arrow::Schema> arrow_schema) {
+    PyObjectPtr pyiceberg_expression_mod =
+        PyImport_ImportModule("pyiceberg.expressions");
+    if (!pyiceberg_expression_mod) {
+        throw std::runtime_error(
+            "Failed to import pyiceberg.expressions module");
+    }
+    // Default return is pyiceberg.expressions.AlwaysTrue()
+    PyObject *ret = PyObject_CallMethod(pyiceberg_expression_mod.get(),
+                                        "AlwaysTrue", nullptr);
+
+    return ret;
 }

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -82,3 +82,7 @@ std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> getColRefMap(
  */
 std::shared_ptr<arrow::DataType> duckdbTypeToArrow(
     const duckdb::LogicalType &type);
+
+PyObject *duckdbFilterToPyicebergFilter(
+    duckdb::TableFilterSet &filters,
+    std::shared_ptr<arrow::Schema> arrow_schema);

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -83,6 +83,12 @@ std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> getColRefMap(
 std::shared_ptr<arrow::DataType> duckdbTypeToArrow(
     const duckdb::LogicalType &type);
 
-PyObject *duckdbFilterToPyicebergFilter(
+/**
+ * @brief Convert duckdb table filters to pyiceberg expressions.
+ * @param filters - the duckdb table filters to convert
+ * @param arrow_schema - the arrow schema to bind the filters to
+ * @return a PyObject representing the pyiceberg expression
+ */
+PyObject *duckdbFilterSetToPyicebergFilter(
     duckdb::TableFilterSet &filters,
     std::shared_ptr<arrow::Schema> arrow_schema);

--- a/bodo/pandas/physical/read_iceberg.cpp
+++ b/bodo/pandas/physical/read_iceberg.cpp
@@ -139,7 +139,7 @@ PhysicalReadIceberg::create_internal_reader(
         duckdbFilterToPyicebergFilter(filter_exprs, arrow_schema);
 
     // Perform the python & to combine the filters
-    // IcebergParquetReader takes ownership
+    // IcebergParquetReader takes ownership, so don't decref
     PyObject *py_iceberg_filter_and_duckdb_filter = PyObject_CallMethod(
         duckdb_iceberg_filter, "__and__", "O", iceberg_filter);
     if (!py_iceberg_filter_and_duckdb_filter) {

--- a/bodo/pandas/physical/read_iceberg.cpp
+++ b/bodo/pandas/physical/read_iceberg.cpp
@@ -136,7 +136,7 @@ PhysicalReadIceberg::create_internal_reader(
     // We need to & the iceberg_filter with converted duckdb table filters
     // to apply the filters at the file level.
     PyObjectPtr duckdb_iceberg_filter =
-        duckdbFilterToPyicebergFilter(filter_exprs, arrow_schema);
+        duckdbFilterSetToPyicebergFilter(filter_exprs, arrow_schema);
 
     // Perform the python & to combine the filters
     // IcebergParquetReader takes ownership, so don't decref


### PR DESCRIPTION
## Changes included in this PR
Added utilites to convert duckdb tablefilters to pyicberg filters for file planning
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
I'll add tests when we have tablefilterset -> arrow expr fstring in the next PR. Existing tests pass.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
NA
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.