### PR TITLE
[BSE-4906] Support to_datetime and top-level redirect

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -5,7 +5,7 @@ import pyarrow as pa
 from pandas._libs import lib
 
 from bodo.pandas.frame import BodoDataFrame
-from bodo.pandas.series import BodoSeries
+from bodo.pandas.series import BodoSeries, _get_series_python_func_plan
 from bodo.pandas.utils import (
     BODO_NONE_DUMMY,
     LazyPlan,
@@ -193,3 +193,47 @@ def read_iceberg(
         )
 
     return wrap_plan(plan=plan)
+
+
+def to_datetime(
+    arg,
+    errors="raise",
+    dayfirst=False,
+    yearfirst=False,
+    utc=False,
+    format=None,
+    exact=lib.no_default,
+    unit=None,
+    infer_datetime_format=lib.no_default,
+    origin="unix",
+    cache=True,
+):
+    series = arg
+    dtype = pd.ArrowDtype(pa.timestamp("ns"))
+
+    index = series.head(0).index
+    new_metadata = pd.Series(
+        dtype=dtype,
+        name=series.name,
+        index=index,
+    )
+
+    return _get_series_python_func_plan(
+        series._plan,
+        new_metadata,
+        "pandas.to_datetime",
+        (),
+        {
+            "errors": "raise",
+            "dayfirst": False,
+            "yearfirst": False,
+            "utc": False,
+            "format": None,
+            "exact": lib.no_default,
+            "unit": None,
+            "infer_datetime_format": lib.no_default,
+            "origin": "unix",
+            "cache": True,
+        },
+        is_method=False,
+    )

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -253,6 +253,7 @@ def gen_redirect(name):
     """Returns top-level bodo.pandas redirect method of given name."""
 
     def method(obj, *args, **kwargs):
+        """Redirects top-level method <name> to Series.<name>"""
         if not isinstance(obj, BodoSeries):
             raise BodoLibNotImplementedException(
                 "Only supports BodoSeries obj: falling back to Pandas"

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -8,6 +8,7 @@ from bodo.pandas.frame import BodoDataFrame
 from bodo.pandas.series import BodoSeries, _get_series_python_func_plan
 from bodo.pandas.utils import (
     BODO_NONE_DUMMY,
+    BodoLibNotImplementedException,
     LazyPlan,
     LazyPlanDistributedArg,
     arrow_to_empty_df,
@@ -195,6 +196,7 @@ def read_iceberg(
     return wrap_plan(plan=plan)
 
 
+@check_args_fallback("all")
 def to_datetime(
     arg,
     errors="raise",
@@ -208,6 +210,10 @@ def to_datetime(
     origin="unix",
     cache=True,
 ):
+    if not isinstance(arg, BodoSeries):
+        raise BodoLibNotImplementedException(
+            "to_datetime() is not supported for arg that is not an instance of BodoSeries. Falling back to Pandas."
+        )
     series = arg
     dtype = pd.ArrowDtype(pa.timestamp("ns"))
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -690,7 +690,9 @@ class BodoDatetimeProperties:
             return object.__getattribute__(pd.Series(self._series).dt, name)
 
 
-def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwargs):
+def _get_series_python_func_plan(
+    series_proj, empty_data, func_name, args, kwargs, is_method=True
+):
     """Create a plan for calling a Series method in Python. Creates a proper
     PythonScalarFuncExpression with the correct arguments and a LogicalProjection.
     """
@@ -714,7 +716,7 @@ def _get_series_python_func_plan(series_proj, empty_data, func_name, args, kwarg
         (
             func_name,
             True,  # is_series
-            True,  # is_method
+            is_method,  # is_method
             args,  # args
             kwargs,  # kwargs
         ),

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1110,6 +1110,8 @@ dir_methods = [
             "isin",
             "notnull",
             "isnull",
+            "isna",
+            "notna",
         ],
         pd.ArrowDtype(pa.bool_()),
     ),

--- a/bodo/tests/test_df_lib/test_top_level.py
+++ b/bodo/tests/test_df_lib/test_top_level.py
@@ -1,0 +1,70 @@
+import pandas as pd
+import pytest
+
+import bodo.pandas as bd
+from bodo.tests.utils import _test_equal
+
+
+@pytest.fixture
+def nulls_df():
+    return pd.DataFrame(
+        {
+            "A": [1, None, 3],
+            "B": ["x", None, "z"],
+            "C": [None, None, None],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "top_func, method_name",
+    [
+        (bd.isna, "isna"),
+        (bd.isnull, "isnull"),
+        (bd.notna, "notna"),
+        (bd.notnull, "notnull"),
+    ],
+)
+def test_top_level_redirects(nulls_df, top_func, method_name):
+    bdf = bd.from_pandas(nulls_df)
+    for col in bdf.columns:
+        pd_obj = nulls_df[col]
+        bodo_obj = bdf[col]
+
+        pd_func = getattr(pd_obj, method_name)
+        bodo_func = lambda: top_func(bodo_obj)
+
+        pd_error = bodo_error = False
+        try:
+            out_pd = pd_func()
+        except Exception:
+            pd_error = True
+
+        try:
+            out_bd = bodo_func()
+            assert out_bd.is_lazy_plan()
+            out_bd = out_bd.execute_plan()
+        except Exception:
+            bodo_error = True
+
+        assert pd_error == bodo_error
+        if pd_error:
+            continue
+
+        _test_equal(out_bd, out_pd, check_pandas_types=False, check_names=False)
+
+
+def test_top_level_to_datetime():
+    pdf = pd.DataFrame(
+        {
+            "dates": ["2021-01-01", "2022-02-15", None, "2023-03-30"],
+        }
+    )
+    bdf = bd.from_pandas(pdf)
+
+    pd_obj = pd.to_datetime(pdf["dates"])
+    bd_obj = bd.to_datetime(bdf["dates"])
+    assert bd_obj.is_lazy_plan()
+    bd_obj = bd_obj.execute_plan()
+
+    _test_equal(bd_obj, pd_obj, check_pandas_types=False, check_names=False)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for `bodo.pandas.to_datetime(arg, ...)` in case of arg being a BodoSeries, falling back otherwise. 
Implements top-level redirect for `isnull`, `isna`, `notnull`, `notna` to BodoSeries. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, creates top-level test file to test correctness of bodo.pandas.<name> methods.
## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Support for 5 new top-level methods (4 redirect, 1 implementation)
## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.