### PR TITLE
Fix df column setitem for functions inside arithmatic expressions

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -51,7 +51,6 @@ from bodo.pandas.plan import (
     LogicalOrder,
     LogicalParquetWrite,
     LogicalProjection,
-    PythonScalarFuncExpression,
     _get_df_python_func_plan,
     execute_plan,
     get_proj_expr_single,
@@ -1265,33 +1264,6 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             self._mgr._disable_collect = original_flag
 
 
-def _update_func_expr_source(
-    func_expr: PythonScalarFuncExpression,
-    new_source_plan: LazyPlan,
-    col_index_offset: int,
-):
-    """Update source plan of PythonScalarFuncExpression and add an offset to its
-    input data column index.
-    """
-    # Previous input data column index
-    in_col_ind = func_expr.args[2][0]
-    n_source_cols = len(new_source_plan.empty_data.columns)
-    # Add Index columns of the new source plan as input
-    index_cols = tuple(
-        range(
-            n_source_cols,
-            n_source_cols + get_n_index_arrays(new_source_plan.empty_data.index),
-        )
-    )
-    expr = PythonScalarFuncExpression(
-        func_expr.empty_data,
-        new_source_plan,
-        func_expr.args[1],
-        (in_col_ind + col_index_offset,) + index_cols,
-    )
-    return expr
-
-
 def _add_proj_expr_to_plan(
     df_plan: LazyPlan, value_plan: LazyPlan, key: str, replace_func_source=False
 ):
@@ -1312,8 +1284,8 @@ def _add_proj_expr_to_plan(
     # Get the function expression from the value plan to be added
     func_expr = get_proj_expr_single(value_plan)
 
-    if isinstance(func_expr, PythonScalarFuncExpression) and replace_func_source:
-        func_expr = _update_func_expr_source(func_expr, df_plan, ikey)
+    if replace_func_source:
+        func_expr = func_expr.update_func_expr_source(df_plan, ikey)
 
     # Update output column name
     func_expr = func_expr.replace_empty_data(

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -301,10 +301,10 @@ class PythonScalarFuncExpression(Expression):
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
         """Update the source and column index of the function expression."""
         if self.args[0] != new_source_plan:
-            # Previous input data column index
             assert len(self.args[2]) == 1 + get_n_index_arrays(self.empty_data.index), (
                 "PythonScalarFuncExpression::update_func_expr_source: expected single input column"
             )
+            # Previous input data column index
             in_col_ind = self.args[2][0]
             n_source_cols = len(new_source_plan.empty_data.columns)
             # Add Index columns of the new source plan as input

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -144,6 +144,22 @@ class Expression(LazyPlan):
     def __init__(self, empty_data, *args):
         super().__init__(self.__class__.__name__, empty_data, *args)
 
+    def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
+        """Update the source and column index of function expressions, which could be
+        nested inside this expression."""
+        new_args = [
+            arg.update_func_expr_source(new_source_plan, col_index_offset)
+            if isinstance(arg, Expression)
+            else arg
+            for arg in self.args
+        ]
+        out = self.__class__(
+            self.empty_data,
+            *new_args,
+        )
+        out.is_series = self.is_series
+        return out
+
 
 class LogicalProjection(LogicalOperator):
     """Logical operator for projecting columns and expressions."""
@@ -282,7 +298,32 @@ class AggregateExpression(Expression):
 class PythonScalarFuncExpression(Expression):
     """Expression representing a Python scalar function call in the query plan."""
 
-    pass
+    def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
+        """Update the source and column index of the function expression."""
+        if self.args[0] != new_source_plan:
+            # Previous input data column index
+            assert len(self.args[2]) == 1 + get_n_index_arrays(self.empty_data.index), (
+                "PythonScalarFuncExpression::update_func_expr_source: expected single input column"
+            )
+            in_col_ind = self.args[2][0]
+            n_source_cols = len(new_source_plan.empty_data.columns)
+            # Add Index columns of the new source plan as input
+            index_cols = tuple(
+                range(
+                    n_source_cols,
+                    n_source_cols
+                    + get_n_index_arrays(new_source_plan.empty_data.index),
+                )
+            )
+            expr = PythonScalarFuncExpression(
+                self.empty_data,
+                new_source_plan,
+                self.args[1],
+                (in_col_ind + col_index_offset,) + index_cols,
+            )
+            expr.is_series = self.is_series
+            return expr
+        return self
 
 
 class ComparisonOpExpression(Expression):

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -844,6 +844,35 @@ def test_set_df_column_const(datapath, index_val):
     _test_equal(bdf, pdf, check_pandas_types=False)
 
 
+def test_set_df_column_func_nested_arith(datapath, index_val):
+    """Test setting a dataframe column with nested functions inside an arithmetic operation."""
+    df = pd.DataFrame(
+        {
+            "A": [1.4, 2.1, 3.3],
+            "B": ["A1", "B23", "C345"],
+            "C": [1.1, 2.2, 3.3],
+            "D": [True, False, True],
+        }
+    )
+    df.index = index_val[: len(df)]
+
+    # New column
+    bdf = bd.from_pandas(df)
+    bdf["E"] = bdf.B.str.lower().str.len() + 1
+    assert bdf.is_lazy_plan()
+    pdf = df.copy()
+    pdf["E"] = pdf.B.str.lower().str.len() + 1
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+    # Existing column
+    bdf = bd.from_pandas(df)
+    bdf["B"] = bdf.B.str.lower().str.len() + 1
+    assert bdf.is_lazy_plan()
+    pdf = df.copy()
+    pdf["B"] = pdf.B.str.lower().str.len() + 1
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+
 def test_set_df_column_arith(datapath, index_val):
     """Test setting a dataframe column with a Series function of the same dataframe."""
     df = pd.DataFrame(


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes cases like: `bdf["E"] = bdf.B.str.lower().str.len() + 1`

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.