### PR TITLE
Fix Snowflake SHOW output parsing

### DIFF
--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeUtils.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeUtils.kt
@@ -63,7 +63,7 @@ class SnowflakeUtils {
             if (openParenIndex == -1 || closeParenIndex == -1 || closeParenIndex <= openParenIndex) {
                 throw java.lang.RuntimeException(
                     "UDF formatting error in parseSnowflakeShowFunctionsArguments: " +
-                        "expected signature to look like: 'FUNC(ARGS)'",
+                        "expected signature to look like: 'FUNC(ARGS)', got: '$call'",
                 )
             }
             val argString = call.substring(openParenIndex + 1, closeParenIndex)

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeUtils.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeUtils.kt
@@ -57,15 +57,16 @@ class SnowflakeUtils {
             }
             val call = callParts[0]
 
-            val argParts = call.split("(", ")")
+            val openParenIndex = call.indexOf('(')
+            val closeParenIndex = call.lastIndexOf(')')
 
-            if (argParts.size != 3) {
+            if (openParenIndex == -1 || closeParenIndex == -1 || closeParenIndex <= openParenIndex) {
                 throw java.lang.RuntimeException(
                     "UDF formatting error in parseSnowflakeShowFunctionsArguments: " +
-                        "unexpected special characters",
+                        "expected signature to look like: 'FUNC(ARGS)'",
                 )
             }
-            val argString = argParts[1].trim()
+            val argString = call.substring(openParenIndex + 1, closeParenIndex)
             val (argList, numOptional) =
                 if (argString.isEmpty()) {
                     Pair(listOf(), 0)


### PR DESCRIPTION
## Changes included in this PR

Fixes `parseSnowflakeShowFunctionsArguments` to correctly handle cases when parenthesis appear in the argument types e.g.: `TIMES_TWO_TABLE(VARCHAR(16777216))`

Changes in snowflake behavior likely exposed this bug.

## Testing strategy
Local testing, Nightly SQL tests
https://dev.azure.com/bodo-inc/Bodo/_build/results?buildId=25842&view=logs&jobId=7c76da58-c422-5596-864a-bcb7a26d5c7b
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.