### PR TITLE
[BSE-4908] Support Series.str.extract

### DIFF
--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -746,6 +746,7 @@ def _reconstruct_pandas_index(df, arrow_schema):
     for descr in arrow_schema.pandas_metadata.get("index_columns", []):
         if isinstance(descr, str):
             index_name = None if _is_generated_index_name(descr) else descr
+            # print(df, descr)
             index_level = df[descr]
             df = df.drop(columns=[descr])
         elif descr["kind"] == "range":

--- a/bodo/tests/test_df_lib/test_series_generator.py
+++ b/bodo/tests/test_df_lib/test_series_generator.py
@@ -128,6 +128,31 @@ rpartition_res = pd.DataFrame(
     }
 )
 
+extract_res_0 = pd.DataFrame(
+    {
+        "0": ["1", "2", pd.NA],
+    },
+    index=["X", "Y", "Z"],
+)
+
+extract_res_1 = pd.DataFrame(
+    {
+        "0": ["a", "b", pd.NA],
+        "1": ["1", "2", pd.NA],
+    },
+    index=["X", "Y", "Z"],
+)
+
+extract_res_2 = pd.DataFrame(
+    {
+        "letter": ["a", "b", pd.NA],
+        "digit": ["1", "2", pd.NA],
+    },
+    index=["X", "Y", "Z"],
+)
+
+extract_res_3 = pd.Series(["1", "2", pd.NA], index=["X", "Y", "Z"])
+
 month_name_res_fr_A = pd.Series(
     [
         "janvier",
@@ -250,6 +275,19 @@ expected_results = {
     ],
     "time": [
         ((), {}, "D", null_array),
+    ],
+    "extract": [
+        ((r"[ab](\d)",), {}, "A", extract_res_0),
+        ((r"([ab])(\d)",), {}, "A", extract_res_1),
+        ((r"(?P<letter>[ab])(?P<digit>\d)",), {}, "A", extract_res_2),
+        (
+            (r"[ab](\d)",),
+            {
+                "expand": False,
+            },
+            "A",
+            extract_res_3,
+        ),
     ],
 }
 

--- a/bodo/tests/test_df_lib/test_series_str_methods.py
+++ b/bodo/tests/test_df_lib/test_series_str_methods.py
@@ -171,15 +171,26 @@ test_map_arg = {
         ((), {"sep": "-"}),
     ],
     "normalize": [
-        (("NFC"), {}),
-        (("NFD"), {}),
+        (("NFC",), {}),
+        (("NFD",), {}),
     ],
-    "join": [(("*"), {}), ((" and "), {})],
+    "join": [(("*",), {}), ((" and ",), {})],
     "decode": [
-        (("ascii"), {}),
+        (("ascii",), {}),
     ],
     "encode": [
-        (("ascii"), {}),
+        (("ascii",), {}),
+    ],
+    "extract": [
+        ((r"[ab](\d)",), {}),
+        ((r"([ab])(\d)",), {}),
+        ((r"(?P<letter>[ab])(?P<digit>\d)",), {}),
+        (
+            (r"[ab](\d)",),
+            {
+                "expand": False,
+            },
+        ),
     ],
 }
 
@@ -246,6 +257,8 @@ df_join_flat = pd.DataFrame(
 
 df_decode = pd.DataFrame({"A": [b"hi", b"()", b"hello my name is chris.", None]})
 
+df_extract = pd.DataFrame({"A": ["a1", "b2", "c3"]}, index=["X", "Y", "Z"])
+
 # Stores customized DataFrames for some methods. Could enable testing with closer customization to each method.
 exception_dfmap = {
     "normalize": (df_normalize,),
@@ -254,6 +267,7 @@ exception_dfmap = {
         df_join_flat,
     ),
     "decode": (df_decode,),
+    "extract": (df_extract,),
 }
 
 empty_arg = [((), {})]


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Implements `Series.str.extract`. 
Adds support for  `Series.str.extract`. 
Refactors helper functions used in extract and partition to correctly propagate index column data. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, adds test cases for extract in test case generator. 

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Support for Series.str.extract. 

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.