### PR TITLE
[BSE-4928] Fix split hanging in nightly

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -7,6 +7,7 @@ import typing as pt
 import warnings
 from collections.abc import Callable, Hashable
 
+import numpy
 import pandas as pd
 import pyarrow as pa
 from pandas._typing import (
@@ -939,10 +940,15 @@ def _str_extract_helper(s, pat, expand, n_cols, flags):
 def _get_split_len(s, is_split=True, pat=None, n=-1, regex=None):
     """Runs str.split per element in s and returns length of resulting match group for each index."""
     if is_split:
-        split_s = s.str.split(pat=pat, n=n, expand=True, regex=regex)
+        split_s = s.str.split(pat=pat, n=n, expand=False, regex=regex)
     else:
-        split_s = s.str.rsplit(pat=pat, n=n, expand=True)
-    return split_s.count(axis="columns")
+        split_s = s.str.rsplit(pat=pat, n=n, expand=False)
+
+    def get_len(x):
+        """Get length if output of str.split() is numpy array, otherwise 1."""
+        return len(x) if isinstance(x, numpy.ndarray) else 1
+
+    return split_s.map(get_len)
 
 
 def validate_str_cat(lhs, rhs):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes split test hanging in nightly. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, tests added in previous PR. 

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Users can now run split in parallel. 

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.