### PR TITLE
[BSE-4947] Support Series.std and Series.describe

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -688,12 +688,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         shape of a dataset's distribution, excluding NaN values.
         """
         reduced_self = _compute_series_reduce(self, ["count", "min", "max", "sum"])
-        count, min, max, sum = (
-            reduced_self[0],
-            reduced_self[1],
-            reduced_self[2],
-            reduced_self[3],
-        )
+        count, min, max, sum = (reduced_self[i] for i in range(4))
 
         # Evaluate mean
         if count <= 0:
@@ -705,7 +700,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         squared_sum = _compute_series_reduce(squared, ["sum"])[0]
         std_val = ((squared_sum - (sum**2) / count) / (count - 1)) ** 0.5
 
-        # TODO: implement quantile
+        # TODO [BSE-4970]: implement Series.quantile
         quantile = self.quantile([0.25, 0.5, 0.75])
         result = [
             count,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1696,7 +1696,8 @@ def test_series_reductions():
             "C2": np.append(np.arange(n // 2) + 1.1, np.flip(np.arange(n // 2)) + 2.2),
             "D": np.append(np.flip(np.arange(n // 2)), np.arange(n // 2)),
             "E": [None] * n,
-            "F": np.append(np.arange(n - 1), [None]),
+            # TODO: fix test case below that fails for n > 68
+            # "F": [i for i in range(n-1)] + [None]
         }
     )
 
@@ -1707,6 +1708,12 @@ def test_series_reductions():
         assert np.isclose(bdf[c].product(), df[c].product(), rtol=1e-6)
         assert bdf[c].count() == df[c].count()
         out_pandas, out_bodo = df[c].mean(), bdf[c].mean()
+        assert (
+            np.isclose(out_pandas, out_bodo, rtol=1e-6)
+            if not pd.isna(out_bodo)
+            else pd.isna(out_pandas)
+        )
+        out_pandas, out_bodo = df[c].std(), bdf[c].std()
         assert (
             np.isclose(out_pandas, out_bodo, rtol=1e-6)
             if not pd.isna(out_bodo)

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1696,8 +1696,7 @@ def test_series_reductions():
             "C2": np.append(np.arange(n // 2) + 1.1, np.flip(np.arange(n // 2)) + 2.2),
             "D": np.append(np.flip(np.arange(n // 2)), np.arange(n // 2)),
             "E": [None] * n,
-            # TODO: fix test case below that fails for n > 68
-            # "F": [i for i in range(n-1)] + [None]
+            "F": np.append(np.arange(n - 1), [None]),
         }
     )
 
@@ -1875,3 +1874,23 @@ def test_loc(datapath):
         sort_output=False,
         reset_index=True,
     )
+
+
+def test_series_describe():
+    """Basic test for Series describe."""
+    n = 10000
+    df = pd.DataFrame(
+        {
+            "A": np.arange(n),
+            "B": np.flip(np.arange(n, dtype=np.int32)),
+            "C": np.append(np.arange(n // 2), np.flip(np.arange(n // 2))),
+            "D": np.append(np.flip(np.arange(n // 2)), np.arange(n // 2)),
+        }
+    )
+
+    bdf = bd.from_pandas(df)
+
+    for c in df.columns:
+        describe_pd = df[c].describe()
+        describe_bodo = bdf[c].describe()
+        _test_equal(describe_pd, describe_bodo, check_pandas_types=False)

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1885,6 +1885,7 @@ def test_series_describe():
             "B": np.flip(np.arange(n, dtype=np.int32)),
             "C": np.append(np.arange(n // 2), np.flip(np.arange(n // 2))),
             "D": np.append(np.flip(np.arange(n // 2)), np.arange(n // 2)),
+            "E": [None] * n,
         }
     )
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1685,7 +1685,8 @@ def test_series_min_max_unsupported_types():
         bdf["A"].max()
 
 
-def test_series_reductions():
+@pytest.mark.parametrize("method", ["sum", "product", "count", "mean", "std"])
+def test_series_reductions(method):
     """Basic test for Series sum, product, count, and mean."""
     n = 10000
     df = pd.DataFrame(
@@ -1703,16 +1704,8 @@ def test_series_reductions():
     bdf = bd.from_pandas(df)
 
     for c in df.columns:
-        assert np.isclose(bdf[c].sum(), df[c].sum(), rtol=1e-6)
-        assert np.isclose(bdf[c].product(), df[c].product(), rtol=1e-6)
-        assert bdf[c].count() == df[c].count()
-        out_pandas, out_bodo = df[c].mean(), bdf[c].mean()
-        assert (
-            np.isclose(out_pandas, out_bodo, rtol=1e-6)
-            if not pd.isna(out_bodo)
-            else pd.isna(out_pandas)
-        )
-        out_pandas, out_bodo = df[c].std(), bdf[c].std()
+        out_pandas = getattr(df[c], method)()
+        out_bodo = getattr(bdf[c], method)()
         assert (
             np.isclose(out_pandas, out_bodo, rtol=1e-6)
             if not pd.isna(out_bodo)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for Series.std and Series.describe. 
Evaluation of quantile falls back to Pandas, issue created here: https://bodo.atlassian.net/browse/BSE-4970?atlOrigin=eyJpIjoiOTE4YmM2NzY4NTdlNDYyMjhlYjkxMTI2OWRlYjAyNjQiLCJwIjoiaiJ9

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, adds tests for std and describe.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Series.std and Series.describe
## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.