### PR TITLE
Support simple path read/write for Iceberg tables and partition/sort spec in write

### DIFF
--- a/bodo/io/iceberg/write.py
+++ b/bodo/io/iceberg/write.py
@@ -798,6 +798,8 @@ def start_write_rank_0(
 
         io = table.io
         data_loc = _get_write_data_path(properties, table.location())
+        partition_spec = table.spec()
+        sort_order = table.sort_order()
 
     else:
         assert mode == "append"

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -290,7 +290,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         )
         execute_plan(write_plan)
 
-    @check_args_fallback(unsupported="snapshot_properties")
+    @check_args_fallback(unsupported="none")
     def to_iceberg(
         self,
         table_identifier: str,
@@ -324,6 +324,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         elif catalog_properties is None:
             catalog_properties = {}
 
+        if snapshot_properties is None:
+            snapshot_properties = {}
+
         catalog = pyiceberg.catalog.load_catalog(catalog_name, **catalog_properties)
 
         if_exists = "append" if append else "replace"
@@ -347,6 +350,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             False,
             None,
             location,
+            snapshot_properties,
         )
         bucket_region = bodo.io.fs_io.get_s3_bucket_region_wrapper(table_loc, False)
         max_pq_chunksize = properties.get(
@@ -391,6 +395,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             partition_infos,
             partition_spec,
             sort_order_id,
+            snapshot_properties,
         )
         if not success:
             raise BodoError("Iceberg write failed.")

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -365,6 +365,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             False,
             None,
             location,
+            partition_spec,
+            sort_order,
             snapshot_properties,
         )
         bucket_region = bodo.io.fs_io.get_s3_bucket_region_wrapper(table_loc, False)

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -317,6 +317,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         import pyiceberg.table.sorting
 
         from bodo.pandas.base import _empty_like
+        from bodo.utils.typing import CreateTableMetaType
 
         # Support simple directory only calls like:
         # df.to_iceberg("table", location="/path/to/table")
@@ -337,7 +338,16 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             sort_order = pyiceberg.table.sorting.UNSORTED_SORT_ORDER
 
         if properties is None:
-            properties = {}
+            properties = ()
+        else:
+            if not isinstance(properties, dict):
+                raise BodoError(
+                    "Iceberg write properties must be a dictionary, got: "
+                    f"{type(properties)}"
+                )
+            # Convert properties to a tuple of items to match expected type in
+            # CreateTableMetaType
+            properties = tuple(properties.items())
 
         if snapshot_properties is None:
             snapshot_properties = {}
@@ -363,7 +373,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             df_schema,
             if_exists,
             False,
-            None,
+            CreateTableMetaType(None, None, properties),
             location,
             partition_spec,
             sort_order,

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -312,8 +312,18 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
 
         # TODO: add `partition_spec`, `sort_order` and `properties` arguments
 
-        if catalog_properties is None:
+        # Support simple directory only calls like:
+        # df.to_iceberg("table", location="/path/to/table")
+        if catalog_name is None and catalog_properties is None and location is not None:
+            catalog_properties = {
+                pyiceberg.catalog.PY_CATALOG_IMPL: "bodo.io.iceberg.catalog.dir.DirCatalog",
+                pyiceberg.catalog.WAREHOUSE_LOCATION: location,
+            }
+            # DirCatalog does not support extra location argument in create_table
+            location = None
+        elif catalog_properties is None:
             catalog_properties = {}
+
         catalog = pyiceberg.catalog.load_catalog(catalog_name, **catalog_properties)
 
         if_exists = "append" if append else "replace"

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -39,14 +39,7 @@ def test_simple_table_read(
 ):
     db_schema, warehouse_loc = iceberg_database(table_name)
     py_out = pyiceberg_reader.read_iceberg_table_single_rank(table_name, db_schema)
-    bodo_out = bpd.read_iceberg(
-        f"{db_schema}.{table_name}",
-        None,
-        {
-            pyiceberg.catalog.PY_CATALOG_IMPL: "bodo.io.iceberg.catalog.dir.DirCatalog",
-            pyiceberg.catalog.WAREHOUSE_LOCATION: warehouse_loc,
-        },
-    )
+    bodo_out = bpd.read_iceberg(f"{db_schema}.{table_name}", location=warehouse_loc)
     _test_equal(
         bodo_out,
         py_out,
@@ -544,11 +537,7 @@ def test_write():
     )
 
     bdf = bpd.from_pandas(df)
-    catalog_properties = {
-        pyiceberg.catalog.PY_CATALOG_IMPL: "bodo.io.iceberg.catalog.dir.DirCatalog",
-        pyiceberg.catalog.WAREHOUSE_LOCATION: "iceberg_warehouse",
-    }
-    bdf.to_iceberg("test_table", None, catalog_properties=catalog_properties)
+    bdf.to_iceberg("test_table", location="iceberg_warehouse")
     assert bdf.is_lazy_plan()
 
     # Read using PyIceberg to verify the write

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -555,6 +555,7 @@ def test_write():
             location=path,
             partition_spec=part_spec,
             sort_order=sort_order,
+            properties={"p_a1": "pvalue_a1"},
             snapshot_properties={"p_key": "p_value"},
         )
         assert bdf.is_lazy_plan()
@@ -579,5 +580,6 @@ def test_write():
             },
         )
         table = catalog.load_table("test_table")
+        assert table.properties.get("p_a1") == "pvalue_a1"
         snapshot = table.current_snapshot()
         assert snapshot.summary.get("p_key") == "p_value"

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -1,5 +1,7 @@
 import datetime
 import operator
+import os
+import tempfile
 
 import numba.core.utils
 import numpy as np
@@ -537,32 +539,36 @@ def test_write():
     )
 
     bdf = bpd.from_pandas(df)
-    bdf.to_iceberg(
-        "test_table",
-        location="iceberg_warehouse",
-        snapshot_properties={"p_key": "p_value"},
-    )
-    assert bdf.is_lazy_plan()
 
-    # Read using PyIceberg to verify the write
-    out_df = pyiceberg_reader.read_iceberg_table("test_table", "iceberg_warehouse")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "iceberg_warehouse")
 
-    _test_equal(
-        out_df,
-        df,
-        check_pandas_types=False,
-        sort_output=True,
-        reset_index=True,
-    )
+        bdf.to_iceberg(
+            "test_table",
+            location=path,
+            snapshot_properties={"p_key": "p_value"},
+        )
+        assert bdf.is_lazy_plan()
 
-    # Check that the snapshot properties are set correctly
-    catalog = pyiceberg.catalog.load_catalog(
-        None,
-        **{
-            pyiceberg.catalog.PY_CATALOG_IMPL: "bodo.io.iceberg.catalog.dir.DirCatalog",
-            pyiceberg.catalog.WAREHOUSE_LOCATION: "iceberg_warehouse",
-        },
-    )
-    table = catalog.load_table("test_table")
-    snapshot = table.current_snapshot()
-    assert snapshot.summary.get("p_key") == "p_value"
+        # Read using PyIceberg to verify the write
+        out_df = pyiceberg_reader.read_iceberg_table("test_table", path)
+
+        _test_equal(
+            out_df,
+            df,
+            check_pandas_types=False,
+            sort_output=True,
+            reset_index=True,
+        )
+
+        # Check that the snapshot properties are set correctly
+        catalog = pyiceberg.catalog.load_catalog(
+            None,
+            **{
+                pyiceberg.catalog.PY_CATALOG_IMPL: "bodo.io.iceberg.catalog.dir.DirCatalog",
+                pyiceberg.catalog.WAREHOUSE_LOCATION: path,
+            },
+        )
+        table = catalog.load_table("test_table")
+        snapshot = table.current_snapshot()
+        assert snapshot.summary.get("p_key") == "p_value"

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -10,6 +10,9 @@ import pyarrow as pa
 import pyiceberg.catalog
 import pyiceberg.expressions
 import pytest
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.table.sorting import SortField, SortOrder
+from pyiceberg.transforms import IdentityTransform
 
 import bodo.pandas as bpd
 from bodo.io.iceberg.catalog.dir import DirCatalog
@@ -543,9 +546,15 @@ def test_write():
     with tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, "iceberg_warehouse")
 
+        part_spec = PartitionSpec(
+            PartitionField(2, 1001, IdentityTransform(), "id_part")
+        )
+        sort_order = SortOrder(SortField(source_id=4, transform=IdentityTransform()))
         bdf.to_iceberg(
             "test_table",
             location=path,
+            partition_spec=part_spec,
+            sort_order=sort_order,
             snapshot_properties={"p_key": "p_value"},
         )
         assert bdf.is_lazy_plan()

--- a/docs/docs/api_docs/dataframe_lib/dataframe.md
+++ b/docs/docs/api_docs/dataframe_lib/dataframe.md
@@ -387,3 +387,78 @@ Output:
 ```
 
 ---
+
+## BodoDataFrame.to\_iceberg
+``` py
+BodoDataFrame.to_iceberg(
+        table_identifier,
+        catalog_name=None,
+        *,
+        catalog_properties=None,
+        location=None,
+        append=False,
+        partition_spec=None,
+        sort_order=None,
+        properties=None,
+        snapshot_properties=None
+)
+```
+Write a DataFrame as an Iceberg dataset.
+
+Refer to [`pandas.DataFrame.to_iceberg`](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.to_iceberg.html) for more details.
+
+!!! warning
+    This function is experimental in Pandas and may change in future releases.
+
+<p class="api-header">Parameters</p>
+
+: __table_identifier: *str*:__ Table identifier to write
+: __catalog_name: *str, optional*:__ Name of the catalog to use. If not provided, the default catalog will be used. See [PyIceberg's documentation](https://py.iceberg.apache.org/#connecting-to-a-catalog) for more details.
+: __catalog_properties: *dict[str, Any], optional*:__ Properties for the catalog connection.
+: __location: *str, optional*:__ Location of the table (if supported by the catalog)
+: __append: *bool*:__ Append or overwrite if the table exists
+: __partition_spec: *PartitionSpec, optional*:__ PyIceberg partition spec for the table (only used if creating a new table). See [PyIceberg's documentation](https://py.iceberg.apache.org/api/#partitions) for more details.
+: __sort_order: *SortOrder, optional*:__ PyIceberg sort order for the table (only used if creating a new table). See [PyIceberg's documentation](https://py.iceberg.apache.org/api/#partitions) for more details.
+: __properties: *dict[str, Any], optional*:__ Properties to add to the new table.
+: __snapshot_properties: *dict[str, Any], optional*:__ Properties to add to the new table snapshot.
+
+<p class="api-header">Example</p>
+
+
+Simple write of a table on the filesystem without a catalog:
+``` py
+import bodo.pandas as bodo_pd
+import pandas as pd
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.table.sorting import SortField, SortOrder
+
+df = pd.DataFrame(
+        {
+            "one": [-1.0, 1.3, 2.5, 3.0, 4.0, 6.0, 10.0],
+            "two": ["foo", "bar", "baz", "foo", "bar", "baz", "foo"],
+            "three": [True, False, True, True, True, False, False],
+            "four": [-1.0, 5.1, 2.5, 3.0, 4.0, 6.0, 11.0],
+            "five": ["foo", "bar", "baz", None, "bar", "baz", "foo"],
+        }
+    )
+
+bdf = bodo_pd.from_pandas(df)
+part_spec = PartitionSpec(PartitionField(2, 1001, IdentityTransform(), "id_part"))
+sort_order = SortOrder(SortField(source_id=4, transform=IdentityTransform()))
+bdf.to_iceberg("test_table", location="./iceberg_warehouse", partition_spec=part_spec, sort_order=sort_order)
+
+out_df = bodo_pd.read_iceberg("test_table", location="./iceberg_warehouse")
+# Only reads Parquet files of partition "foo" from storage
+print(out_df[out_df["two"] == "foo"])
+```
+
+Output:
+```
+    one  two  three  four  five
+0  -1.0  foo   True  -1.0   foo
+1   3.0  foo   True   3.0  <NA>
+2  10.0  foo  False  11.0   foo
+```
+
+---

--- a/docs/docs/api_docs/dataframe_lib/dataframe.md
+++ b/docs/docs/api_docs/dataframe_lib/dataframe.md
@@ -418,7 +418,7 @@ Refer to [`pandas.DataFrame.to_iceberg`](https://pandas.pydata.org/docs/dev/refe
 : __location: *str, optional*:__ Location of the table (if supported by the catalog)
 : __append: *bool*:__ Append or overwrite if the table exists
 : __partition_spec: *PartitionSpec, optional*:__ PyIceberg partition spec for the table (only used if creating a new table). See [PyIceberg's documentation](https://py.iceberg.apache.org/api/#partitions) for more details.
-: __sort_order: *SortOrder, optional*:__ PyIceberg sort order for the table (only used if creating a new table). See [PyIceberg's documentation](https://py.iceberg.apache.org/api/#partitions) for more details.
+: __sort_order: *SortOrder, optional*:__ PyIceberg sort order for the table (only used if creating a new table). See [PyIceberg's documentation](https://py.iceberg.apache.org/reference/pyiceberg/table/sorting/#pyiceberg.table.sorting.SortOrder) for more details.
 : __properties: *dict[str, Any], optional*:__ Properties to add to the new table.
 : __snapshot_properties: *dict[str, Any], optional*:__ Properties to add to the new table snapshot.
 

--- a/docs/docs/api_docs/dataframe_lib/io.md
+++ b/docs/docs/api_docs/dataframe_lib/io.md
@@ -76,6 +76,7 @@ bodo.pandas.read_iceberg(
     snapshot_id: int | None = None,
     limit: int | None = None,
     scan_properties: dict[str, Any] | None = None,
+    location: str | None = None,
 ) -> BodoDataFrame
 ```
 
@@ -95,6 +96,7 @@ Refer to [`pandas.read_iceberg`](https://pandas.pydata.org/docs/dev/reference/ap
 : __selected_fields: *tuple[str], optional*:__ Fields to select from the table, if not provided, all fields will be selected.
 : __snapshot_id: *int, optional*:__ ID of the snapshot to read from. If not provided, the latest snapshot will be used.
 : __limit: *int, optional*:__ Maximum number of rows to read. If not provided, all rows will be read.
+: __location: *str, optional*:__ Location for the table.
 
 : Non-default values for case_sensitive and scan_properties will trigger a fallback to [`pandas.read_iceberg`](https://pandas.pydata.org/docs/dev/reference/api/pandas.read_iceberg.html).
 
@@ -102,7 +104,15 @@ Refer to [`pandas.read_iceberg`](https://pandas.pydata.org/docs/dev/reference/ap
 <p class="api-header">Returns</p>
 : __BodoDataFrame__
 
-<p class="api-header">Example</p>
+<p class="api-header">Examples</p>
+
+Simple read of a table stored without a catalog on the filesystem:
+``` py
+import bodo
+import bodo.pandas as bodo_pd
+df = bodo_pd.read_iceberg("my_table", location="s3://path/to/iceberg/warehouse")
+```
+
 
 Read a table using a predefined PyIceberg catalog.
 ``` py


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Also adds support for `properties` and `snapshot_properties` fields in write.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Enhanced read/write support for Iceberg.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.