### PR TITLE
Fix Timedelta issues and enable timedelta tests for dataframe library

### DIFF
--- a/bodo/hiframes/pd_index_ext.py
+++ b/bodo/hiframes/pd_index_ext.py
@@ -3654,7 +3654,7 @@ def overload_init_engine(I, ban_unique=True):
                         I._dict[val] = i
 
         return impl
-    elif isinstance(I, TimedeltaIndexType):
+    elif isinstance(I, TimedeltaIndexType) and I.data == bodo.timedelta_array_type:
 
         def impl(I, ban_unique=True):  # pragma: no cover
             if len(I) > 0 and not I._dict:

--- a/bodo/hiframes/pd_index_ext.py
+++ b/bodo/hiframes/pd_index_ext.py
@@ -182,6 +182,15 @@ def typeof_pd_index(val, c):
             get_val_type_maybe_str_literal(val.name),
             boolean_array_type,
         )
+
+    if (
+        val.inferred_type == "timedelta64"
+        or pd._libs.lib.infer_dtype(val, True) == "timedelta64"
+    ):
+        return TimedeltaIndexType(
+            get_val_type_maybe_str_literal(val.name), bodo.typeof(val.values)
+        )
+
     # catch-all for all remaining Index types
     arr_typ = bodo.hiframes.boxing._infer_series_arr_type(val)
     if arr_typ == bodo.datetime_date_array_type or isinstance(
@@ -192,6 +201,7 @@ def typeof_pd_index(val, c):
             get_val_type_maybe_str_literal(val.name),
             arr_typ,
         )
+
     # catch-all for non-supported Index types
     # RangeIndex is directly supported (TODO: make sure this is not called)
     raise NotImplementedError(f"unsupported pd.Index type {val}")

--- a/bodo/hiframes/pd_index_ext.py
+++ b/bodo/hiframes/pd_index_ext.py
@@ -79,7 +79,6 @@ from bodo.utils.utils import (
 )
 
 _dt_index_data_typ = types.Array(types.NPDatetime("ns"), 1, "C")
-_timedelta_index_data_typ = types.Array(types.NPTimedelta("ns"), 1, "C")
 iNaT = pd._libs.tslibs.iNaT
 NaT = types.NPDatetime("ns")("NaT")  # TODO: pd.NaT
 
@@ -1359,7 +1358,7 @@ class TimedeltaIndexType(types.IterableType, types.ArrayCompatible, SingleIndexT
     ndim = 1
 
     def copy(self):
-        return TimedeltaIndexType(self.name_typ)
+        return TimedeltaIndexType(self.name_typ, self.data)
 
     @property
     def dtype(self):
@@ -1398,9 +1397,9 @@ types.timedelta_index = timedelta_index
 class TimedeltaIndexTypeModel(models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [
-            ("data", _timedelta_index_data_typ),
+            ("data", fe_type.data),
             ("name", fe_type.name_typ),
-            ("dict", types.DictType(_timedelta_index_data_typ.dtype, types.int64)),
+            ("dict", types.DictType(types.NPTimedelta("ns"), types.int64)),
         ]
         super().__init__(dmm, fe_type, members)
 
@@ -1408,7 +1407,9 @@ class TimedeltaIndexTypeModel(models.StructModel):
 @typeof_impl.register(pd.TimedeltaIndex)
 def typeof_timedelta_index(val, c):
     # keep string literal value in type since reset_index() may need it
-    return TimedeltaIndexType(get_val_type_maybe_str_literal(val.name))
+    return TimedeltaIndexType(
+        get_val_type_maybe_str_literal(val.name), bodo.typeof(val.values)
+    )
 
 
 @box(TimedeltaIndexType)
@@ -1421,10 +1422,8 @@ def box_timedelta_index(typ, val, c):
         c.context, c.builder, val
     )
 
-    c.context.nrt.incref(c.builder, _timedelta_index_data_typ, timedelta_index.data)
-    arr_obj = c.pyapi.from_native_value(
-        _timedelta_index_data_typ, timedelta_index.data, c.env_manager
-    )
+    c.context.nrt.incref(c.builder, typ.data, timedelta_index.data)
+    arr_obj = c.pyapi.from_native_value(typ.data, timedelta_index.data, c.env_manager)
     c.context.nrt.incref(c.builder, typ.name_typ, timedelta_index.name)
     name_obj = c.pyapi.from_native_value(
         typ.name_typ, timedelta_index.name, c.env_manager
@@ -1451,7 +1450,7 @@ def unbox_timedelta_index(typ, val, c):
     # get data and name attributes
     # TODO: use to_numpy()
     values_obj = c.pyapi.object_getattr_string(val, "values")
-    data = c.pyapi.to_native_value(_timedelta_index_data_typ, values_obj).value
+    data = c.pyapi.to_native_value(typ.data, values_obj).value
     name_obj = c.pyapi.object_getattr_string(val, "name")
     name = c.pyapi.to_native_value(typ.name_typ, name_obj).value
     c.pyapi.decref(values_obj)
@@ -1462,7 +1461,7 @@ def unbox_timedelta_index(typ, val, c):
     index_val.data = data
     index_val.name = name
     # create empty dict for get_loc hashmap
-    dtype = _timedelta_index_data_typ.dtype
+    dtype = types.NPTimedelta("ns")
     _is_error, ind_dict = c.pyapi.call_jit_code(
         lambda: numba.typed.Dict.empty(dtype, types.int64),
         types.DictType(dtype, types.int64)(),
@@ -1491,7 +1490,7 @@ def init_timedelta_index(typingctx, data, name=None):
         context.nrt.incref(builder, signature.args[1], name_val)
 
         # create empty dict for get_loc hashmap
-        dtype = _timedelta_index_data_typ.dtype
+        dtype = types.NPTimedelta("ns")
         timedelta_index.dict = context.compile_internal(
             builder,
             lambda: numba.typed.Dict.empty(dtype, types.int64),
@@ -1501,7 +1500,7 @@ def init_timedelta_index(typingctx, data, name=None):
 
         return timedelta_index._getvalue()
 
-    ret_typ = TimedeltaIndexType(name)
+    ret_typ = TimedeltaIndexType(name, data)
     sig = signature(ret_typ, data, name)
     return sig, codegen
 
@@ -1516,7 +1515,7 @@ class TimedeltaIndexAttribute(AttributeTemplate):
     key = TimedeltaIndexType
 
     def resolve_values(self, ary):
-        return _timedelta_index_data_typ
+        return ary.data
 
     # TODO: support pd.Timedelta
     # @bound_function("timedelta_index.max", no_unliteral=True)
@@ -3243,8 +3242,8 @@ def array_type_to_index(arr_typ, name_typ=None):
     if isinstance(arr_typ, bodo.CategoricalArrayType):
         return CategoricalIndexType(arr_typ, name_typ)
 
-    if arr_typ.dtype == types.NPTimedelta("ns"):
-        return TimedeltaIndexType(name_typ)
+    if arr_typ.dtype in (types.NPTimedelta("ns"), bodo.pd_timedelta_type):
+        return TimedeltaIndexType(name_typ, arr_typ)
 
     if (
         isinstance(
@@ -3647,6 +3646,23 @@ def overload_init_engine(I, ban_unique=True):
                     if not bodo.libs.array_kernels.isna(arr, i):
                         val = bodo.hiframes.pd_categorical_ext.get_code_for_value(
                             arr.dtype, arr[i]
+                        )
+                        if ban_unique and val in I._dict:
+                            raise ValueError(
+                                "Index.get_loc(): non-unique Index not supported yet"
+                            )
+                        I._dict[val] = i
+
+        return impl
+    elif isinstance(I, TimedeltaIndexType):
+
+        def impl(I, ban_unique=True):  # pragma: no cover
+            if len(I) > 0 and not I._dict:
+                arr = bodo.utils.conversion.coerce_to_array(I)
+                for i in range(len(arr)):
+                    if not bodo.libs.array_kernels.isna(arr, i):
+                        val = bodo.hiframes.pd_timestamp_ext.integer_to_timedelta64(
+                            arr[i].value
                         )
                         if ban_unique and val in I._dict:
                             raise ValueError(

--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -1847,7 +1847,11 @@ def get_value_for_type(dtype, use_arrow_time=False):  # pragma: no cover
 
     # timedelta array
     if dtype == timedelta_array_type:
-        return pd.array([datetime.timedelta(33)])
+        # Use Arrow duration array to ensure pd.Index() below doesn't convert it to
+        # a non-nullable numpy timedelta64 array (leading to parallel errors).
+        return pd.array(
+            [datetime.timedelta(33)], dtype=pd.ArrowDtype(pa.duration("ns"))
+        )
 
     # Index types
     if bodo.hiframes.pd_index_ext.is_pd_index_type(dtype):

--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -619,16 +619,12 @@ class Spawner:
         pickled_args = cloudpickle.dumps((args_to_send, kwargs_to_send))
         self.worker_intercomm.bcast(pickled_args, root=self.bcast_root)
         if is_dispatcher:
-            func_to_execute.decorator_args["distributed"] = (
-                func_to_execute.decorator_args.get("distributed", set()).union(
-                    dist_flags["distributed"]
-                )
-            )
-            func_to_execute.decorator_args["distributed_block"] = (
-                func_to_execute.decorator_args.get("distributed_block", set()).union(
-                    dist_flags["distributed_block"]
-                )
-            )
+            func_to_execute.decorator_args["distributed"] = set(
+                func_to_execute.decorator_args.get("distributed", set())
+            ).union(dist_flags["distributed"])
+            func_to_execute.decorator_args["distributed_block"] = set(
+                func_to_execute.decorator_args.get("distributed_block", set())
+            ).union(dist_flags["distributed_block"])
         # Send DataFrame/Series/Index/array arguments (others are already sent)
         for arg, arg_meta in itertools.chain(
             zip(args, args_meta), zip(kwargs.values(), kwargs_meta.values())

--- a/bodo/tests/dataframe_common.py
+++ b/bodo/tests/dataframe_common.py
@@ -43,7 +43,7 @@ df_value_params = [
         ),
         marks=pytest.mark.skipif(
             bodo.test_dataframe_library_enabled,
-            reason="[BSE-4779/4764] Support conversion from duration[ns], categorical dtypes.",
+            reason="[BSE-4764] Support conversion from categorical dtypes.",
         ),
         id="categorical_df",
     ),

--- a/bodo/tests/series_common.py
+++ b/bodo/tests/series_common.py
@@ -119,10 +119,6 @@ series_val_params = [
             ]
         ),
         id="timedelta",
-        marks=pytest.mark.skipif(
-            bodo.test_dataframe_library_enabled,
-            reason="[BSE-4779] Duration[ns] support.",
-        ),
     ),
     pytest.param(
         pd.Series(

--- a/bodo/tests/test_dataframe_part2.py
+++ b/bodo/tests/test_dataframe_part2.py
@@ -651,8 +651,7 @@ def test_df_apply_name_datetime_index(memory_leak_check):
 
 
 @pytest.mark.slow
-# TODO [BSE-4779]: Dataframe Lib: unsupported dtype duration[ns]
-# @pytest.mark.df_lib
+@pytest.mark.df_lib
 def test_df_apply_name_timedelta_index(memory_leak_check):
     """
     Check that you can get name information from DataFrame.apply with
@@ -1142,8 +1141,7 @@ def test_df_apply_supported_types(df_value, memory_leak_check):
 
 
 @pytest.mark.slow
-# TODO [BSE-4779 DataFrame lib: support duration[ns] type
-# @pytest.mark.df_lib
+@pytest.mark.df_lib
 def test_df_apply_datetime(memory_leak_check):
     def test_impl(df):
         return df.apply(lambda r: r.A, axis=1)

--- a/bodo/tests/test_dataframe_part3.py
+++ b/bodo/tests/test_dataframe_part3.py
@@ -769,10 +769,6 @@ pd_supported_merge_cols = [
             for year in range(1999, 2004)
         ),
         id="DatetimeTimedeltaArrayType",
-        marks=pytest.mark.skipif(
-            bodo.test_dataframe_library_enabled,
-            reason="[BSE-4779] Timedelta support in DF lib.",
-        ),
     ),
     # TODO [BE-1804]: test once intervals are supported
     # pytest.param(

--- a/bodo/tests/test_series_part2.py
+++ b/bodo/tests/test_series_part2.py
@@ -103,8 +103,7 @@ def test_series_map_none_timestamp(memory_leak_check):
     check_func(impl, (S,))
 
 
-# TODO [BSE-4779]: DataFrame Lib: Support for duration[ns] type.
-# @pytest.mark.df_lib
+@pytest.mark.df_lib
 def test_series_map_isna_check(memory_leak_check):
     """Test checking for NA input values in UDF"""
 

--- a/bodo/utils/conversion.py
+++ b/bodo/utils/conversion.py
@@ -2091,7 +2091,10 @@ def overload_convert_to_td64ns(data):
             bodo.utils.conversion.TD_DTYPE
         )  # pragma: no cover
 
-    if is_np_arr_typ(data, types.NPTimedelta("ns")):
+    if (
+        is_np_arr_typ(data, types.NPTimedelta("ns"))
+        or data == bodo.timedelta_array_type
+    ):
         return lambda data: data  # pragma: no cover
 
     if is_str_arr_type(data):
@@ -2181,7 +2184,7 @@ def overload_index_from_array(data, name=None):
             data, name=name
         )  # pragma: no cover
 
-    if data.dtype == types.NPTimedelta("ns"):
+    if data.dtype in (types.NPTimedelta("ns"), bodo.pd_timedelta_type):
         return lambda data, name=None: pd.TimedeltaIndex(
             data, name=name
         )  # pragma: no cover

--- a/bodo/utils/conversion.py
+++ b/bodo/utils/conversion.py
@@ -2061,7 +2061,7 @@ def overload_convert_to_dt64ns(data):
 
     if is_np_arr_typ(data, types.int64):
         return lambda data: data.view(
-            bodo.utils.conversion.NS_DTYPE
+            bodo.utils.conversion.TD_DTYPE
         )  # pragma: no cover
 
     if is_np_arr_typ(data, types.NPDatetime("ns")):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Fixes Timedelta bugs.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.