### PR TITLE
BSE-4975: Change parquet readahead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,11 @@ bodo/libs/memory.cpp
 bodo/io/pyarrow_wrappers.cpp
 bodo/io/pyarrow_wrappers.h
 bodo/io/pyarrow_wrappers_api.h
+bodo/memory.cpp
+bodo/pandas/plan_optimizer.cpp
+bodo/tests/memory_tester.cpp
+bodo/transforms/type_inference/native_typer.cpp
+bodo/transforms/type_inference/native_typer.h
 
 # Iceberg Connector
 iceberg_db

--- a/bodo/io/iceberg/read_metadata.py
+++ b/bodo/io/iceberg/read_metadata.py
@@ -362,7 +362,7 @@ def get_table_length(table, snapshot_id: int = -1) -> int:
             for entry in manifest_entries:
                 if (
                     entry.status == ManifestEntryStatus.DELETED
-                    or entry.content != ManifestContent.DATA
+                    or manifest.content != ManifestContent.DATA
                 ):
                     continue
                 datafile = entry.data_file

--- a/bodo/io/iceberg_parquet_reader.cpp
+++ b/bodo/io/iceberg_parquet_reader.cpp
@@ -1180,8 +1180,8 @@ void IcebergParquetReader::init_scanners() {
             dataset_py, dataset_expr_filter_py, this->selected_fields,
             this->batch_size != -1 ? this->batch_size
                                    : arrow::dataset::kDefaultBatchSize,
-            /*use_threads*/ true, arrow::dataset::kDefaultBatchReadahead,
-            arrow::dataset::kDefaultFragmentReadahead, this->cpu_executor()));
+            /*use_threads*/ true, this->batch_readahead(),
+            this->frag_readahead()));
     }
     this->iceberg_reader_metrics.create_scanners_time += end_timer(start);
 

--- a/bodo/io/iceberg_parquet_reader.cpp
+++ b/bodo/io/iceberg_parquet_reader.cpp
@@ -1180,7 +1180,8 @@ void IcebergParquetReader::init_scanners() {
             dataset_py, dataset_expr_filter_py, this->selected_fields,
             this->batch_size != -1 ? this->batch_size
                                    : arrow::dataset::kDefaultBatchSize,
-            /*use_threads*/ true, this->batch_readahead, this->frag_readahead));
+            /*use_threads*/ true, this->batch_readahead, this->frag_readahead,
+            this->cpu_executor()));
     }
     this->iceberg_reader_metrics.create_scanners_time += end_timer(start);
 

--- a/bodo/io/iceberg_parquet_reader.cpp
+++ b/bodo/io/iceberg_parquet_reader.cpp
@@ -1180,8 +1180,7 @@ void IcebergParquetReader::init_scanners() {
             dataset_py, dataset_expr_filter_py, this->selected_fields,
             this->batch_size != -1 ? this->batch_size
                                    : arrow::dataset::kDefaultBatchSize,
-            /*use_threads*/ true, this->batch_readahead(),
-            this->frag_readahead()));
+            /*use_threads*/ true, this->batch_readahead, this->frag_readahead));
     }
     this->iceberg_reader_metrics.create_scanners_time += end_timer(start);
 

--- a/bodo/io/parquet_pio.py
+++ b/bodo/io/parquet_pio.py
@@ -1133,7 +1133,9 @@ def get_scanner_batches(
     rows_to_read: int,  # total number of rows this process is going to read
     partitioning,
     schema: pa.Schema,
-    batch_size: int | None = None,
+    batch_size: int,
+    batch_readahead: int,
+    fragment_readahed: int,
 ):
     """return RecordBatchReader for dataset of 'fpaths' that contain the rows
     that match filters (or all rows if filters is None). Only project the
@@ -1190,10 +1192,10 @@ def get_scanner_batches(
         # this at some point.
         columns=selected_names,
         filter=filters,
-        batch_size=batch_size or 128 * 1024,
+        batch_size=batch_size,
         use_threads=True,
-        # XXX Specify batch_readahead (default: 16)?
-        # XXX Specify fragment_readahead (default: 4)?
+        batch_readahead=batch_readahead,
+        fragment_readahead=fragment_readahed,
         # XXX Specify memory pool?
     ).to_reader()
     return rb_reader, start_offset

--- a/bodo/io/parquet_reader.cpp
+++ b/bodo/io/parquet_reader.cpp
@@ -187,8 +187,8 @@ void ParquetReader::init_pq_scanner() {
         int(parallel), this->filesystem.get(), str_as_dict_cols_py.get(),
         this->start_row_first_piece, this->count, this->ds_partitioning.get(),
         this->pyarrow_schema, batch_size == -1 ? 128 * 1024 : batch_size,
-        static_cast<long>(this->batch_readahead()),
-        static_cast<long>(this->frag_readahead()));
+        static_cast<long>(this->batch_readahead),
+        static_cast<long>(this->frag_readahead));
     if (scanner_batches_tup == nullptr && PyErr_Occurred()) {
         throw std::runtime_error("python");
     }

--- a/bodo/io/parquet_reader.cpp
+++ b/bodo/io/parquet_reader.cpp
@@ -175,20 +175,18 @@ void ParquetReader::init_pq_scanner() {
         PyList_SetItem(selected_fields_py, i++, PyLong_FromLong(field_num));
     }
 
-    PyObjectPtr batch_size_py =
-        batch_size == -1 ? Py_None : PyLong_FromLong(batch_size);
     PyObjectPtr pq_mod = PyImport_ImportModule("bodo.io.parquet_pio");
     // This only loads record batches that match the filter.
     // get_scanner_batches returns a tuple with the record batch reader and the
     // updated offset for the first batch.
     PyObjectPtr scanner_batches_tup = PyObject_CallMethod(
-        pq_mod, "get_scanner_batches", "OOOdiOOLLOOLll", fnames_list_py.get(),
+        pq_mod, "get_scanner_batches", "OOOdiOOLLOOLLL", fnames_list_py.get(),
         this->expr_filters.get(), selected_fields_py.get(), avg_num_pieces,
         int(parallel), this->filesystem.get(), str_as_dict_cols_py.get(),
         this->start_row_first_piece, this->count, this->ds_partitioning.get(),
         this->pyarrow_schema, batch_size == -1 ? 128 * 1024 : batch_size,
-        static_cast<long>(this->batch_readahead),
-        static_cast<long>(this->frag_readahead));
+        static_cast<int64_t>(this->batch_readahead),
+        static_cast<int64_t>(this->frag_readahead));
     if (scanner_batches_tup == nullptr && PyErr_Occurred()) {
         throw std::runtime_error("python");
     }

--- a/bodo/io/parquet_reader.cpp
+++ b/bodo/io/parquet_reader.cpp
@@ -182,11 +182,13 @@ void ParquetReader::init_pq_scanner() {
     // get_scanner_batches returns a tuple with the record batch reader and the
     // updated offset for the first batch.
     PyObjectPtr scanner_batches_tup = PyObject_CallMethod(
-        pq_mod, "get_scanner_batches", "OOOdiOOLLOOO", fnames_list_py.get(),
+        pq_mod, "get_scanner_batches", "OOOdiOOLLOOLll", fnames_list_py.get(),
         this->expr_filters.get(), selected_fields_py.get(), avg_num_pieces,
         int(parallel), this->filesystem.get(), str_as_dict_cols_py.get(),
         this->start_row_first_piece, this->count, this->ds_partitioning.get(),
-        this->pyarrow_schema, batch_size_py.get());
+        this->pyarrow_schema, batch_size == -1 ? 128 * 1024 : batch_size,
+        static_cast<long>(this->batch_readahead()),
+        static_cast<long>(this->frag_readahead()));
     if (scanner_batches_tup == nullptr && PyErr_Occurred()) {
         throw std::runtime_error("python");
     }


### PR DESCRIPTION
## Changes included in this PR
Previously each rank would try to read 16 batches (16 * 128k rows) ahead and 4 fragments (4 files) a head due to Arrow's default settings which are meant for a single reader. This PR adjusts those defaults based on the number of ranks on the node.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
PR CI + streaming Iceberg read into write benchmark + local nyc taxi head OOM.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Lower memory consumption during parquet/iceberg reads.
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.