### PR TITLE
Avoid Arrow data types for UDF calls

### DIFF
--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -57,12 +57,12 @@ def get_lazy_single_manager_class() -> type[
     )
 
 
-def cpp_table_to_df(cpp_table, arrow_schema=None):
+def cpp_table_to_df(cpp_table, arrow_schema=None, use_arrow_dtypes=True):
     """Convert a C++ table (table_info) to a pandas DataFrame."""
     from bodo.ext import plan_optimizer
 
     arrow_table = plan_optimizer.cpp_table_to_arrow(cpp_table)
-    df = arrow_table_to_pandas(arrow_table, arrow_schema)
+    df = arrow_table_to_pandas(arrow_table, arrow_schema, use_arrow_dtypes)
     return df
 
 
@@ -614,8 +614,13 @@ def run_func_on_table(cpp_table, result_type, in_args):
     """Run a user-defined function (UDF) on a DataFrame created from C++ table and
     return the result as a C++ table and column names.
     """
-    input = cpp_table_to_df(cpp_table)
     func, is_series, is_attr, args, kwargs = in_args
+
+    # Arrow dtypes can be very slow for UDFs in Pandas:
+    # https://github.com/pandas-dev/pandas/issues/61747
+    # TODO[BSE-4948]: Use Arrow dtypes when Bodo engine is specified
+    use_arrow_dtypes = not (is_attr and func in ("apply", "str"))
+    input = cpp_table_to_df(cpp_table, use_arrow_dtypes=use_arrow_dtypes)
 
     if is_series:
         assert input.shape[1] == 1, "run_func_on_table: single column expected"
@@ -870,7 +875,7 @@ def _fix_struct_arr_names(arr, pa_type):
     )
 
 
-def _arrow_to_pd_array(arrow_array, pa_type):
+def _arrow_to_pd_array(arrow_array, pa_type, use_arrow_dtypes=True):
     """Convert a PyArrow array to a pandas array with the specified Arrow type."""
 
     # Our type inference may fail for some object columns so use the proper Arrow type
@@ -886,10 +891,13 @@ def _arrow_to_pd_array(arrow_array, pa_type):
     if pa_type != arrow_array.type:
         arrow_array = arrow_array.cast(pa_type)
 
-    return pd.array(arrow_array, dtype=pd.ArrowDtype(pa_type))
+    if use_arrow_dtypes:
+        return pd.array(arrow_array, dtype=pd.ArrowDtype(pa_type))
+
+    return arrow_array.to_pandas()
 
 
-def arrow_table_to_pandas(arrow_table, arrow_schema=None):
+def arrow_table_to_pandas(arrow_table, arrow_schema=None, use_arrow_dtypes=True):
     """Convert a PyArrow Table to a pandas DataFrame. Not using Table.to_pandas()
     since it doesn't use ArrowDtype and has issues (e.g. repeated column names fails).
 
@@ -906,7 +914,7 @@ def arrow_table_to_pandas(arrow_table, arrow_schema=None):
 
     df = pd.DataFrame(
         {
-            i: _arrow_to_pd_array(arrow_table.columns[i], field.type)
+            i: _arrow_to_pd_array(arrow_table.columns[i], field.type, use_arrow_dtypes)
             for i, field in enumerate(arrow_schema)
         }
     )


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
This makes the example code below with df.apply >4x faster on my local M1 Mac. Works around a Pandas performance issue when using Arrow dtypes in UDFs:
https://github.com/pandas-dev/pandas/issues/61747
Also tested Pandas main branch and the issue persists so the Pandas 3 release won't solve it.

```python
import bodo.pandas as pd
import numpy as np
import time

NUM_ROWS = 500_000
df = pd.DataFrame({
    "A": np.arange(NUM_ROWS) % 30,
    "B": np.arange(NUM_ROWS)+1.0
})

t0 = time.time()
df["C"] = df.apply(lambda r: 0 if r.A == 0 else (r.B // r.A), axis=1)
print(df)
t1 = time.time()
print(f"Time taken: {t1 - t0:.2f} seconds")
```

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Measured performance locally (obvious).

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.