### PR TITLE
Scatter dataframe lazily right before execution

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -65,13 +65,11 @@ def from_pandas(df):
 
     res_id = None
     if bodo.dataframe_library_run_parallel:
-        mgr = bodo.spawn.spawner.get_spawner().scatter_data(df)
-        res_id = mgr._md_result_id
         plan = LazyPlan(
             "LogicalGetPandasReadParallel",
             empty_df,
             n_rows,
-            LazyPlanDistributedArg(mgr, res_id),
+            LazyPlanDistributedArg(df),
         )
     else:
         plan = LazyPlan("LogicalGetPandasReadSeq", empty_df, df)

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -4,7 +4,6 @@ import typing as pt
 import warnings
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
-from copy import deepcopy
 
 import pandas as pd
 from pandas._libs import lib
@@ -820,16 +819,12 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         empty_join_out.columns = [
             c + str(i) for i, c in enumerate(empty_join_out.columns)
         ]
-        # We want to avoid having self appear on the rhs since the unique_ptr
-        # to the duckdb plan will delete it on the lhs first before it processes the rhs
-        # TODO [BSE-4865]: check right._plan for self recursively.
-        right_plan = deepcopy(right._plan) if self is right else right._plan
 
         planComparisonJoin = LazyPlan(
             "LogicalComparisonJoin",
             empty_join_out,
             self._plan,
-            right_plan,
+            right._plan,
             plan_optimizer.CJoinType.INNER,
             key_indices,
         )

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -115,25 +115,14 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                     return self._source_plan[1]
 
             if bodo.dataframe_library_run_parallel:
-                if getattr(self._mgr, "_md_result_id", None) is not None:
-                    # If the plan has been executed but the results are still
-                    # distributed then re-use those results as is.
-                    nrows = self._mgr._md_nrows
-                    res_id = self._mgr._md_result_id
-                    mgr = self._mgr
-                else:
-                    # The data has been collected and is no longer distributed
-                    # so we need to re-distribute the results.
-                    mgr = bodo.spawn.spawner.get_spawner().scatter_data(self)
-                    res_id = mgr._md_result_id
-                    nrows = len(self)
+                nrows = len(self)
                 self._source_plan = (
                     empty_data,
                     LazyPlan(
                         "LogicalGetPandasReadParallel",
                         empty_data,
                         nrows,
-                        LazyPlanDistributedArg(mgr, res_id),
+                        LazyPlanDistributedArg(self),
                     ),
                 )
             else:

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -768,6 +768,10 @@ cdef class LogicalGetPandasReadParallel(LogicalOperator):
         # plan locally for cardinality.  If so, extract res_id from that object.
         if not isinstance(result_id, str):
             result_id = result_id.res_id
+            # Set dummy result_id when not available, which is the case when we are constructing the plan just for cardinality
+            # and not for execution.
+            if result_id is None:
+                result_id = ""
         self.out_schema = out_schema
         self.nrows = nrows
         cdef unique_ptr[CLogicalGet] c_logical_get = make_dataframe_get_parallel_node(result_id.encode(), out_schema, self.getCardinality())

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -95,23 +95,12 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
                 empty_data = _empty_like(self)
                 if bodo.dataframe_library_run_parallel:
-                    if getattr(self._mgr, "_md_result_id", None) is not None:
-                        # If the plan has been executed but the results are still
-                        # distributed then re-use those results as is.
-                        nrows = self._mgr._md_nrows
-                        res_id = self._mgr._md_result_id
-                        mgr = self._mgr
-                    else:
-                        # The data has been collected and is no longer distributed
-                        # so we need to re-distribute the results.
-                        nrows = len(self)
-                        mgr = bodo.spawn.spawner.get_spawner().scatter_data(self)
-                        res_id = mgr._md_result_id
+                    nrows = len(self)
                     self._source_plan = LazyPlan(
                         "LogicalGetPandasReadParallel",
                         empty_data,
                         nrows,
-                        LazyPlanDistributedArg(mgr, res_id),
+                        LazyPlanDistributedArg(self),
                     )
                 else:
                     self._source_plan = LazyPlan(

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -523,9 +523,30 @@ def execute_plan(plan: LazyPlan):
     if bodo.dataframe_library_run_parallel:
         import bodo.spawn.spawner
 
+        # Initialize LazyPlanDistributedArg objects that may need scattering data
+        # to workers before execution.
+        for a in plan.args:
+            _init_lazy_distributed_arg(a)
+
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
     return _exec_plan(plan)
+
+
+def _init_lazy_distributed_arg(arg):
+    """Initialize the LazyPlanDistributedArg objects for the given plan argument that
+    may need scattering data to workers before execution.
+    Has to be called right before plan execution since the dataframe state
+    may change (distributed to collected) and the result ID may not be valid anymore.
+    """
+    if isinstance(arg, LazyPlan):
+        for a in arg.args:
+            _init_lazy_distributed_arg(a)
+    elif isinstance(arg, (tuple, list)):
+        for a in arg:
+            _init_lazy_distributed_arg(a)
+    elif isinstance(arg, LazyPlanDistributedArg):
+        arg.init()
 
 
 def get_plan_cardinality(plan: LazyPlan):
@@ -1036,9 +1057,30 @@ class LazyPlanDistributedArg:
     Class to hold the arguments for a LazyPlan that are distributed on the workers.
     """
 
-    def __init__(self, mgr, res_id: str):
-        self.mgr = mgr
-        self.res_id = res_id
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+        self.mgr = None
+        self.res_id = None
+
+    def init(self):
+        """Initialize to make sure the result ID is set in preparation for pickling
+        result ID to workers for execution.
+        Should be called right before execution of the plan since the dataframe state
+        may change (distributed to collected) and the result ID may not be valid
+        anymore.
+        """
+        if getattr(self.df._mgr, "_md_result_id", None) is not None:
+            # The dataframe is already distributed so we can use the existing result ID
+            self.res_id = self.df._mgr._md_result_id
+        elif self.mgr is not None:
+            # We scattered a DataFrame already and own a manager to reuse
+            self.res_id = self.mgr._md_result_id
+        else:
+            # The dataframe is not distributed yet so we need to scatter it
+            # and create a new result ID.
+            mgr = bodo.spawn.spawner.get_spawner().scatter_data(self.df)
+            self.res_id = mgr._md_result_id
+            self.mgr = mgr
 
     def __reduce__(self):
         """
@@ -1046,6 +1088,9 @@ class LazyPlanDistributedArg:
         We can't send the manager to the workers without triggering collection
         so we just send the result ID instead.
         """
+        assert self.res_id is not None, (
+            "LazyPlanDistributedArg: result ID is not set, call init() first"
+        )
         return (str, (self.res_id,))
 
 

--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -780,11 +780,14 @@ class Spawner:
         | LazySingleArrayManager
     ):
         """Scatter data to all workers and return the manager for the data."""
+        self._is_running = True
         self.worker_intercomm.bcast(CommandType.SCATTER.value, self.bcast_root)
         bodo.libs.distributed_api.scatterv(
             data, root=self.bcast_root, comm=self.worker_intercomm
         )
         res_id = self.worker_intercomm.recv(None, source=0)
+        self._is_running = False
+        self._run_del_queue()
         if isinstance(data, pd.DataFrame):
             return get_lazy_manager_class()(
                 None,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1739,3 +1739,21 @@ def test_read_csv(datapath):
         bodo_out,
         py_out,
     )
+
+
+def test_df_state_change():
+    """Make sure dataframe state change doesn't lead to stale result id in plan
+    execution"""
+
+    @bodo.jit(spawn=True)
+    def get_df(df):
+        return df
+
+    bdf = get_df(pd.DataFrame({"A": [1, 2, 3, 4, 5, 6]}))
+    bdf2 = bdf.A.map(lambda x: x)
+
+    # Collect the df, original result id is stale
+    print(bdf)
+
+    # Plan execution shouldn't fail due to stale res id
+    print(bdf2)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Scatters input dataframes lazily right before plan execution to avoid stale result id being used in workers. Also fixes common sub-plan used in right and left side of joins to eliminate deepcopy (which is problematic for objects like LazyPlanDistributedArg). Fixes a critical bug in parallel scatter as well.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Avoids "Result ID ... not found in result registry" and other critical errors.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.