### PR TITLE
Refactor LazyPlan uses into proper Python class hierarchy

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -281,7 +281,7 @@ def read_iceberg_table(table: PyIcebergTable) -> BodoDataFrame:
     # https://github.com/ehsantn/iceberg-python/blob/cae24259aa7ea3923703f65b58da7ff5a67414ba/pyiceberg/catalog/__init__.py#L242
     if pyiceberg.catalog.TYPE not in catalog_properties:
         catalog_properties[pyiceberg.catalog.PY_CATALOG_IMPL] = (
-            table.catalog.__class__.__module__ + "." + table.catalog.__class__.__name__,
+            table.catalog.__class__.__module__ + "." + table.catalog.__class__.__name__
         )
 
     return read_iceberg(

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -245,7 +245,7 @@ def read_iceberg(
         pyiceberg_schema,
         snapshot_id if snapshot_id is not None else -1,
         table_len_estimate,
-        __pa_schema=arrow_schema,
+        arrow_schema=arrow_schema,
     )
 
     if selected_fields is not None:

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -343,11 +343,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             warnings.warn(
                 "BodoDataFrame::rename copy=False argument ignored assuming A=A.rename(copy=False) idiom."
             )
-        renamed_plan = LazyPlan(
-            orig_plan.plan_class,
-            orig_plan.empty_data.rename(columns=columns),
-            *orig_plan.args,
-            **orig_plan.kwargs,
+        renamed_plan = orig_plan.replace_empty_data(
+            orig_plan.empty_data.rename(columns=columns)
         )
         return wrap_plan(renamed_plan)
 

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -13,7 +13,12 @@ import pyarrow as pa
 from pandas._libs import lib
 from pandas.core.dtypes.inference import is_dict_like, is_list_like
 
-from bodo.pandas.plan import LazyPlan, make_col_ref_exprs
+from bodo.pandas.plan import (
+    LazyPlan,
+    LogicalAggregate,
+    LogicalProjection,
+    make_col_ref_exprs,
+)
 from bodo.pandas.utils import (
     BodoLibFallbackWarning,
     BodoLibNotImplementedException,
@@ -422,8 +427,7 @@ def _groupby_agg_plan(
         ) in enumerate(func)
     ]
 
-    plan = LazyPlan(
-        "LogicalAggregate",
+    plan = LogicalAggregate(
         empty_data,
         grouped._obj._plan,
         key_indices,
@@ -437,8 +441,7 @@ def _groupby_agg_plan(
         col_indices += list(range(len(grouped._keys)))
 
         exprs = make_col_ref_exprs(col_indices, plan)
-        plan = LazyPlan(
-            "LogicalProjection",
+        plan = LogicalProjection(
             empty_data,
             plan,
             exprs,

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -14,7 +14,7 @@ from pandas._libs import lib
 from pandas.core.dtypes.inference import is_dict_like, is_list_like
 
 from bodo.pandas.plan import (
-    LazyPlan,
+    AggregateExpression,
     LogicalAggregate,
     LogicalProjection,
     make_col_ref_exprs,
@@ -411,8 +411,7 @@ def _groupby_agg_plan(
     key_indices = [grouped._obj.columns.get_loc(c) for c in grouped._keys]
 
     exprs = [
-        LazyPlan(
-            "AggregateExpression",
+        AggregateExpression(
             empty_data.iloc[:, i]
             if isinstance(empty_data, pd.DataFrame)
             else empty_data,

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -140,7 +140,6 @@ class LazyPlan:
             **self.kwargs,
         )
         out.is_series = self.is_series
-        out.pa_schema = self.pa_schema
         return out
 
 

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -228,6 +228,36 @@ class LogicalIcebergWrite(LogicalOperator):
     pass
 
 
+class ColRefExpression(Expression):
+    """Expression representing a column reference in the query plan."""
+
+    pass
+
+
+class NullExpression(Expression):
+    """Expression representing a null value in the query plan."""
+
+    pass
+
+
+class ConstantExpression(Expression):
+    """Expression representing a constant value in the query plan."""
+
+    pass
+
+
+class AggregateExpression(Expression):
+    """Expression representing an aggregate function in the query plan."""
+
+    pass
+
+
+class PythonScalarFuncExpression(Expression):
+    """Expression representing a Python scalar function call in the query plan."""
+
+    pass
+
+
 def execute_plan(plan: LazyPlan):
     """Execute a dataframe plan using Bodo's execution engine.
 

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -165,7 +165,7 @@ class LogicalProjection(LogicalOperator):
     def __init__(self, empty_data, source, exprs):
         self.source = source
         self.exprs = exprs
-        super().__init__("LogicalProjection", empty_data, source, exprs)
+        super().__init__(empty_data, source, exprs)
 
 
 class LogicalFilter(LogicalOperator):

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -132,6 +132,17 @@ class LazyPlan:
         cache[id(self)] = ret
         return ret
 
+    def replace_empty_data(self, empty_data):
+        """Replace the empty_data of the plan with a new empty_data."""
+        out = self.__class__(
+            empty_data,
+            *self.args,
+            **self.kwargs,
+        )
+        out.is_series = self.is_series
+        out.pa_schema = self.pa_schema
+        return out
+
 
 class LogicalOperator(LazyPlan):
     """Base class for all logical operators in the Bodo query plan."""

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -133,6 +133,101 @@ class LazyPlan:
         return ret
 
 
+class LogicalOperator(LazyPlan):
+    """Base class for all logical operators in the Bodo query plan."""
+
+    def __init__(self, empty_data, *args, **kwargs):
+        super().__init__(self.__class__.__name__, empty_data, *args, **kwargs)
+
+
+class Expression(LazyPlan):
+    """Base class for all expressions in the Bodo query plan,
+    such as column references, function calls, and arithmetic operations.
+    """
+
+    def __init__(self, empty_data, *args, **kwargs):
+        super().__init__(self.__class__.__name__, empty_data, *args, **kwargs)
+
+
+class LogicalProjection(LogicalOperator):
+    """Logical operator for projecting columns and expressions."""
+
+    pass
+
+
+class LogicalFilter(LogicalOperator):
+    """Logical operator for filtering rows based on conditions."""
+
+    pass
+
+
+class LogicalAggregate(LogicalOperator):
+    """Logical operator for aggregation operations."""
+
+    pass
+
+
+class LogicalComparisonJoin(LogicalOperator):
+    """Logical operator for comparison-based joins."""
+
+    pass
+
+
+class LogicalSetOperation(LogicalOperator):
+    """Logical operator for set operations like union."""
+
+    pass
+
+
+class LogicalLimit(LogicalOperator):
+    """Logical operator for limiting the number of rows (e.g. df.head())."""
+
+    pass
+
+
+class LogicalOrder(LogicalOperator):
+    """Logical operator for sorting data."""
+
+    pass
+
+
+class LogicalGetParquetRead(LogicalOperator):
+    """Logical operator for reading Parquet files."""
+
+    pass
+
+
+class LogicalGetPandasReadSeq(LogicalOperator):
+    """Logical operator for sequential read of a Pandas DataFrame."""
+
+    pass
+
+
+class LogicalGetPandasReadParallel(LogicalOperator):
+    """Logical operator for parallel read of a Pandas DataFrame.\
+    """
+
+    pass
+
+
+class LogicalGetIcebergRead(LogicalOperator):
+    """Logical operator for reading Apache Iceberg tables."""
+
+    pass
+
+
+class LogicalParquetWrite(LogicalOperator):
+    """Logical operator for writing data to Parquet files."""
+
+    pass
+
+
+class LogicalIcebergWrite(LogicalOperator):
+    """Logical operator for writing data to Apache Iceberg tables."""
+
+    pass
+
+
 def execute_plan(plan: LazyPlan):
     """Execute a dataframe plan using Bodo's execution engine.
 
@@ -356,8 +451,7 @@ def count_plan(self):
     # Can't be known statically so create count plan on top of
     # existing plan.
     count_star_schema = pd.Series(dtype="uint64", name="count_star")
-    aggregate_plan = LazyPlan(
-        "LogicalAggregate",
+    aggregate_plan = LogicalAggregate(
         count_star_schema,
         self._plan,
         [],
@@ -374,8 +468,7 @@ def count_plan(self):
             )
         ],
     )
-    projection_plan = LazyPlan(
-        "LogicalProjection",
+    projection_plan = LogicalProjection(
         count_star_schema,
         aggregate_plan,
         make_col_ref_exprs([0], aggregate_plan),
@@ -411,8 +504,7 @@ def _get_df_python_func_plan(df_plan, empty_data, func, args, kwargs, is_method=
             df_plan,
         )
     )
-    plan = LazyPlan(
-        "LogicalProjection",
+    plan = LogicalProjection(
         empty_data,
         df_plan,
         (udf_arg,) + index_col_refs,

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -258,6 +258,32 @@ class PythonScalarFuncExpression(Expression):
     pass
 
 
+class ComparisonOpExpression(Expression):
+    """Expression representing a comparison operation in the query plan."""
+
+    pass
+
+
+class ConjunctionOpExpression(Expression):
+    """Expression representing a conjunction (AND) operation in the query plan."""
+
+    pass
+
+
+class UnaryOpExpression(Expression):
+    """Expression representing a unary operation (e.g. negation) in the query plan."""
+
+    pass
+
+
+class ArithOpExpression(Expression):
+    """Expression representing an arithmetic operation (e.g. addition, subtraction)
+    in the query plan.
+    """
+
+    pass
+
+
 def execute_plan(plan: LazyPlan):
     """Execute a dataframe plan using Bodo's execution engine.
 
@@ -424,7 +450,7 @@ def make_col_ref_exprs(key_indices, src_plan):
         # Using Arrow schema instead of zero_size_self.iloc to handle Index
         # columns correctly.
         empty_data = arrow_to_empty_df(pa.schema([src_plan.pa_schema[k]]))
-        p = LazyPlan("ColRefExpression", empty_data, src_plan, k)
+        p = ColRefExpression(empty_data, src_plan, k)
         exprs.append(p)
 
     return exprs
@@ -486,8 +512,7 @@ def count_plan(self):
         self._plan,
         [],
         [
-            LazyPlan(
-                "AggregateExpression",
+            AggregateExpression(
                 count_star_schema,
                 self._plan,
                 "count_star",
@@ -513,8 +538,7 @@ def _get_df_python_func_plan(df_plan, empty_data, func, args, kwargs, is_method=
     PythonScalarFuncExpression with provided arguments and a LogicalProjection.
     """
     df_len = len(df_plan.empty_data.columns)
-    udf_arg = LazyPlan(
-        "PythonScalarFuncExpression",
+    udf_arg = PythonScalarFuncExpression(
         empty_data,
         df_plan,
         (

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -504,18 +504,6 @@ cdef class LogicalOrder(LogicalOperator):
         return self.sources[0].getCardinality()
 
 
-cdef class LogicalColRef(LogicalOperator):
-    cdef readonly vector[int] select_vec
-
-    def __cinit__(self, object out_schema, LogicalOperator source, select_idxs):
-        self.out_schema = out_schema
-        self.select_vec = select_idxs
-        self.sources = [source]
-
-    def __str__(self):
-        return f"LogicalColRef({self.select_vec}, {self.out_schema})"
-
-
 cpdef get_pushed_down_columns(proj):
     """Get column indices that are pushed down from projection to its source node. Used for testing.
     """

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -23,12 +23,23 @@ from bodo.pandas.lazy_metadata import LazyMetadata
 from bodo.pandas.lazy_wrapper import BodoLazyWrapper, ExecState
 from bodo.pandas.managers import LazyMetadataMixin, LazySingleBlockManager
 from bodo.pandas.plan import (
+    AggregateExpression,
+    ArithOpExpression,
+    ColRefExpression,
+    ComparisonOpExpression,
+    ConjunctionOpExpression,
     LazyPlan,
     LazyPlanDistributedArg,
     LogicalAggregate,
     LogicalFilter,
+    LogicalGetPandasReadParallel,
+    LogicalGetPandasReadSeq,
     LogicalLimit,
+    LogicalOperator,
+    LogicalOrder,
     LogicalProjection,
+    PythonScalarFuncExpression,
+    UnaryOpExpression,
     _get_df_python_func_plan,
     execute_plan,
     get_proj_expr_single,
@@ -102,15 +113,13 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 empty_data = _empty_like(self)
                 if bodo.dataframe_library_run_parallel:
                     nrows = len(self)
-                    self._source_plan = LazyPlan(
-                        "LogicalGetPandasReadParallel",
+                    self._source_plan = LogicalGetPandasReadParallel(
                         empty_data,
                         nrows,
                         LazyPlanDistributedArg(self),
                     )
                 else:
-                    self._source_plan = LazyPlan(
-                        "LogicalGetPandasReadSeq",
+                    self._source_plan = LogicalGetPandasReadSeq(
                         empty_data,
                         self,
                     )
@@ -164,8 +173,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan(
-            "ComparisonOpExpression",
+        expr = ComparisonOpExpression(
             empty_data,
             lhs,
             rhs,
@@ -217,8 +225,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
-        expr = LazyPlan(
-            "ConjunctionOpExpression",
+        expr = ConjunctionOpExpression(
             empty_data,
             lhs,
             rhs,
@@ -265,8 +272,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         assert isinstance(empty_data, pd.Series), "Series expected"
         source_expr = get_proj_expr_single(self._plan)
-        expr = LazyPlan(
-            "UnaryOpExpression",
+        expr = UnaryOpExpression(
             empty_data,
             source_expr,
             "__invert__",
@@ -320,7 +326,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         if reverse:
             lhs, rhs = rhs, lhs
 
-        expr = LazyPlan("ArithOpExpression", empty_data, lhs, rhs, op)
+        expr = ArithOpExpression(empty_data, lhs, rhs, op)
 
         key_indices = [i + 1 for i in range(get_n_index_arrays(empty_data.index))]
         plan_keys = get_single_proj_source_if_present(self._plan)
@@ -426,7 +432,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         lazy_metadata: LazyMetadata,
         collect_func: Callable[[str], pt.Any] | None = None,
         del_func: Callable[[str], None] | None = None,
-        plan: plan_optimizer.LogicalOperator | None = None,
+        plan: LogicalOperator | None = None,
     ) -> BodoSeries:
         """
         Create a BodoSeries from a lazy metadata object.
@@ -609,8 +615,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         zero_size_self = _empty_like(self)
 
         return wrap_plan(
-            plan=LazyPlan(
-                "LogicalOrder",
+            plan=LogicalOrder(
                 zero_size_self,
                 self._plan,
                 ascending,
@@ -1257,8 +1262,7 @@ def _compute_series_reduce(bodo_series: BodoSeries, func_names: list[str]):
     zero_size_self = arrow_to_empty_df(new_arrow_schema)
 
     exprs = [
-        LazyPlan(
-            "AggregateExpression",
+        AggregateExpression(
             zero_size_self,
             bodo_series._plan,
             func_name,
@@ -1426,18 +1430,17 @@ def make_expr(expr, plan, first, schema, index_cols, side="right"):
     if expr is None:
         idx = 1 if side == "right" else 0
         empty_data = arrow_to_empty_df(pa.schema([schema[idx]]))
-        return LazyPlan("ColRefExpression", empty_data, plan, (idx))
+        return ColRefExpression(empty_data, plan, (idx))
     elif is_col_ref(expr):
         idx = expr.args[1]
         idx = get_new_idx(idx, first, side)
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
-        return LazyPlan("ColRefExpression", empty_data, plan, (idx))
+        return ColRefExpression(empty_data, plan, (idx))
     elif is_scalar_func(expr):
         idx = expr.args[2][0]
         idx = get_new_idx(idx, first, side)
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
-        return LazyPlan(
-            "PythonScalarFuncExpression",
+        return PythonScalarFuncExpression(
             empty_data,
             plan,
             expr.args[1],
@@ -1533,8 +1536,7 @@ def get_col_as_series_expr(idx, empty_data, series_out, index_cols):
     Extracts indexed column values from list series and
     returns resulting scalar expression.
     """
-    return LazyPlan(
-        "PythonScalarFuncExpression",
+    return PythonScalarFuncExpression(
         empty_data,
         series_out._plan,
         (
@@ -1567,8 +1569,7 @@ def _get_series_python_func_plan(
     index_cols = range(
         n_cols, n_cols + get_n_index_arrays(source_data.empty_data.index)
     )
-    expr = LazyPlan(
-        "PythonScalarFuncExpression",
+    expr = PythonScalarFuncExpression(
         empty_data,
         source_data,
         (

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -25,6 +25,10 @@ from bodo.pandas.managers import LazyMetadataMixin, LazySingleBlockManager
 from bodo.pandas.plan import (
     LazyPlan,
     LazyPlanDistributedArg,
+    LogicalAggregate,
+    LogicalFilter,
+    LogicalLimit,
+    LogicalProjection,
     _get_df_python_func_plan,
     execute_plan,
     get_proj_expr_single,
@@ -172,8 +176,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         plan_keys = get_single_proj_source_if_present(self._plan)
         key_exprs = tuple(make_col_ref_exprs(key_indices, plan_keys))
 
-        plan = LazyPlan(
-            "LogicalProjection",
+        plan = LogicalProjection(
             empty_data,
             # Use the original table without the Series projection node.
             self._plan.args[0],
@@ -226,8 +229,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         plan_keys = get_single_proj_source_if_present(self._plan)
         key_exprs = tuple(make_col_ref_exprs(key_indices, plan_keys))
 
-        plan = LazyPlan(
-            "LogicalProjection",
+        plan = LogicalProjection(
             empty_data,
             # Use the original table without the Series projection node.
             self._plan.args[0],
@@ -274,8 +276,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         plan_keys = get_single_proj_source_if_present(self._plan)
         key_exprs = tuple(make_col_ref_exprs(key_indices, plan_keys))
 
-        plan = LazyPlan(
-            "LogicalProjection",
+        plan = LogicalProjection(
             empty_data,
             # Use the original table without the Series projection node.
             self._plan.args[0],
@@ -325,8 +326,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         plan_keys = get_single_proj_source_if_present(self._plan)
         key_exprs = tuple(make_col_ref_exprs(key_indices, plan_keys))
 
-        plan = LazyPlan(
-            "LogicalProjection",
+        plan = LogicalProjection(
             empty_data,
             # Use the original table without the Series projection node.
             self._plan.args[0],
@@ -403,7 +403,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             # Drop the explicit integer Index generated from filtering RangeIndex (TODO: support RangeIndex properly).
             empty_data.reset_index(drop=True, inplace=True)
         return wrap_plan(
-            plan=LazyPlan("LogicalFilter", empty_data, self._plan, key_plan),
+            plan=LogicalFilter(empty_data, self._plan, key_plan),
         )
 
     @staticmethod
@@ -498,8 +498,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             ):
                 from bodo.pandas.base import _empty_like
 
-                planLimit = LazyPlan(
-                    "LogicalLimit",
+                planLimit = LogicalLimit(
                     _empty_like(self),
                     self._plan,
                     n,
@@ -955,8 +954,7 @@ class BodoStringMethods:
         )
 
         # Creates DataFrame with n_cols columns
-        df_plan = LazyPlan(
-            "LogicalProjection",
+        df_plan = LogicalProjection(
             empty_data,
             series_out._plan,
             expr + index_col_refs,
@@ -1049,8 +1047,7 @@ class BodoDatetimeProperties:
         assert series_out.is_lazy_plan()
 
         # Creates DataFrame with 3 columns
-        df_plan = LazyPlan(
-            "LogicalProjection",
+        df_plan = LogicalProjection(
             empty_data,
             series_out._plan,
             expr + index_col_refs,
@@ -1110,8 +1107,7 @@ class BodoDatetimeProperties:
         assert series_out.is_lazy_plan()
 
         # Creates DataFrame with 3 columns
-        df_plan = LazyPlan(
-            "LogicalProjection",
+        df_plan = LogicalProjection(
             empty_data,
             series_out._plan,
             expr + index_col_refs,
@@ -1272,8 +1268,7 @@ def _compute_series_reduce(bodo_series: BodoSeries, func_names: list[str]):
         for func_name in func_names
     ]
 
-    plan = LazyPlan(
-        "LogicalAggregate",
+    plan = LogicalAggregate(
         zero_size_self,
         bodo_series._plan,
         [],
@@ -1515,8 +1510,7 @@ def zip_series_plan(lhs, rhs) -> BodoSeries:
         empty_data = pd.concat([left_empty_data, right_empty_data])
         empty_data.index = index
 
-        result = LazyPlan(
-            "LogicalProjection",
+        result = LogicalProjection(
             empty_data,
             result,
             (
@@ -1589,8 +1583,7 @@ def _get_series_python_func_plan(
     # Select Index columns explicitly for output
     index_col_refs = tuple(make_col_ref_exprs(index_cols, source_data))
     return wrap_plan(
-        plan=LazyPlan(
-            "LogicalProjection",
+        plan=LogicalProjection(
             empty_data,
             source_data,
             (expr,) + index_col_refs,
@@ -1674,8 +1667,7 @@ def _split_internal(self, name, pat, n, expand, regex=None):
     )
 
     # Creates DataFrame with n_cols columns
-    df_plan = LazyPlan(
-        "LogicalProjection",
+    df_plan = LogicalProjection(
         empty_data,
         series_out._plan,
         expr + index_col_refs,
@@ -1734,8 +1726,7 @@ def gen_partition(name):
         assert series_out.is_lazy_plan()
 
         # Creates DataFrame with 3 columns
-        df_plan = LazyPlan(
-            "LogicalProjection",
+        df_plan = LogicalProjection(
             empty_data,
             series_out._plan,
             expr + index_col_refs,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -10,6 +10,7 @@ import pytest
 
 import bodo
 import bodo.pandas as bd
+from bodo.pandas.plan import LogicalGetPandasReadParallel, LogicalGetPandasReadSeq
 from bodo.pandas.utils import BodoLibFallbackWarning
 from bodo.tests.utils import _test_equal, pytest_mark_spawn_mode, temp_config_override
 
@@ -46,7 +47,7 @@ def test_from_pandas(datapath, index_val):
     with temp_config_override("dataframe_library_run_parallel", False):
         bdf = bd.from_pandas(df)
         assert bdf.is_lazy_plan()
-        assert bdf._mgr._plan.plan_class == "LogicalGetPandasReadSeq"
+        assert isinstance(bdf._mgr._plan, LogicalGetPandasReadSeq)
         duckdb_plan = bdf._mgr._plan.generate_duckdb()
         _test_equal(duckdb_plan.df, df)
         _test_equal(
@@ -59,7 +60,7 @@ def test_from_pandas(datapath, index_val):
     # Parallel test
     bdf = bd.from_pandas(df)
     assert bdf.is_lazy_plan()
-    assert bdf._mgr._plan.plan_class == "LogicalGetPandasReadParallel"
+    assert isinstance(bdf._mgr._plan, LogicalGetPandasReadParallel)
     _test_equal(
         bdf,
         df,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Uses proper Python classes instead of generic LazyPlan for creating plans. Also fixes a few issues I found in the process. Limiting the scope for now and will continue in follow up PRs.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Some bug fixes including Iceberg write.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.