### PR TITLE
[BSE-4946] Suppress subsequent fallback warnings

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -136,7 +136,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             warnings.warn(BodoLibFallbackWarning(msg))
-            return object.__getattribute__(pd.Series(self), name)
+            return object.__getattribute__(pd.Series(self._obj), name)
 
         return object.__getattribute__(self, name)
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -685,7 +685,9 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         shape of a dataset's distribution, excluding NaN values.
         """
         if not isinstance(self.dtype, pd.ArrowDtype):
-            raise BodoLibNotImplementedException("self is not a BodoSeries.")
+            raise BodoLibNotImplementedException(
+                "BodoSeries.describe() is not supported for non-Arrow dtypes."
+            )
 
         pa_type = self.dtype.pyarrow_dtype
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1166,7 +1166,7 @@ def fallback_wrapper(attr):
 
         def silenced_method(*args, **kwargs):
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
+                warnings.simplefilter("ignore", category=BodoLibFallbackWarning)
                 return attr(*args, **kwargs)
 
         return silenced_method

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -136,7 +136,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             warnings.warn(BodoLibFallbackWarning(msg))
-            return object.__getattribute__(self, name)
+            return object.__getattribute__(pd.Series(self), name)
 
         return object.__getattribute__(self, name)
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -118,15 +118,18 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
     def __getattribute__(self, name: str):
         """Custom attribute access that triggers a fallback warning for unsupported attributes."""
 
-        try:
-            return object.__getattribute__(self, name)
-        except AttributeError:
+        cls = object.__getattribute__(self, "__class__")
+        base = cls.__mro__[0]
+
+        if name not in base.__dict__ and not name.startswith("_"):
             msg = (
-                f"Series.{name} is not implemented in Bodo Dataframe Library yet. "
+                f"{name} is not implemented in Bodo Dataframe Library yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             warnings.warn(BodoLibFallbackWarning(msg))
             return object.__getattribute__(pd.Series(self._obj), name)
+
+        return object.__getattribute__(self, name)
 
     @check_args_fallback("all")
     def _cmp_method(self, other, op):

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -118,27 +118,15 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
     def __getattribute__(self, name: str):
         """Custom attribute access that triggers a fallback warning for unsupported attributes."""
 
-        ignore_fallback_attrs = [
-            "dtype",
-            "name",
-            "to_string",
-        ]
-        cls = object.__getattribute__(self, "__class__")
-        base = cls.__mro__[0]
-
-        if (
-            name not in base.__dict__
-            and name not in ignore_fallback_attrs
-            and not name.startswith("_")
-        ):
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
             msg = (
-                f"{name} is not implemented in Bodo Dataframe Library yet. "
+                f"Series.{name} is not implemented in Bodo Dataframe Library yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             warnings.warn(BodoLibFallbackWarning(msg))
             return object.__getattribute__(pd.Series(self._obj), name)
-
-        return object.__getattribute__(self, name)
 
     @check_args_fallback("all")
     def _cmp_method(self, other, op):

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1151,14 +1151,27 @@ class BodoDatetimeProperties:
         )
 
 
-def fallback_wrapper(func):
-    def silenced(*args, **kwargs):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            res = func(*args, **kwargs)
-            return res
+def fallback_wrapper(attr):
+    """
+    Wrap callable attributes with a warning silencer, unless they are known
+    accessors or indexers like `.iloc`, `.loc`, `.str`, `.dt`, `.cat`.
+    """
 
-    return silenced
+    # Avoid wrapping indexers & accessors
+    if (
+        callable(attr)
+        and not hasattr(attr, "__getitem__")
+        and not hasattr(attr, "__getattr__")
+    ):
+
+        def silenced_method(*args, **kwargs):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                return attr(*args, **kwargs)
+
+        return silenced_method
+
+    return attr
 
 
 def map_validate_reduce(func_names, pa_type):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes behavior of Series method fallback raising warnings for every unsupported internal/subsequent call. 

Edit: it turns out a lot of inplace editing methods (like `fillna` and `reset_index`) does not work when `self` is casted to a Pandas Series in getattr. Wrapping the initial fallback method with a warning-silencing wrapper works safely. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
N/A

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Users are not spammed with warnings. 

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.