### PR TITLE
[BSE-4978] Support Series.aggregate

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -781,6 +781,8 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 "Series.agg() is not supported for the provided arguments yet."
             )
 
+    aggregate = agg
+
 
 class BodoStringMethods:
     """Support Series.str string processing methods same as Pandas."""

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -777,7 +777,9 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             reduced = _compute_series_reduce(self, func)
             return BodoSeries(reduced, index=func)
         else:
-            raise BodoLibNotImplementedException()
+            raise BodoLibNotImplementedException(
+                "Series.agg() is not supported for the provided arguments yet."
+            )
 
 
 class BodoStringMethods:

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -350,7 +350,9 @@ def check_args_fallback(
                     if except_msg:
                         msg += f"\nException: {except_msg}"
                     warnings.warn(BodoLibFallbackWarning(msg))
-                    py_res = getattr(base_class, func.__name__)(self, *args, **kwargs)
+                    py_res = fallback_wrapper(getattr(base_class, func.__name__))(
+                        self, *args, **kwargs
+                    )
                     return py_res
 
         return wrapper
@@ -1220,3 +1222,26 @@ def is_scalar_func(expr):
 
 def is_arith_expr(expr):
     return expr.plan_class == "ArithOpExpression"
+
+
+def fallback_wrapper(attr):
+    """
+    Wrap callable attributes with a warning silencer, unless they are known
+    accessors or indexers like `.iloc`, `.loc`, `.str`, `.dt`, `.cat`.
+    """
+
+    # Avoid wrapping indexers & accessors
+    if (
+        callable(attr)
+        and not hasattr(attr, "__getitem__")
+        and not hasattr(attr, "__getattr__")
+    ):
+
+        def silenced_method(*args, **kwargs):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=BodoLibFallbackWarning)
+                return attr(*args, **kwargs)
+
+        return silenced_method
+
+    return attr

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1927,3 +1927,20 @@ def test_series_describe():
         describe_pd = df[c].describe()
         describe_bodo = bdf[c].describe()
         _test_equal(describe_pd, describe_bodo, check_pandas_types=False)
+
+
+def test_series_agg():
+    import pandas as pd
+
+    import bodo.pandas as bd
+
+    df = pd.DataFrame({"A": [1, 2, 3, 4, 5]})
+    bdf = bd.from_pandas(df)
+
+    bodo_out = bdf.A.aggregate("sum")
+    pd_out = df.A.aggregate("sum")
+    assert bodo_out == pd_out
+
+    bodo_out = bdf.A.aggregate(["min", "max", "count", "product"])
+    pd_out = df.A.aggregate(["min", "max", "count", "product"])
+    _test_equal(bodo_out, pd_out, check_pandas_types=False)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for Series.aggregate() for func=`max`, `min`, `sum`, `product`, etc.


## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, adds end-to-end test. 
## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Series.aggregate() is available. 
## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.