### PR TITLE
Fix for nightly failure in read_jsonl for multiple ranks

### DIFF
--- a/bodo/tests/test_io_hf.py
+++ b/bodo/tests/test_io_hf.py
@@ -19,21 +19,13 @@ def test_read_csv_hf(datapath, memory_leak_check):
 @pytest.mark.slow
 def test_read_json_hf(datapath, memory_leak_check):
     """Test read_json from Hugging Face"""
-    from huggingface_hub import hf_hub_download
-
-    # Download the file from the dataset repository
-    file_path = hf_hub_download(
-        repo_id="HuggingFaceH4/MATH-500", repo_type="dataset", filename="test.jsonl"
-    )
-
-    pandas_result = pd.read_json(file_path, lines=True)
 
     def test_impl():
         return pd.read_json(
-            "hf://datasets/HuggingFaceH4/MATH-500/test.jsonl", lines=True
+            "hf://datasets/craigwu/vstar_bench/test_questions.jsonl", lines=True
         )
 
-    check_func(test_impl, (), py_output=pandas_result)
+    check_func(test_impl, ())
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Changes included in this PR

I noticed this test is failing on multiple workers only for certain paths likely how they are encoded:
https://bodo.atlassian.net/browse/BSE-4962

If you go back to bodo version 2025.4 this test also fails, suggesting it is not related to a recent PR that breaking this test.

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
locally ran tests on multiple ranks
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.