### PR TITLE
Reduce codecov target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
         enabled: true
         # Overall coverage must remain at 80% or higher, 
         # with a tolerance of up to 0.2% below the target before failing.
-        target: 80%
+        target: 60%
         threshold: 0.2
     patch:
       default:


### PR DESCRIPTION
As title, until we get coverage working for spawn mode/df lib tests, no reason to have this always be red