### PR TITLE
Fix df setitem for common Series.str.cat cases

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -1266,7 +1266,9 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
 
 
 def _update_func_expr_source(
-    func_expr: LazyPlan, new_source_plan: LazyPlan, col_index_offset: int
+    func_expr: PythonScalarFuncExpression,
+    new_source_plan: LazyPlan,
+    col_index_offset: int,
 ):
     """Update source plan of PythonScalarFuncExpression and add an offset to its
     input data column index.

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -255,7 +255,10 @@ class LogicalIcebergWrite(LogicalOperator):
 class ColRefExpression(Expression):
     """Expression representing a column reference in the query plan."""
 
-    pass
+    def __init__(self, empty_data, source, col_index):
+        self.source = source
+        self.col_index = col_index
+        super().__init__(empty_data, source, col_index)
 
 
 class NullExpression(Expression):

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1441,12 +1441,12 @@ def make_expr(expr, plan, first, schema, index_cols, side="right"):
     if expr is None:
         idx = 1 if side == "right" else 0
         empty_data = arrow_to_empty_df(pa.schema([schema[idx]]))
-        return ColRefExpression(empty_data, plan, (idx))
+        return ColRefExpression(empty_data, plan, idx)
     elif is_col_ref(expr):
         idx = expr.args[1]
         idx = get_new_idx(idx, first, side)
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
-        return ColRefExpression(empty_data, plan, (idx))
+        return ColRefExpression(empty_data, plan, idx)
     elif is_scalar_func(expr):
         idx = expr.args[2][0]
         idx = get_new_idx(idx, first, side)
@@ -1493,7 +1493,7 @@ def zip_series_plan(lhs, rhs) -> BodoSeries:
         and isinstance(lhs_list[1].exprs[0], ColRefExpression)
         and isinstance(rhs_list[1].exprs[0], ColRefExpression)
     ):
-        arg_inds = (lhs_list[1].exprs[0].args[1], rhs_list[1].exprs[0].args[1])
+        arg_inds = (lhs_list[1].exprs[0].col_index, rhs_list[1].exprs[0].col_index)
         return result, arg_inds
 
     # Pads shorter list with None values.

--- a/bodo/tests/test_df_lib/test_series_str_cat.py
+++ b/bodo/tests/test_df_lib/test_series_str_cat.py
@@ -131,9 +131,6 @@ def test_str_cat_fallback_not_bodo_series(fallback_df):
         _ = bdf["A"].str.cat(others=fallback_df["B"])
 
 
-@pytest.mark.skip(
-    reason="TODO: fix failure in this case: df['C'] = df.A.str.cat(others=df.B) "
-)
 def test_assignment_str_cat_lazy_plan():
     pdf = pd.DataFrame(
         {
@@ -143,11 +140,9 @@ def test_assignment_str_cat_lazy_plan():
     )
     bdf = bd.from_pandas(pdf)
 
-    bdf = bdf.A.str.cat(others=bdf.B)
+    bdf["C"] = bdf.A.str.cat(others=bdf.B)
     assert bdf.is_lazy_plan()
 
-    bdf["C"] = bdf
     pdf["C"] = pdf["A"].str.cat(others=pdf["B"])
 
-    assert bdf.is_lazy_plan()
     _test_equal(bdf.execute_plan(), pdf, check_pandas_types=False, check_names=False)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes setting a dataframe column with str.cat on two of the dataframe's columns (e.g. `df["C"] = df.A.str.cat(others=df.B)`) which is the common case. Just avoids extra projection generation in this case so existing setitem functionality works.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Output of str.cat can be set to the dataframe.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.