### PR TITLE
NYC taxi changes

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -77,7 +77,6 @@ def from_pandas(df):
 
     # TODO [BSE-4788]: Refactor with convert_to_arrow_dtypes util
     pa_schema = pa.Schema.from_pandas(df.iloc[:sample_size])
-
     empty_df = arrow_to_empty_df(pa_schema)
     n_rows = len(df)
 
@@ -119,6 +118,7 @@ def read_parquet(
         "hive" if use_hive else None,
     )
     arrow_schema = pq_dataset.schema
+
     empty_df = arrow_to_empty_df(arrow_schema)
 
     plan = LogicalGetParquetRead(

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -67,7 +67,7 @@ def _cast_timestamp_dtypes(pa_schema):
         for idx in idxs:
             field = pa_schema.field(idx)
             if pa.types.is_timestamp(field.type):
-                new_field = pa.field(field.name, pa.timestamp("ns"))
+                new_field = pa.field(field.name, pa.timestamp("ns", tz=field.type.tz))
                 pa_schema = pa_schema.set(idx, new_field)
 
     return pa_schema

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -119,7 +119,6 @@ def read_parquet(
         "hive" if use_hive else None,
     )
     arrow_schema = pq_dataset.schema
-
     empty_df = arrow_to_empty_df(arrow_schema)
 
     plan = LogicalGetParquetRead(

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -53,6 +53,19 @@ if pt.TYPE_CHECKING:
     from pyiceberg.table import Table as PyIcebergTable
 
 
+def _cast_timestamp_dtypes(pa_schema):
+    """Returns a new pa_schema with timestamp types cast to ns."""
+    for name in pa_schema.names:
+        idxs = pa_schema.get_all_field_indices(name)
+        for idx in idxs:
+            field = pa_schema.field(idx)
+            if pa.types.is_timestamp(field.type):
+                new_field = pa.field(field.name, pa.timestamp("ns"))
+                pa_schema = pa_schema.set(idx, new_field)
+
+    return pa_schema
+
+
 def from_pandas(df):
     """Convert a Pandas DataFrame to a BodoDataFrame."""
 
@@ -70,6 +83,8 @@ def from_pandas(df):
 
     # TODO [BSE-4788]: Refactor with convert_to_arrow_dtypes util
     pa_schema = pa.Schema.from_pandas(df.iloc[:sample_size])
+    pa_schema = _cast_timestamp_dtypes(pa_schema)
+
     empty_df = arrow_to_empty_df(pa_schema)
     n_rows = len(df)
 
@@ -112,6 +127,7 @@ def read_parquet(
         "hive" if use_hive else None,
     )
     arrow_schema = pq_dataset.schema
+    arrow_schema = _cast_timestamp_dtypes(arrow_schema)
 
     empty_df = arrow_to_empty_df(arrow_schema)
 

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -60,19 +60,6 @@ if pt.TYPE_CHECKING:
     from pyiceberg.table import Table as PyIcebergTable
 
 
-def _cast_timestamp_dtypes(pa_schema):
-    """Returns a new pa_schema with timestamp types cast to ns."""
-    for name in pa_schema.names:
-        idxs = pa_schema.get_all_field_indices(name)
-        for idx in idxs:
-            field = pa_schema.field(idx)
-            if pa.types.is_timestamp(field.type):
-                new_field = pa.field(field.name, pa.timestamp("ns", tz=field.type.tz))
-                pa_schema = pa_schema.set(idx, new_field)
-
-    return pa_schema
-
-
 def from_pandas(df):
     """Convert a Pandas DataFrame to a BodoDataFrame."""
 
@@ -90,7 +77,6 @@ def from_pandas(df):
 
     # TODO [BSE-4788]: Refactor with convert_to_arrow_dtypes util
     pa_schema = pa.Schema.from_pandas(df.iloc[:sample_size])
-    pa_schema = _cast_timestamp_dtypes(pa_schema)
 
     empty_df = arrow_to_empty_df(pa_schema)
     n_rows = len(df)
@@ -133,7 +119,6 @@ def read_parquet(
         "hive" if use_hive else None,
     )
     arrow_schema = pq_dataset.schema
-    arrow_schema = _cast_timestamp_dtypes(arrow_schema)
 
     empty_df = arrow_to_empty_df(arrow_schema)
 

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -380,7 +380,7 @@ def read_csv(
         func_args.append(parse_dates)
     func += ")\n"
     csv_func = bodo_spawn_exec(func, {"pd": pd}, {}, __name__)
-    jit_csv_func = bodo.jit(csv_func)
+    jit_csv_func = bodo.jit(csv_func, cache=True)
     return jit_csv_func(filepath_or_buffer, *func_args)
 
 

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -161,8 +161,6 @@ def execute_plan(plan: LazyPlan):
             # triggers execution.  This traceback can help fix the bug or
             # select a different Pandas API or an internal Pandas function that
             # bypasses the issue.
-            traceback.print_stack(file=sys.stdout)
-            print("")  # Print on new line during tests.
             print("Unoptimized plan")
             print(duckdb_plan.toString())
 
@@ -201,6 +199,8 @@ def execute_plan(plan: LazyPlan):
         for a in plan.args:
             _init_lazy_distributed_arg(a)
 
+        traceback.print_stack(file=sys.stdout)
+        print("")  # Print on new line during tests.
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
     return _exec_plan(plan)

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -195,14 +195,11 @@ def execute_plan(plan: LazyPlan):
     if bodo.dataframe_library_run_parallel:
         # Initialize LazyPlanDistributedArg objects that may need scattering data
         # to workers before execution.
-        import time
 
         import bodo.spawn.spawner
 
-        start_init = time.time()
         for a in plan.args:
             _init_lazy_distributed_arg(a)
-        print("initializing lazy args took: ", time.time() - start_init)
 
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
@@ -215,7 +212,7 @@ def _init_lazy_distributed_arg(arg, cache=None):
     Has to be called right before plan execution since the dataframe state
     may change (distributed to collected) and the result ID may not be valid anymore.
     """
-    # cache LazyPlan's to prevent redundant checking.
+    # cache LazyPlans to prevent redundant checking.
     if cache is None:
         cache = set()
 

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -193,12 +193,16 @@ def execute_plan(plan: LazyPlan):
         )
 
     if bodo.dataframe_library_run_parallel:
-        import bodo.spawn.spawner
-
         # Initialize LazyPlanDistributedArg objects that may need scattering data
         # to workers before execution.
+        import time
+
+        import bodo.spawn.spawner
+
+        start_init = time.time()
         for a in plan.args:
             _init_lazy_distributed_arg(a)
+        print("initializing lazy args took: ", time.time() - start_init)
 
         return bodo.spawn.spawner.submit_func_to_workers(_exec_plan, [], plan)
 
@@ -323,6 +327,7 @@ class LazyPlanDistributedArg:
         anymore.
         """
         if getattr(self.df._mgr, "_md_result_id", None) is not None:
+            print("initializing", self)
             # The dataframe is already distributed so we can use the existing result ID
             self.res_id = self.df._mgr._md_result_id
         elif self.mgr is not None:

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -503,7 +503,6 @@ class LazyPlanDistributedArg:
         anymore.
         """
         if getattr(self.df._mgr, "_md_result_id", None) is not None:
-            # print("initializing", self)
             # The dataframe is already distributed so we can use the existing result ID
             self.res_id = self.df._mgr._md_result_id
         elif self.mgr is not None:

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1836,11 +1836,7 @@ def validate_dtype(name, obj):
             raise AttributeError("Can only use .str accessor with string values!")
     if accessor == "dt":
         if dtype not in allowed_types_map.get(
-            name,
-            [
-                pd.ArrowDtype(pa.timestamp("ns")),
-                pd.ArrowDtype(pa.duration("ns")),
-            ],
+            name, [pd.ArrowDtype(pa.timestamp("ns")), pd.ArrowDtype(pa.duration("ns"))]
         ):
             raise AttributeError("Can only use .dt accessor with datetimelike values!")
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -990,6 +990,8 @@ class BodoDatetimeProperties:
     def __init__(self, series):
         allowed_types = allowed_types_map["dt_default"]
         # Validates series type
+        # Allows duration[ns] type, timestamp any precision without timezone.
+        # TODO: timestamp with timezone, other duration types.
         if not (
             isinstance(series, BodoSeries)
             and (

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1844,7 +1844,12 @@ def validate_dtype(name, obj):
             raise AttributeError("Can only use .str accessor with string values!")
     if accessor == "dt":
         if dtype not in allowed_types_map.get(
-            name, [pd.ArrowDtype(pa.timestamp("ns")), pd.ArrowDtype(pa.duration("ns"))]
+            name,
+            [
+                pd.ArrowDtype(pa.timestamp("ns")),
+                pd.ArrowDtype(pa.timestamp("us")),
+                pd.ArrowDtype(pa.duration("ns")),
+            ],
         ):
             raise AttributeError("Can only use .dt accessor with datetimelike values!")
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -987,7 +987,7 @@ class BodoDatetimeProperties:
     def __init__(self, series):
         allowed_types = allowed_types_map["dt_default"]
         # Validates series type
-        if not (isinstance(series, BodoSeries) and series.dtype in allowed_types,):
+        if not (isinstance(series, BodoSeries) and series.dtype in allowed_types):
             raise AttributeError("Can only use .dt accessor with datetimelike values")
         self._series = series
         self._dtype = series.dtype
@@ -1847,7 +1847,6 @@ def validate_dtype(name, obj):
             name,
             [
                 pd.ArrowDtype(pa.timestamp("ns")),
-                pd.ArrowDtype(pa.timestamp("us")),
                 pd.ArrowDtype(pa.duration("ns")),
             ],
         ):

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -395,9 +395,6 @@ def _empty_pd_array(pa_type):
         return pd.array(
             ["dummy"], pd.ArrowDtype(pa.dictionary(pa.int32(), pa.string()))
         )[:0]
-    elif isinstance(pa_type, pa.TimestampType):
-        # Convert timestamp types to nanoseconds to match backend types.
-        pa_type = pa.timestamp("ns")
 
     pa_arr = pa.array([], type=pa_type, from_pandas=True)
     return pd.array(pa_arr, dtype=pd.ArrowDtype(pa_type))

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -395,6 +395,9 @@ def _empty_pd_array(pa_type):
         return pd.array(
             ["dummy"], pd.ArrowDtype(pa.dictionary(pa.int32(), pa.string()))
         )[:0]
+    elif isinstance(pa_type, pa.TimestampType):
+        # Convert timestamp types to nanoseconds to match backend types.
+        pa_type = pa.timestamp("ns")
 
     pa_arr = pa.array([], type=pa_type, from_pandas=True)
     return pd.array(pa_arr, dtype=pd.ArrowDtype(pa_type))


### PR DESCRIPTION
## Changes included in this PR

First round of changes for running NYC taxi and collecting performance data:
1. Prevent unnecessary fallback when input DataFrame or parquet contains timestamp with non ns precision
2. Optimize `_init_lazy_distributed_arg` by making sure it's only called once per LazyPlan.
3. Adds cache flag to read_csv.

### 5m rows

Monthly Taxi Travel Times Computation Time:  3.86s
 - time spent in read_csv: 1.77s
 - time spent in execute_plan: 1.76s
 - time spent in map: 0.28s

Monthly Taxi Travel Times Computation Time:  1.00s (total time calling `get_monthly_travels_weather` with cache=True)

### 20m rows

Monthly Taxi Travel Times Computation Time:  21.61s
 - time spent in execute_plan: 18.70s 
- time spent in read_csv: 1.71s
 - time spent in map: 0.98s

Monthly Taxi Travel Times Computation Time:  4.11s (total time calling `get_monthly_travels_weather` with cache=True)


## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.