### PR TITLE
Fix DateTimeProperties validation

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -987,7 +987,7 @@ class BodoDatetimeProperties:
     def __init__(self, series):
         allowed_types = allowed_types_map["dt_default"]
         # Validates series type
-        if not (isinstance(series, BodoSeries) and series.dtype in allowed_types,):
+        if not (isinstance(series, BodoSeries) and series.dtype in allowed_types):
             raise AttributeError("Can only use .dt accessor with datetimelike values")
         self._series = series
         self._dtype = series.dtype


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fix typo in DateTimeProperties constructor's validation logic.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
N/A

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.