### PR TITLE
First batch of changes from NYC taxi and TPCH work.

### DIFF
--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -92,6 +92,68 @@ expressionTypeToArrowCompute(const duckdb::ExpressionType &expr_type) {
     }
 }
 
+arrow::compute::Expression tableFilterToArrowExpr(duckdb::idx_t col_idx, duckdb::unique_ptr<duckdb::TableFilter> &tf, PyObject *schema_fields) {
+    switch (tf->filter_type) {
+        case duckdb::TableFilterType::CONSTANT_COMPARISON: {
+            duckdb::unique_ptr<duckdb::ConstantFilter> constantFilter =
+                dynamic_cast_unique_ptr<duckdb::ConstantFilter>(
+                    std::move(tf));
+            PyObject *py_selected_field =
+                PyList_GetItem(schema_fields, col_idx);
+            if (!PyUnicode_Check(py_selected_field)) {
+                throw std::runtime_error(
+                    "tableFilterSetToArrowCompute selected field is "
+                    "not unicode object.");
+            }
+            auto column_ref = arrow::compute::field_ref(
+                PyUnicode_AsUTF8(py_selected_field));
+            auto scalar_val = std::visit(
+                [](const auto &value) {
+                    return arrow::compute::literal(value);
+                },
+                extractValue(constantFilter->constant));
+            auto expr = expressionTypeToArrowCompute(
+                constantFilter->comparison_type)(column_ref, scalar_val);
+            return expr;
+        } break;
+        case duckdb::TableFilterType::CONJUNCTION_AND: {
+            duckdb::unique_ptr<duckdb::ConjunctionAndFilter> conjunctionAndFilter =
+                dynamic_cast_unique_ptr<duckdb::ConjunctionAndFilter>(
+                    std::move(tf));
+            assert(conjunctionAndFilter->child_filters.size() >= 2);
+            auto expr = arrow::compute::and_(
+                tableFilterToArrowExpr(col_idx, conjunctionAndFilter->child_filters[0], schema_fields),
+                tableFilterToArrowExpr(col_idx, conjunctionAndFilter->child_filters[1], schema_fields));
+            for (size_t i = 2; i < conjunctionAndFilter->child_filters.size(); ++i) {
+                expr = arrow::compute::and_(
+                    expr,
+                    tableFilterToArrowExpr(col_idx, conjunctionAndFilter->child_filters[i], schema_fields));
+            }
+            return expr;
+        } break;
+        case duckdb::TableFilterType::CONJUNCTION_OR: {
+            duckdb::unique_ptr<duckdb::ConjunctionOrFilter> conjunctionOrFilter =
+                dynamic_cast_unique_ptr<duckdb::ConjunctionOrFilter>(
+                    std::move(tf));
+            assert(conjunctionOrFilter->child_filters.size() >= 2);
+            auto expr = arrow::compute::or_(
+                tableFilterToArrowExpr(col_idx, conjunctionOrFilter->child_filters[0], schema_fields),
+                tableFilterToArrowExpr(col_idx, conjunctionOrFilter->child_filters[1], schema_fields));
+            for (size_t i = 2; i < conjunctionOrFilter->child_filters.size(); ++i) {
+                expr = arrow::compute::or_(
+                    expr,
+                    tableFilterToArrowExpr(col_idx, conjunctionOrFilter->child_filters[i], schema_fields));
+            }
+            return expr;
+        } break;
+        default:
+            throw std::runtime_error(
+                "tableFilterToArrowExpr unsupported filter "
+                "type " +
+                std::to_string(static_cast<int>(tf->filter_type)));
+    }
+}
+
 PyObject *tableFilterSetToArrowCompute(duckdb::TableFilterSet &filters,
                                        PyObject *schema_fields) {
     PyObject *ret = Py_None;
@@ -102,35 +164,9 @@ PyObject *tableFilterSetToArrowCompute(duckdb::TableFilterSet &filters,
     std::vector<arrow::compute::Expression> parts;
 
     for (auto &tf : filters.filters) {
-        switch (tf.second->filter_type) {
-            case duckdb::TableFilterType::CONSTANT_COMPARISON: {
-                duckdb::unique_ptr<duckdb::ConstantFilter> constantFilter =
-                    dynamic_cast_unique_ptr<duckdb::ConstantFilter>(
-                        std::move(tf.second));
-                PyObject *py_selected_field =
-                    PyList_GetItem(schema_fields, tf.first);
-                if (!PyUnicode_Check(py_selected_field)) {
-                    throw std::runtime_error(
-                        "tableFilterSetToArrowCompute selected field is "
-                        "not unicode object.");
-                }
-                auto column_ref = arrow::compute::field_ref(
-                    PyUnicode_AsUTF8(py_selected_field));
-                auto scalar_val = std::visit(
-                    [](const auto &value) {
-                        return arrow::compute::literal(value);
-                    },
-                    extractValue(constantFilter->constant));
-                auto expr = expressionTypeToArrowCompute(
-                    constantFilter->comparison_type)(column_ref, scalar_val);
-                parts.push_back(expr);
-            } break;
-            default:
-                throw std::runtime_error(
-                    "tableFilterSetToArrowCompute unsupported filter "
-                    "type " +
-                    std::to_string(static_cast<int>(tf.second->filter_type)));
-        }
+        duckdb::idx_t col_idx = tf.first;
+        duckdb::unique_ptr<duckdb::TableFilter> filter = std::move(tf.second);
+        parts.push_back(tableFilterToArrowExpr(col_idx, filter, schema_fields));
     }
 
     arrow::compute::Expression whole = arrow::compute::and_(parts);

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -277,6 +277,12 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         errors: IgnoreRaise = "ignore",
     ) -> BodoDataFrame | None:
         orig_plan = self._plan
+        # TODO: The value of copy here is ignored.
+        # Most cases of copy=False we have are the idiom A=A.rename(copy=False) where there is still
+        # only one possible reference to the data so we can treat this case like copy=True since for us
+        # we only materialize as needed and so copying isn't an overhead.
+        if copy == False:
+            warnings.warn("BodoDataFrame::rename copy=False argument ignored assuming A=A.rename(copy=False) idiom.")
         renamed_plan = LazyPlan(
             orig_plan.plan_class,
             orig_plan.empty_data.rename(columns=columns),

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -1199,18 +1199,9 @@ def _add_proj_expr_to_plan(
         is_replace = False
 
     # Get the function expression from the value plan to be added
-    func_expr = value_plan.args[1][0]
+    func_expr = get_proj_expr_single(value_plan)
 
-    # Handle trivial cases like df["C"] = df["B"]
-    if func_expr.plan_class == "ColRefExpression":
-        # Copy since empty_data is changed below
-        func_expr = LazyPlan(
-            "ColRefExpression",
-            func_expr.empty_data,
-            *func_expr.args,
-            **func_expr.kwargs,
-        )
-    elif func_expr.plan_class == "PythonScalarFuncExpression":
+    if func_expr.plan_class == "PythonScalarFuncExpression":
         func_expr = (
             _update_func_expr_source(func_expr, df_plan, ikey)
             if replace_func_source
@@ -1223,7 +1214,13 @@ def _add_proj_expr_to_plan(
             )
         )
     else:
-        return None
+        # Copy since empty_data is changed below
+        func_expr = LazyPlan(
+            func_expr.plan_class,
+            func_expr.empty_data,
+            *func_expr.args,
+            **func_expr.kwargs,
+        )
 
     # Update output column name
     func_expr.empty_data = func_expr.empty_data.set_axis([key], axis=1)

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -275,7 +275,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         inplace: bool = False,
         level: Level | None = None,
         errors: IgnoreRaise = "ignore",
-    ) -> DataFrame | None:
+    ) -> BodoDataFrame | None:
         orig_plan = self._plan
         renamed_plan = LazyPlan(
             orig_plan.plan_class,

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -103,7 +103,7 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
     arrow::Result<arrow::Datum> cmp_res =
         arrow::compute::CallFunction(comparator, {src1, src2});
     if (!cmp_res.ok()) [[unlikely]] {
-        throw std::runtime_error("do_array_compute: Error in Arrow compute: " +
+        throw std::runtime_error("do_array_compute_binary: Error in Arrow compute: " +
                                  cmp_res.status().message());
     }
 
@@ -135,7 +135,7 @@ std::shared_ptr<array_info> do_arrow_compute_unary(
     arrow::Result<arrow::Datum> cmp_res =
         arrow::compute::CallFunction(comparator, {src1});
     if (!cmp_res.ok()) [[unlikely]] {
-        throw std::runtime_error("do_array_compute: Error in Arrow compute: " +
+        throw std::runtime_error("do_array_compute_unary: Error in Arrow compute: " +
                                  cmp_res.status().message());
     }
 
@@ -170,7 +170,7 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
     arrow::Result<arrow::Datum> cmp_res =
         arrow::compute::Cast(src1, arrow_ret_type);
     if (!cmp_res.ok()) [[unlikely]] {
-        throw std::runtime_error("do_array_compute: Error in Arrow compute: " +
+        throw std::runtime_error("do_array_compute_cast: Error in Arrow compute: " +
                                  cmp_res.status().message());
     }
 

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -496,7 +496,7 @@ class PhysicalBinaryExpression : public PhysicalExpression {
         if (opstr == "+") {
             comparator = "add";
         } else if (opstr == "-") {
-            comparator = "substract";
+            comparator = "subtract";
         } else if (opstr == "*") {
             comparator = "multiply";
         } else if (opstr == "/") {

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -428,6 +428,7 @@ def execute_plan(plan: LazyPlan):
             and bodo.libs.distributed_api.get_rank() == 0
         ):
             print("")  # Print on new line during tests.
+            print("Unoptimized plan")
             print(duckdb_plan.toString())
 
         # Print the plan before optimization
@@ -442,6 +443,7 @@ def execute_plan(plan: LazyPlan):
             bodo.dataframe_library_dump_plans
             and bodo.libs.distributed_api.get_rank() == 0
         ):
+            print("Optimized plan")
             print(optimized_plan.toString())
 
         # Print the plan after optimization

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1310,3 +1310,20 @@ def test_series_filter_series(datapath, file_path, op, mode):
         sort_output=True,
         reset_index=True,
     )
+
+
+def test_rename(datapath, index_val):
+    """Very simple test for df.apply() for sanity checking."""
+    df = pd.DataFrame(
+        {
+            "a": pd.array([1, 2, 3] * 10, "Int64"),
+            "b": pd.array([4, 5, 6] * 10, "Int64"),
+            "c": ["a", "b", "c"] * 10,
+        },
+        index=index_val[:30],
+    )
+    bdf = bd.from_pandas(df)
+    rename_dict = {"a": "alpha", "b": "bravo", "c": "charlie"}
+    bdf2 = bdf.rename(columns=rename_dict)
+    df2 = df.rename(columns=rename_dict)
+    _test_equal(bdf2, df2, check_pandas_types=False)

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -762,6 +762,51 @@ def test_set_df_column_const(datapath, index_val):
     _test_equal(bdf, pdf, check_pandas_types=False)
 
 
+def test_set_df_column_arith(datapath, index_val):
+    """Test setting a dataframe column with a Series function of the same dataframe."""
+    df = pd.DataFrame(
+        {
+            "A": pd.array([1, 2, 3, 7], "Int64"),
+            "B": ["A1\t", "B1 ", "C1\n", "Abc\t"],
+            "C": pd.array([4, 5, 6, -1], "Int64"),
+        }
+    )
+    df.index = index_val[: len(df)]
+    bdf = bd.from_pandas(df)
+
+    # Test addition
+    bdf = bd.from_pandas(df)
+    bdf["D"] = bdf["A"] + 13
+    pdf = df.copy()
+    pdf["D"] = pdf["A"] + 13
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+    # Test subtraction
+    bdf = bd.from_pandas(df)
+    bdf["D"] = bdf["A"] - 13
+    pdf = df.copy()
+    pdf["D"] = pdf["A"] - 13
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+    # Test multiply
+    bdf = bd.from_pandas(df)
+    bdf["D"] = bdf["A"] * 13
+    pdf = df.copy()
+    pdf["D"] = pdf["A"] * 13
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+    # Test division
+    bdf = bd.from_pandas(df)
+    bdf["D"] = bdf["A"] / 2
+    pdf = df.copy()
+    pdf["D"] = pdf["A"] / 2
+    assert bdf.is_lazy_plan()
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+
 def test_parquet_read_partitioned(datapath):
     """Test reading a partitioned parquet dataset."""
     path = datapath("dataframe_library/example_partitioned.parquet")


### PR DESCRIPTION
## Changes included in this PR

1) Source plan caching fix.
2) Implement bound_between.
3) Support rename.
4) Add test for setitem of arithmetic expressions.
5) Fix setitem to allow arithmetic expressions.

## Testing strategy

run_ci - source plan caching and setitem arithmetic expressions are by the tests.  bound_between and rename should only be triggered by nyc taxi and tpch q5 at this point and have been tested locally.

## User facing changes

None

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.