### PR TITLE
Make send recv test deterministic

### DIFF
--- a/bodo/tests/test_distributed.py
+++ b/bodo/tests/test_distributed.py
@@ -2785,8 +2785,7 @@ def test_send_recv(val):
 
         return None
 
-    expected_out = val if bodo.get_rank() == recv_rank else None
-    check_func(impl, (val, recv_rank, send_rank), py_output=expected_out)
+    check_func(impl, (val, recv_rank, send_rank))
 
 
 @pytest.mark.slow

--- a/bodo/tests/test_distributed.py
+++ b/bodo/tests/test_distributed.py
@@ -2756,18 +2756,13 @@ def test_send_recv(val):
 
     if bodo.get_size() == 1:
         return
-    np.random.seed(np.uint64(hash(val)).astype(np.uint32))
-    send_rank = np.random.randint(bodo.get_size())
-    recv_rank = np.random.randint(bodo.get_size())
-    # make sure send_rank != recv_rank
-    if send_rank == recv_rank:
-        if send_rank == 0:
-            recv_rank = 1
-        else:
-            recv_rank = send_rank - 1
-    assert send_rank != recv_rank
-    print(f"send_rank: {send_rank}")
-    print(f"recv_rank: {recv_rank}")
+
+    if val:
+        send_rank = 0
+        recv_rank = 1
+    else:
+        send_rank = 1
+        recv_rank = 0
 
     send_type = bodo.typeof(val)
 
@@ -2783,7 +2778,10 @@ def test_send_recv(val):
 
         return None
 
-    check_func(impl, (val, recv_rank, send_rank))
+    expected_out = val if bodo.get_rank() == recv_rank else None
+    check_func(
+        impl, (val, recv_rank, send_rank), py_output=expected_out, only_1DVar=True
+    )
 
 
 @pytest.mark.slow

--- a/bodo/tests/test_distributed.py
+++ b/bodo/tests/test_distributed.py
@@ -2757,12 +2757,19 @@ def test_send_recv(val):
     if bodo.get_size() == 1:
         return
 
-    if val:
-        send_rank = 0
-        recv_rank = 1
-    else:
-        send_rank = 1
-        recv_rank = 0
+    seed = np.uint32(val)
+    np.random.seed(seed)
+    send_rank = np.random.randint(bodo.get_size())
+    recv_rank = np.random.randint(bodo.get_size())
+    # make sure send_rank != recv_rank
+    if send_rank == recv_rank:
+        if send_rank == 0:
+            recv_rank = 1
+        else:
+            recv_rank = send_rank - 1
+    assert send_rank != recv_rank
+    print(f"send_rank: {send_rank}")
+    print(f"recv_rank: {recv_rank}")
 
     send_type = bodo.typeof(val)
 
@@ -2779,9 +2786,7 @@ def test_send_recv(val):
         return None
 
     expected_out = val if bodo.get_rank() == recv_rank else None
-    check_func(
-        impl, (val, recv_rank, send_rank), py_output=expected_out, only_1DVar=True
-    )
+    check_func(impl, (val, recv_rank, send_rank), py_output=expected_out)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Changes included in this PR
Previously this test was using `hash` which is non-deterministic across ranks. I think this makes it more clear.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.