### PR TITLE
Treat missing index columns in Pandas Metadata as RangeIndex when reading Parquet

### DIFF
--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -855,6 +855,10 @@ def _reconstruct_pandas_index(df, arrow_schema):
     for descr in arrow_schema.pandas_metadata.get("index_columns", []):
         if isinstance(descr, str):
             index_name = None if _is_generated_index_name(descr) else descr
+            # Index not found in table: matching Pyarrow's behavior, which treats
+            # missing index as RangeIndex.
+            if descr not in df:
+                continue
             index_level = df[descr]
             df = df.drop(columns=[descr])
         elif descr["kind"] == "range":


### PR DESCRIPTION
## Changes included in this PR

If a Parquet file has an index column listed in the metadata that is not present in the actual table, assume it is supposed to be a RangeIndex. This is consistent to what pyarrow does here:
https://github.com/apache/arrow/blob/5e9fce493f21098d616f08034bc233fcc529b3ad/python/pyarrow/pandas_compat.py#L994

## Testing strategy

Ran:
``` py
import bodo.pandas as bd

print(bd.read_parquet("gs://cloud-samples-data/bigquery/us-states/us-states.parquet"))
```
And compared output to Pyarrow.

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.