### PR TITLE
Fix setting columns in lazy manager in sequential mode

### DIFF
--- a/bodo/pandas/array_manager.py
+++ b/bodo/pandas/array_manager.py
@@ -262,6 +262,9 @@ class LazyArrayManager(ArrayManager, LazyMetadataMixin[ArrayManager]):
             self.arrays = data._mgr.arrays
             self._axes = data._mgr._axes
             self._plan = None
+            self._md_result_id = None
+            self._md_nrows = None
+            self._md_head = None
             return data
 
     def _collect(self):
@@ -503,6 +506,9 @@ class LazySingleArrayManager(SingleArrayManager, LazyMetadataMixin[SingleArrayMa
             self.arrays = data._mgr.arrays
             self._axes = data._mgr.axes
             self._plan = None
+            self._md_result_id = None
+            self._md_nrows = None
+            self._md_head = None
             return data
 
     def _collect(self):

--- a/bodo/pandas/managers.py
+++ b/bodo/pandas/managers.py
@@ -227,6 +227,9 @@ class LazyBlockManager(BlockManager, LazyMetadataMixin[BlockManager]):
             self.blocks = data._mgr.blocks
             self.axes = data._mgr.axes
             self._plan = None
+            self._md_result_id = None
+            self._md_nrows = None
+            self._md_head = None
             BlockManager._rebuild_blknos_and_blklocs(self)
             return data
 
@@ -481,6 +484,9 @@ class LazySingleBlockManager(SingleBlockManager, LazyMetadataMixin[SingleBlockMa
             self.blocks = data._mgr.blocks
             self.axes = data._mgr.axes
             self._plan = None
+            self._md_result_id = None
+            self._md_nrows = None
+            self._md_head = None
             return data
 
     def _collect(self):

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1327,3 +1327,22 @@ def test_rename(datapath, index_val):
     bdf2 = bdf.rename(columns=rename_dict)
     df2 = df.rename(columns=rename_dict)
     _test_equal(bdf2, df2, check_pandas_types=False)
+
+
+def test_col_set_dtypes_bug():
+    """Make sure setting columns doesn't lead to failure due to inconsistent dtypes
+    inside the lazy manager in sequential mode.
+    """
+
+    with temp_config_override("dataframe_library_run_parallel", False):
+        df = pd.DataFrame(
+            {
+                "A": ["A", "B", "C"] * 2,
+                "B": ["NY", "TX", "CA"] * 2,
+            }
+        )
+
+        df = bd.from_pandas(df)
+        df2 = df[["A", "B"]]
+        df["C"] = df2.apply(lambda x: x.A + x.B, axis=1)
+        print(df)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes a bug due to inconsistent manager state in sequential mode.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added a unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Minor bug fix.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.