### PR TITLE
Support na_action and kws in Series.map()

### DIFF
--- a/bodo/hiframes/pd_series_ext.py
+++ b/bodo/hiframes/pd_series_ext.py
@@ -791,11 +791,19 @@ class SeriesAttribute(OverloadedKeyAttributeTemplate):
             else None
         )
 
-        def map_stub(arg, na_action=None):  # pragma: no cover
-            pass
+        # add dummy default value for UDF kws to avoid errors
+        kw_names = ", ".join(f"{a} = ''" for a in kws.keys())
+        func_text = f"def map_stub(arg, na_action=None, {kw_names}):\n"
+        func_text += "    pass\n"
+        loc_vars = {}
+        exec(func_text, {}, loc_vars)
+        map_stub = loc_vars["map_stub"]
 
         pysig = numba.core.utils.pysignature(map_stub)
-        return self._resolve_map_func(ary, func, pysig, "map", na_action=na_action)
+
+        return self._resolve_map_func(
+            ary, func, pysig, "map", na_action=na_action, kws=kws
+        )
 
     @bound_function("series.apply", no_unliteral=True)
     def resolve_apply(self, ary, args, kws):

--- a/bodo/pandas_compat.py
+++ b/bodo/pandas_compat.py
@@ -340,18 +340,15 @@ if pandas_version >= (3, 0):
                     f"BodoExecutionEngine: map() expected input data to be Series, got: {type(data)}"
                 )
 
-            if skip_na:
-                raise ValueError(
-                    "BodoExecutionEngine: na_action not supported other than the default None for map()."
-                )
-
             if args or kwargs:
                 raise ValueError(
                     "BodoExecutionEngine: passing additional arguments to UDF not supported for map()."
                 )
 
+            na_action = "ignore" if skip_na else None
+
             def map_func(data):
-                return data.map(func)
+                return data.map(func, na_action=na_action)
 
             map_func_jit = decorator(map_func)
 

--- a/bodo/pandas_compat.py
+++ b/bodo/pandas_compat.py
@@ -340,19 +340,19 @@ if pandas_version >= (3, 0):
                     f"BodoExecutionEngine: map() expected input data to be Series, got: {type(data)}"
                 )
 
-            if args or kwargs:
-                raise ValueError(
-                    "BodoExecutionEngine: passing additional arguments to UDF not supported for map()."
+            if isinstance(func, Callable):
+                args, _ = _prepare_function_arguments(
+                    func, args, kwargs, num_required_args=1
                 )
 
             na_action = "ignore" if skip_na else None
 
-            def map_func(data):
-                return data.map(func, na_action=na_action)
+            def map_func(data, args):
+                return data.map(func, na_action=na_action, args=args)
 
             map_func_jit = decorator(map_func)
 
-            return map_func_jit(data)
+            return map_func_jit(data, args)
 
         @staticmethod
         def apply(

--- a/bodo/tests/test_pandas_udf_compat.py
+++ b/bodo/tests/test_pandas_udf_compat.py
@@ -121,16 +121,16 @@ def test_udf_str(engine):
 
 def test_udf_map(engine):
     """Test basic map support with bodo engine."""
-    ser = pd.Series(np.arange(30))
+    ser = pd.Series([1, 2, 3, 4, None] * 2, dtype="Int64")
 
     def udf(x):
-        return str(x + 10)
+        return x + 10
 
-    bodo_out = ser.map(udf, engine=engine)
+    bodo_out = ser.map(udf, na_action="ignore", engine=engine)
 
-    pandas_out = ser.map(udf)
+    pandas_out = ser.map(udf, na_action="ignore").astype("Int64")
 
-    _test_equal(bodo_out, pandas_out, check_pandas_types=False)
+    _test_equal(bodo_out, pandas_out, check_pandas_types=False, check_dtype=False)
 
 
 def test_udf_map_unsupported():
@@ -146,7 +146,3 @@ def test_udf_map_unsupported():
     # additional kwargs are not supported
     with pytest.raises(ValueError, match=r"BodoExecutionEngine:.*"):
         ser.map(udf, y=1, engine=engine)
-
-    # na_action='ignore' not supported
-    with pytest.raises(ValueError, match=r"BodoExecutionEngine:.*"):
-        ser.map(udf, na_action="ignore", engine=engine)

--- a/bodo/tests/test_pandas_udf_compat.py
+++ b/bodo/tests/test_pandas_udf_compat.py
@@ -123,26 +123,11 @@ def test_udf_map(engine):
     """Test basic map support with bodo engine."""
     ser = pd.Series([1, 2, 3, 4, None] * 2, dtype="Int64")
 
-    def udf(x):
-        return x + 10
+    def udf(x, a):
+        return x + a
 
-    bodo_out = ser.map(udf, na_action="ignore", engine=engine)
+    bodo_out = ser.map(udf, na_action="ignore", engine=engine, a=4)
 
-    pandas_out = ser.map(udf, na_action="ignore").astype("Int64")
+    pandas_out = ser.map(udf, na_action="ignore", a=4).astype("Int64")
 
     _test_equal(bodo_out, pandas_out, check_pandas_types=False, check_dtype=False)
-
-
-def test_udf_map_unsupported():
-    """Test passing unsupported arguments to map raises appropriate errors."""
-    ser = pd.Series([1, 2, 3, 4, None] * 2)
-    engine = bodo.jit
-
-    def udf(x, y=2):
-        if x is None:
-            return None
-        return str(x + y)
-
-    # additional kwargs are not supported
-    with pytest.raises(ValueError, match=r"BodoExecutionEngine:.*"):
-        ser.map(udf, y=1, engine=engine)

--- a/bodo/tests/test_series_part1.py
+++ b/bodo/tests/test_series_part1.py
@@ -2859,7 +2859,6 @@ def test_series_map_args(memory_leak_check):
 
 
 @pytest.mark.slow
-@pytest.mark.df_lib
 def test_series_map_na_action_kws(memory_leak_check):
     """Test Series.map with na_action and kw arguments"""
 

--- a/bodo/tests/test_series_part1.py
+++ b/bodo/tests/test_series_part1.py
@@ -2861,7 +2861,7 @@ def test_series_map_args(memory_leak_check):
 @pytest.mark.slow
 @pytest.mark.df_lib
 def test_series_map_na_action_kws(memory_leak_check):
-    """Test Series.map with na_action argument"""
+    """Test Series.map with na_action and kw arguments"""
 
     def test_impl(S):
         return S.map(lambda a, b: 2 * a + b, na_action="ignore", b=4)

--- a/bodo/tests/test_series_part1.py
+++ b/bodo/tests/test_series_part1.py
@@ -2842,9 +2842,6 @@ def test_series_map_supported_types(series_val):
 def test_series_map_args(memory_leak_check):
     """Test Series.map with unsupported and wrong arguments"""
 
-    def test_na_action_ignore(S):
-        return S.map(lambda a: a, na_action="ignore")
-
     def test_na_action_none(S):
         return S.map(lambda a: a, na_action=None)
 
@@ -2852,8 +2849,6 @@ def test_series_map_args(memory_leak_check):
         return S.map("XX")
 
     S = pd.Series([2, 1, 3])
-    with pytest.raises(BodoError, match="Series.map.* only supports default value"):
-        bodo.jit(test_na_action_ignore)(S)
 
     bodo.jit(test_na_action_none)(S)
 
@@ -2861,6 +2856,18 @@ def test_series_map_args(memory_leak_check):
         BodoError, match="Series.map.*: user-defined function not supported"
     ):
         bodo.jit(test_wrong_func)(S)
+
+
+@pytest.mark.slow
+@pytest.mark.df_lib
+def test_series_map_na_action(memory_leak_check):
+    """Test Series.map with na_action argument"""
+
+    def test_impl(S):
+        return S.map(lambda a: 2 * a, na_action="ignore")
+
+    S = pd.Series([2, 1, 3, None, 4, 5], dtype="Int64")
+    check_func(test_impl, (S,), check_dtype=False)
 
 
 # TODO: add memory_leak_check after fix its failure with Categorical

--- a/bodo/tests/test_series_part1.py
+++ b/bodo/tests/test_series_part1.py
@@ -2860,14 +2860,15 @@ def test_series_map_args(memory_leak_check):
 
 @pytest.mark.slow
 @pytest.mark.df_lib
-def test_series_map_na_action(memory_leak_check):
+def test_series_map_na_action_kws(memory_leak_check):
     """Test Series.map with na_action argument"""
 
     def test_impl(S):
-        return S.map(lambda a: 2 * a, na_action="ignore")
+        return S.map(lambda a, b: 2 * a + b, na_action="ignore", b=4)
 
     S = pd.Series([2, 1, 3, None, 4, 5], dtype="Int64")
-    check_func(test_impl, (S,), check_dtype=False)
+    py_out = pd.Series([8, 6, 10, None, 12, 14], dtype="Int64")
+    check_func(test_impl, (S,), py_output=py_out, check_dtype=False)
 
 
 # TODO: add memory_leak_check after fix its failure with Categorical

--- a/bodo/transforms/series_pass.py
+++ b/bodo/transforms/series_pass.py
@@ -3501,16 +3501,15 @@ class SeriesPass:
         if func_name in ("map", "apply"):
             nodes = []
             kws = dict(rhs.kws)
-            extra_args = []
             if func_name == "apply":
                 func_var = get_call_expr_arg("apply", rhs.args, kws, 0, "func")
-                extra_args = get_call_expr_arg("apply", rhs.args, kws, 2, "args", [])
-                if extra_args:
-                    extra_args = get_build_sequence_vars(
-                        self.func_ir, self.typemap, self.calltypes, extra_args, nodes
-                    )
             else:
                 func_var = get_call_expr_arg("map", rhs.args, kws, 0, "arg")
+            extra_args = get_call_expr_arg(func_name, rhs.args, kws, 2, "args", [])
+            if extra_args:
+                extra_args = get_build_sequence_vars(
+                    self.func_ir, self.typemap, self.calltypes, extra_args, nodes
+                )
             na_action = None
             if func_name == "map":
                 kws.pop("arg", None)

--- a/bodo/transforms/series_pass.py
+++ b/bodo/transforms/series_pass.py
@@ -3511,15 +3511,39 @@ class SeriesPass:
                     )
             else:
                 func_var = get_call_expr_arg("map", rhs.args, kws, 0, "arg")
+            na_action = None
             if func_name == "map":
                 kws.pop("arg", None)
+                na_action = get_call_expr_arg(
+                    "map", rhs.args, kws, 1, "na_action", use_default=True
+                )
                 kws.pop("na_action", None)
+                if na_action is not None:
+                    na_action = self.typemap[na_action.name]
+                    if is_overload_none(na_action):
+                        na_action = None
+                    else:
+                        assert is_overload_constant_str(na_action), (
+                            "Series.map(): na_action should be a constant string"
+                        )
+                        na_action = get_overload_const_str(na_action)
+                        assert na_action == "ignore", (
+                            "Series.map(): na_action should be None or 'ignore''"
+                        )
             else:
                 kws.pop("func", None)
                 kws.pop("convert_dtype", None)
             kws.pop("args", None)
             return self._handle_series_map(
-                assign, lhs, rhs, series_var, func_var, extra_args, kws, nodes
+                assign,
+                lhs,
+                rhs,
+                series_var,
+                func_var,
+                na_action,
+                extra_args,
+                kws,
+                nodes,
             )
 
         # astype with string output
@@ -3551,7 +3575,7 @@ class SeriesPass:
         return [assign]
 
     def _handle_series_map(
-        self, assign, lhs, rhs, series_var, func_var, extra_args, kws, nodes
+        self, assign, lhs, rhs, series_var, func_var, na_action, extra_args, kws, nodes
     ):
         """translate df.A.map(lambda a:...) to prange()"""
         # get the function object (ir.Expr.make_function or actual python function)
@@ -3658,6 +3682,11 @@ class SeriesPass:
                 f"  S{i} = bodo.utils.utils.alloc_type(n, _arr_typ{i}, (-1,))\n"
             )
         func_text += "  for i in numba.parfors.parfor.internal_prange(n):\n"
+        if na_action == "ignore":
+            func_text += "    if bodo.libs.array_kernels.isna(A, i):\n"
+            for i in range(n_out_cols):
+                func_text += f"      bodo.libs.array_kernels.setna(S{i}, i)\n"
+            func_text += "      continue\n"
         func_text += "    t2 = bodo.utils.conversion.box_if_dt64(A[i])\n"
         func_text += f"    v = map_func(t2, {udf_arg_names})\n"
         if is_df_output:

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -3697,7 +3697,7 @@ class TypingTransforms:
 
         # mapping of Series functions to their arguments that require constant values
         series_call_const_args = {
-            "map": [(0, "arg")],
+            "map": [(0, "arg"), (1, "na_action")],
             "apply": [(0, "func")],
             "to_frame": [(0, "name")],
             "value_counts": [


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for na_action and kws in Series.map JIT to enhance Pandas UDF support.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test. Tested Pandas 3 changes locally since not released yet.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
`na_action` and kws will work in Series.map with Bodo engine when Pandas 3 is out.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.