### PR TITLE
Handle reductions with empty batches.

### DIFF
--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -50,6 +50,14 @@ class DataFrameGroupBy:
         self._dropna = dropna
         self._selection = selection
 
+    @property
+    def selection_for_plan(self):
+        return (
+            self._selection
+            if self._selection is not None
+            else list(filter(lambda col: col not in self._keys, self._obj.columns))
+        )
+
     def __getitem__(self, key) -> DataFrameGroupBy | SeriesGroupBy:
         """
         Return a DataFrameGroupBy or SeriesGroupBy for the selected data columns.
@@ -257,6 +265,14 @@ class SeriesGroupBy:
         self._as_index = as_index
         self._dropna = dropna
 
+    @property
+    def selection_for_plan(self):
+        return (
+            self._selection
+            if self._selection is not None
+            else list(filter(lambda col: col not in self._keys, self._obj.columns))
+        )
+
     @check_args_fallback(unsupported="none")
     def __getattribute__(self, name: str, /) -> Any:
         try:
@@ -397,11 +413,7 @@ def _groupby_agg_plan(
     """Compute groupby.func() on the Series or DataFrame GroupBy object."""
     from bodo.pandas.base import _empty_like
 
-    grouped_selection = (
-        grouped._selection
-        if grouped._selection is not None
-        else list(filter(lambda col: col not in grouped._keys, grouped._obj.columns))
-    )
+    grouped_selection = grouped.selection_for_plan
 
     zero_size_df = _empty_like(grouped._obj)
     empty_data_pandas = zero_size_df.groupby(grouped._keys, as_index=grouped._as_index)[

--- a/bodo/pandas/physical/project.h
+++ b/bodo/pandas/physical/project.h
@@ -94,6 +94,18 @@ class PhysicalProjection : public PhysicalSourceSink {
                 } else {
                     col_names.emplace_back("comp");
                 }
+            } else if (expr->type == duckdb::ExpressionType::CONJUNCTION_AND ||
+                       expr->type == duckdb::ExpressionType::CONJUNCTION_OR) {
+                std::unique_ptr<bodo::DataType> col_type =
+                    std::make_unique<bodo::DataType>(
+                        bodo_array_type::NULLABLE_INT_BOOL,
+                        Bodo_CTypes::CTypeEnum::_BOOL);
+                this->output_schema->append_column(std::move(col_type));
+                if (input_schema->column_names.size() > 0) {
+                    col_names.emplace_back(input_schema->column_names[0]);
+                } else {
+                    col_names.emplace_back("conjunction");
+                }
             } else {
                 throw std::runtime_error(
                     "Unsupported expression type in projection " +

--- a/bodo/pandas/physical/reduce.h
+++ b/bodo/pandas/physical/reduce.h
@@ -61,6 +61,15 @@ class PhysicalReduce : public PhysicalSource, public PhysicalSink {
             // Update reduction result
             if (iter == 0) {
                 output_scalars.push_back(out_scalar_batch);
+            } else if (!out_scalar_batch->is_valid) {
+                // If we get an empty batch which results in invalid
+                // arrow::Scalar result then just ignore it.
+                continue;
+            } else if (!output_scalars[i]->is_valid) {
+                // The last result can be null if there have been no rows
+                // seen thus far.  In which case, use the current result
+                // just on this batch as the result thus far.
+                output_scalars[i] = out_scalar_batch;
             } else {
                 arrow::Result<arrow::Datum> cmp_res_scalar =
                     arrow::compute::CallFunction(

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -332,7 +332,7 @@ def check_args_fallback(
                             self._keys,
                             as_index=self._as_index,
                             dropna=self._dropna,
-                        )[self._selection]
+                        )[self.selection_for_plan]
                         base_class = self.__class__
                     elif self.__class__ == bodo.pandas.series.BodoStringMethods:
                         base_class = self._series.__class__.__bases__[0].str


### PR DESCRIPTION
## Changes included in this PR

Fix for tpch q14.  If the reduction code sees an initial or subsequent batch with no rows then the arrow::Scalar generated for the reduction operation will be null and then null combined with anything afterward on subsequent batches will be null.  So, this PR basically ignores empty batches.

## Testing strategy

run_ci
tpch locally

## User facing changes

None

## Checklist
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.