### PR TITLE
Fix df column setitem with extra projection column order

### DIFF
--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -933,60 +933,60 @@ def test_set_df_column_extra_proj(datapath, index_val):
 
     # Single projection, new column
     bdf = bd.from_pandas(df)
-    bdf2 = bdf[["B", "C"]]
+    bdf2 = bdf[["C", "B"]]
     bdf2["D"] = bdf["A"] + bdf["C"]
     pdf = df.copy()
-    pdf2 = pdf[["B", "C"]]
+    pdf2 = pdf[["C", "B"]]
     pdf2["D"] = pdf["A"] + pdf["C"]
     assert bdf2.is_lazy_plan()
     _test_equal(bdf2, pdf2, check_pandas_types=False)
 
     # Multiple projections, new column
     bdf = bd.from_pandas(df)
-    bdf2 = bdf[["B", "C"]]
+    bdf2 = bdf[["C", "B"]]
     bdf2["D"] = bdf["B"].str.strip().str.lower()
     pdf = df.copy()
-    pdf2 = pdf[["B", "C"]]
+    pdf2 = pdf[["C", "B"]]
     pdf2["D"] = pdf["B"].str.strip().str.lower()
     assert bdf2.is_lazy_plan()
     _test_equal(bdf2, pdf2, check_pandas_types=False)
 
     # Single projection, existing column in source dataframe
     bdf = bd.from_pandas(df)
-    bdf2 = bdf[["B", "C"]]
+    bdf2 = bdf[["C", "B"]]
     bdf2["A"] = bdf["A"] + bdf["C"]
     pdf = df.copy()
-    pdf2 = pdf[["B", "C"]]
+    pdf2 = pdf[["C", "B"]]
     pdf2["A"] = pdf["A"] + pdf["C"]
     assert bdf2.is_lazy_plan()
     _test_equal(bdf2, pdf2, check_pandas_types=False)
 
     # Multiple projections, existing column in source dataframe
     bdf = bd.from_pandas(df)
-    bdf2 = bdf[["B", "C"]]
+    bdf2 = bdf[["C", "B"]]
     bdf2["A"] = bdf["B"].str.strip().str.lower()
     pdf = df.copy()
-    pdf2 = pdf[["B", "C"]]
+    pdf2 = pdf[["C", "B"]]
     pdf2["A"] = pdf["B"].str.strip().str.lower()
     assert bdf2.is_lazy_plan()
     _test_equal(bdf2, pdf2, check_pandas_types=False)
 
     # Single projection, existing column in projected dataframe
     bdf = bd.from_pandas(df)
-    bdf2 = bdf[["B", "C"]]
+    bdf2 = bdf[["C", "B"]]
     bdf2["B"] = bdf["A"] + bdf["C"]
     pdf = df.copy()
-    pdf2 = pdf[["B", "C"]]
+    pdf2 = pdf[["C", "B"]]
     pdf2["B"] = pdf["A"] + pdf["C"]
     assert bdf2.is_lazy_plan()
     _test_equal(bdf2, pdf2, check_pandas_types=False)
 
     # Multiple projections, existing column in projected dataframe
     bdf = bd.from_pandas(df)
-    bdf2 = bdf[["B", "C"]]
+    bdf2 = bdf[["C", "B"]]
     bdf2["B"] = bdf["B"].str.strip().str.lower()
     pdf = df.copy()
-    pdf2 = pdf[["B", "C"]]
+    pdf2 = pdf[["C", "B"]]
     pdf2["B"] = pdf["B"].str.strip().str.lower()
     assert bdf2.is_lazy_plan()
     _test_equal(bdf2, pdf2, check_pandas_types=False)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Makes sure proper column order is generated for df column setitem with extra projection. Fixes an issue in TPC-H Q8.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Updated unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.