### PR TITLE
Fix reading from S3 path

### DIFF
--- a/bodo/tests/test_s3.py
+++ b/bodo/tests/test_s3.py
@@ -849,6 +849,7 @@ def test_s3_json_write_records_lines_1D_var(
     )
 
 
+@pytest.mark.df_lib
 def test_s3_parquet_read(minio_server_with_s3_envs, s3_bucket, test_df):
     """
     read_parquet


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Ran example locally:
``` py
import bodo.pandas as pd
df = pd.read_parquet("s3://bodo-example-data/nyc-taxi/fhvhv_tripdata/fhvhv_tripdata_2019-02.parquet")
df3 = df.groupby("PULocationID", as_index=False)["trip_miles"].mean()
df3.to_parquet("my_data.pq")
```

Adds new test (ported compiler test, fails on main passes on this branch).
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
User's can now read from S3
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.