### PR TITLE
Fix join output column map to input

### DIFF
--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -17,25 +17,30 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
     explicit PhysicalJoin(
         duckdb::LogicalComparisonJoin& logical_join,
         const duckdb::vector<duckdb::JoinCondition>& conditions) {
-        // Initialize column indices in join build/probe that need to be
-        // produced according to join output bindings
-        duckdb::idx_t left_table_index = -1;
-        duckdb::idx_t right_table_index = -1;
-        std::vector<duckdb::ColumnBinding> left_findings =
-            logical_join.children[0]->GetColumnBindings();
-        std::vector<duckdb::ColumnBinding> right_findings =
-            logical_join.children[1]->GetColumnBindings();
-        if (left_findings.size() > 0) {
-            left_table_index = left_findings[0].table_index;
+        // Find left/right table columns that will be in the join output.
+        // Similar to DuckDB:
+        // https://github.com/duckdb/duckdb/blob/d29a92f371179170688b4df394478f389bf7d1a6/src/execution/operator/join/physical_hash_join.cpp#L58
+        if (logical_join.left_projection_map.empty()) {
+            for (duckdb::idx_t i = 0;
+                 i < logical_join.children[0]->GetColumnBindings().size();
+                 i++) {
+                this->bound_left_inds.insert(i);
+            }
+        } else {
+            for (const auto& c : logical_join.left_projection_map) {
+                this->bound_left_inds.insert(c);
+            }
         }
-        if (right_findings.size() > 0) {
-            right_table_index = right_findings[0].table_index;
-        }
-        for (auto& c : logical_join.GetColumnBindings()) {
-            if (c.table_index == left_table_index) {
-                this->bound_left_inds.insert(c.column_index);
-            } else if (c.table_index == right_table_index) {
-                this->bound_right_inds.insert(c.column_index);
+
+        if (logical_join.right_projection_map.empty()) {
+            for (duckdb::idx_t i = 0;
+                 i < logical_join.children[1]->GetColumnBindings().size();
+                 i++) {
+                this->bound_right_inds.insert(i);
+            }
+        } else {
+            for (const auto& c : logical_join.right_projection_map) {
+                this->bound_right_inds.insert(c);
             }
         }
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

Fixes mapping join output columns to left/right input columns which resolves TPC-H Q20 issue. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Fixes segfaults.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.