### PR TITLE
Check and match filter and expression source plans

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -506,7 +506,7 @@ def concat(
                     if x in old_schema:
                         exprs.extend(make_col_ref_exprs([old_schema.index(x)], plan))
                     else:
-                        exprs.append(NullExpression(new_schema, field_idx))
+                        exprs.append(NullExpression(new_schema, plan, field_idx))
                 return exprs
 
             # Create a reordering of the temp a_new_cols so that the columns are in

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -963,22 +963,17 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 "only string and BodoSeries keys are supported"
             )
 
-        """ Create 0 length versions of the dataframe and the key and
-            simulate the operation to see the resulting type. """
+        # Create 0 length versions of the dataframe and the key and
+        # simulate the operation to see the resulting type.
         zero_size_self = _empty_like(self)
         if isinstance(key, BodoSeries):
-            """ This is a masking operation. """
-            key_plan = (
-                # TODO: error checking for key to be a projection on the same dataframe
-                # with a binary operator
-                get_proj_expr_single(key._plan)
-                if key._plan is not None
-                else plan_optimizer.LogicalGetSeriesRead(key._mgr._md_result_id)
-            )
+            # This is a masking operation.
+            # TODO: error checking for key to be a projection on the same dataframe
+            key_expr = get_proj_expr_single(key._plan)
             zero_size_key = _empty_like(key)
             empty_data = zero_size_self.__getitem__(zero_size_key)
             return wrap_plan(
-                plan=LogicalFilter(empty_data, self._plan, key_plan),
+                plan=LogicalFilter(empty_data, self._plan, key_expr),
             )
         else:
             """ This is selecting one or more columns. Be a bit more

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -1054,6 +1054,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             const_expr = ConstantExpression(
                 # Dummy empty data for LazyPlan
                 empty_data,
+                self._plan,
                 value,
             )
             proj_exprs = _get_setitem_proj_exprs(

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -160,6 +160,11 @@ class Expression(LazyPlan):
         out.is_series = self.is_series
         return out
 
+    def replace_source(self, new_source: LazyPlan):
+        """Replace the source of the expression with a new source plan."""
+        if self.source == new_source:
+            return self
+
 
 class LogicalProjection(LogicalOperator):
     """Logical operator for projecting columns and expressions."""
@@ -276,23 +281,96 @@ class ColRefExpression(Expression):
         self.col_index = col_index
         super().__init__(empty_data, source, col_index)
 
+    def replace_source(self, new_source: LazyPlan):
+        """Replace the source of the expression with a new source plan."""
+        if self.source == new_source:
+            return self
+
+        # If the new source is a projection on the same source, we can just update the
+        # column index
+        if (
+            isinstance(new_source, LogicalProjection)
+            and new_source.source == self.source
+        ):
+            for i, expr in enumerate(new_source.exprs):
+                if (
+                    isinstance(expr, ColRefExpression)
+                    and expr.col_index == self.col_index
+                ):
+                    # Found the same column in the new projection
+                    out = ColRefExpression(self.empty_data, new_source, i)
+                    out.is_series = self.is_series
+                    return out
+
+        # Cannot replace source, return None to indicate failure
+        return None
+
 
 class NullExpression(Expression):
     """Expression representing a null value in the query plan."""
 
-    pass
+    def __init__(self, empty_data, source, field_idx):
+        # Source is kept only for frontend plan checking and not passed to backend.
+        self.empty_data = empty_data
+        self.source = source
+        self.field_idx = field_idx
+        super().__init__(empty_data, field_idx)
+
+    def replace_source(self, new_source: LazyPlan):
+        """Replace the source of the expression with a new source plan."""
+        if self.source == new_source:
+            return self
+
+        # If the new source is a projection on the same source, we can just update the
+        # source
+        if (
+            isinstance(new_source, LogicalProjection)
+            and new_source.source == self.source
+        ):
+            out = NullExpression(self.empty_data, new_source, self.field_idx)
+            out.is_series = self.is_series
+            return out
+
+        # Cannot replace source, return None to indicate failure
+        return None
 
 
 class ConstantExpression(Expression):
     """Expression representing a constant value in the query plan."""
 
-    pass
+    def __init__(self, empty_data, source, value):
+        # Source is kept only for frontend plan checking and not passed to backend.
+        self.empty_data = empty_data
+        self.source = source
+        self.value = value
+        super().__init__(empty_data, value)
+
+    def replace_source(self, new_source: LazyPlan):
+        """Replace the source of the expression with a new source plan."""
+        if self.source == new_source:
+            return self
+
+        # If the new source is a projection on the same source, we can just update the
+        # source
+        if (
+            isinstance(new_source, LogicalProjection)
+            and new_source.source == self.source
+        ):
+            out = ConstantExpression(self.empty_data, new_source, self.value)
+            out.is_series = self.is_series
+            return out
+
+        # Cannot replace source, return None to indicate failure
+        return None
 
 
 class AggregateExpression(Expression):
     """Expression representing an aggregate function in the query plan."""
 
-    pass
+    def replace_source(self, new_source: LazyPlan):
+        # TODO: handle source replacement for aggregate expressions
+        if self.args[0] == new_source:
+            return self
 
 
 class PythonScalarFuncExpression(Expression):
@@ -325,14 +403,52 @@ class PythonScalarFuncExpression(Expression):
             return expr
         return self
 
+    def replace_source(self, new_source: LazyPlan):
+        # TODO: handle source replacement for PythonScalarFuncExpression
+        if self.args[0] == new_source:
+            return self
 
-class ComparisonOpExpression(Expression):
+
+class BinaryExpression(Expression):
+    """Base class for binary expressions in the query plan, such as arithmetic and
+    comparison operations.
+    """
+
+    def __init__(self, empty_data, lhs, rhs, op):
+        self.empty_data = empty_data
+        self.lhs = lhs
+        self.rhs = rhs
+        self.op = op
+        super().__init__(empty_data, lhs, rhs, op)
+
+    def replace_source(self, new_source: LazyPlan):
+        """Replace the source of the expression with a new source plan."""
+        new_lhs = (
+            self.lhs.replace_source(new_source)
+            if isinstance(self.lhs, Expression)
+            else self.lhs
+        )
+        new_rhs = (
+            self.rhs.replace_source(new_source)
+            if isinstance(self.rhs, Expression)
+            else self.rhs
+        )
+
+        if new_lhs is None or new_rhs is None:
+            return None
+
+        out = self.__class__(self.empty_data, new_lhs, new_rhs, self.op)
+        out.is_series = self.is_series
+        return out
+
+
+class ComparisonOpExpression(BinaryExpression):
     """Expression representing a comparison operation in the query plan."""
 
     pass
 
 
-class ConjunctionOpExpression(Expression):
+class ConjunctionOpExpression(BinaryExpression):
     """Expression representing a conjunction (AND) operation in the query plan."""
 
     pass
@@ -341,10 +457,24 @@ class ConjunctionOpExpression(Expression):
 class UnaryOpExpression(Expression):
     """Expression representing a unary operation (e.g. negation) in the query plan."""
 
-    pass
+    def __init__(self, empty_data, source_expr, op):
+        self.empty_data = empty_data
+        self.source_expr = source_expr
+        self.op = op
+        super().__init__(empty_data, source_expr, op)
+
+    def replace_source(self, new_source: LazyPlan):
+        """Replace the source of the expression with a new source plan."""
+        new_source_expr = self.source_expr.replace_source(new_source)
+        if new_source_expr is None:
+            return None
+
+        out = UnaryOpExpression(self.empty_data, new_source_expr, self.op)
+        out.is_series = self.is_series
+        return out
 
 
-class ArithOpExpression(Expression):
+class ArithOpExpression(BinaryExpression):
     """Expression representing an arithmetic operation (e.g. addition, subtraction)
     in the query plan.
     """
@@ -652,3 +782,22 @@ def is_scalar_func(expr):
 
 def is_arith_expr(expr):
     return isinstance(expr, ArithOpExpression)
+
+
+def match_binop_expr_source_plans(lhs, rhs):
+    """Match the source plans of two binary expressions if possible.
+    Returns (None, None) if sources cannot be matched.
+    """
+    if not (isinstance(lhs, Expression) and isinstance(rhs, Expression)):
+        # No matching necessary
+        return lhs, rhs
+
+    new_lhs = lhs.replace_source(rhs.source)
+    if new_lhs is not None:
+        return new_lhs, rhs
+
+    new_rhs = rhs.replace_source(lhs.source)
+    if new_rhs is not None:
+        return lhs, new_rhs
+
+    return None, None

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -449,7 +449,9 @@ class BinaryExpression(Expression):
             else self.rhs
         )
 
-        if new_lhs is None or new_rhs is None:
+        if (new_lhs is None and self.lhs is not None) or (
+            new_rhs is None and self.rhs is not None
+        ):
             return None
 
         out = self.__class__(self.empty_data, new_lhs, new_rhs, self.op)

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -483,12 +483,8 @@ def getPlanStatistics(plan: LazyPlan):
 
 def get_proj_expr_single(proj: LazyPlan):
     """Get the single expression from a LogicalProjection node."""
-    if is_single_projection(proj):
-        return proj.exprs[0]
-    else:
-        if not proj.is_series:
-            raise Exception("Got a non-Series in get_proj_expr_single")
-        return make_col_ref_exprs([0], proj)[0]
+    assert is_single_projection(proj), "Expected single projection"
+    return proj.exprs[0]
 
 
 def get_single_proj_source_if_present(proj: LazyPlan):
@@ -541,7 +537,7 @@ class LazyPlanDistributedArg:
     Class to hold the arguments for a LazyPlan that are distributed on the workers.
     """
 
-    def __init__(self, df: pd.DataFrame):
+    def __init__(self, df: pd.DataFrame | pd.Series):
         self.df = df
         self.mgr = None
         self.res_id = None

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -50,6 +50,7 @@ from bodo.pandas.plan import (
     is_single_colref_projection,
     is_single_projection,
     make_col_ref_exprs,
+    match_binop_expr_source_plans,
 )
 from bodo.pandas.utils import (
     BodoLibFallbackWarning,
@@ -336,6 +337,12 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
+        lhs, rhs = match_binop_expr_source_plans(lhs, rhs)
+        if lhs is None and rhs is None:
+            raise BodoLibNotImplementedException(
+                "binary operation arguments should have the same dataframe source."
+            )
+
         if reverse:
             lhs, rhs = rhs, lhs
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -187,6 +187,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
+        lhs, rhs = match_binop_expr_source_plans(lhs, rhs)
+        if lhs is None and rhs is None:
+            raise BodoLibNotImplementedException(
+                "binary operation arguments should have the same dataframe source."
+            )
         expr = ComparisonOpExpression(
             empty_data,
             lhs,
@@ -239,6 +244,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # Extract argument expressions
         lhs = get_proj_expr_single(self._plan)
         rhs = get_proj_expr_single(other) if isinstance(other, LazyPlan) else other
+        lhs, rhs = match_binop_expr_source_plans(lhs, rhs)
+        if lhs is None and rhs is None:
+            raise BodoLibNotImplementedException(
+                "binary operation arguments should have the same dataframe source."
+            )
         expr = ConjunctionOpExpression(
             empty_data,
             lhs,

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -129,7 +129,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                 # Make sure Series plans are always single expr projections for easier
                 # matching later.
                 self._source_plan = LogicalProjection(
-                    empty_data.to_frame(),
+                    empty_data,
                     read_plan,
                     tuple(
                         make_col_ref_exprs(

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1791,6 +1791,39 @@ def test_series_filter_series(datapath, file_path, op, mode):
     )
 
 
+def test_filter_source_matching():
+    """Test for matching expression source dataframes in filter"""
+
+    df = pd.DataFrame(
+        {
+            "A": [1.4, 2.1, 3.3],
+            "B": ["A", "B", "C"],
+            "C": [1.1, 2.2, 3.3],
+            "D": [True, False, True],
+        }
+    )
+
+    # Match series source
+    bdf = bd.from_pandas(df)
+    bdf2 = bdf[["B", "C", "D"]]
+    bodo_out = bdf2[bdf.D]
+    df2 = df[["B", "C", "D"]].copy()
+    py_out = df2[df.D]
+    _test_equal(
+        bodo_out, py_out, check_pandas_types=False, sort_output=True, reset_index=True
+    )
+
+    # Match expression source
+    bdf = bd.from_pandas(df)
+    bdf2 = bdf[["B", "C", "D"]]
+    bodo_out = bdf2[(bdf.C > 2.0) & (bdf2.B != "B")]
+    df2 = df[["B", "C", "D"]].copy()
+    py_out = df2[(df.C > 2.0) & (df2.B != "B")]
+    _test_equal(
+        bodo_out, py_out, check_pandas_types=False, sort_output=True, reset_index=True
+    )
+
+
 def test_rename(datapath, index_val):
     """Very simple test for df.apply() for sanity checking."""
     df = pd.DataFrame(

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -2,16 +2,16 @@
 Tests dataframe library frontend (no triggering of execution).
 """
 
+import pandas as pd
 import pytest
 
-import bodo.pandas as pd
+import bodo.pandas as bd
 from bodo.pandas.utils import BodoLibFallbackWarning
 
 
-@pytest.mark.skip("disabled for release until merge is implemented")
 def test_read_join_filter_proj(datapath):
-    df1 = pd.read_parquet(datapath("dataframe_library/df1.parquet"))
-    df2 = pd.read_parquet(datapath("dataframe_library/df2.parquet"))
+    df1 = bd.read_parquet(datapath("dataframe_library/df1.parquet"))
+    df2 = bd.read_parquet(datapath("dataframe_library/df2.parquet"))
     df3 = df1.merge(df2, on="A")
     df3 = df3[df3.A > 3]
     df3[["B", "C"]]
@@ -25,7 +25,7 @@ def test_df_getitem_fallback_warning():
             "B": ["A1", "B1", "C1"],
         },
     )
-    bdf = pd.from_pandas(df)
+    bdf = bd.from_pandas(df)
     with pytest.warns(BodoLibFallbackWarning):
         bdf[:]
 
@@ -37,7 +37,7 @@ def test_df_setitem_fallback_warning():
             "A": pd.array([1, 2, 3], "Int64"),
         },
     )
-    bdf = pd.from_pandas(df)
+    bdf = bd.from_pandas(df)
     with pytest.warns(BodoLibFallbackWarning):
         bdf[:] = 1
 
@@ -50,7 +50,7 @@ def test_df_apply_fallback_warning():
             "B": ["A1", "B1", "C1"],
         },
     )
-    bdf = pd.from_pandas(df)
+    bdf = bd.from_pandas(df)
     with pytest.warns(BodoLibFallbackWarning):
         bdf.apply(lambda a: pd.Series([1, 2]), axis=1)
 
@@ -65,7 +65,7 @@ def test_df_apply_bad_dtype_fallback_warning():
             "B": ["A1", "B1", "C1"] * 50,
         },
     )
-    bdf = pd.from_pandas(df)
+    bdf = bd.from_pandas(df)
     # All None Case
     with pytest.warns(BodoLibFallbackWarning):
         bdf.apply(lambda a: None, axis=1)
@@ -93,8 +93,8 @@ def test_merge_validation_checks():
         },
     )
 
-    bdf1 = pd.from_pandas(df1)
-    bdf2 = pd.from_pandas(df2)
+    bdf1 = bd.from_pandas(df1)
+    bdf2 = bd.from_pandas(df2)
 
     # Pandas merge should raise ValueError due to mismatched key lengths
     with pytest.raises(ValueError):
@@ -123,7 +123,7 @@ def test_merge_validation_checks():
         },
     )
 
-    bdf3 = pd.from_pandas(df3)
+    bdf3 = bd.from_pandas(df3)
 
     # Pandas passes checks when column names are multi-character strings
     df1.merge(df3, how="inner", left_on=("A",), right_on="cat")
@@ -162,7 +162,7 @@ def test_fallback_warning_on_unknown_attribute():
     import pandas as pds
 
     df = pds.DataFrame({"A": [1, 2, 3]})
-    bdf = pd.from_pandas(df)
+    bdf = bd.from_pandas(df)
 
     # Trigger __getattribute__ fallback by accessing an unsupported attribute
     with pytest.warns(
@@ -190,7 +190,7 @@ def test_single_fallback_warning_emitted():
     import pandas as pds
 
     df = pds.DataFrame({"A": ["a", "b", "a", "c"]})
-    bdf = pd.from_pandas(df)
+    bdf = bd.from_pandas(df)
 
     # pop(0) will fall back and may internally call other methods, but should only raise initial warning.
     with warnings.catch_warnings(record=True) as record:

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -41,6 +41,24 @@ def test_df_getitem_fallback_warning():
     with pytest.warns(BodoLibFallbackWarning):
         bdf[S]
 
+    # Arithmetic expression arguments with different source plans
+    bdf = bd.from_pandas(df)
+    bdf2 = bd.from_pandas(pd.DataFrame({"A": [1, 2, 3]}))
+    with pytest.warns(BodoLibFallbackWarning):
+        (bdf.A + bdf2.A)
+
+    # Comparison expression arguments with different source plans
+    bdf = bd.from_pandas(df)
+    bdf2 = bd.from_pandas(pd.DataFrame({"A": [1, 2, 3]}))
+    with pytest.warns(BodoLibFallbackWarning):
+        (bdf.A == bdf2.A)
+
+    # Conjunction expression arguments with different source plans
+    bdf = bd.from_pandas(df)
+    bdf2 = bd.from_pandas(pd.DataFrame({"A": [1, 2, 3]}))
+    with pytest.warns(BodoLibFallbackWarning):
+        ((bdf.A == 1) & (bdf2.A == 1))
+
 
 def test_df_setitem_fallback_warning():
     """Make sure DataFrame.__setitem__() raises a warning when falling back to Pandas."""

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -29,6 +29,18 @@ def test_df_getitem_fallback_warning():
     with pytest.warns(BodoLibFallbackWarning):
         bdf[:]
 
+    # Non-bodo Series
+    bdf = bd.from_pandas(df)
+    with pytest.warns(BodoLibFallbackWarning):
+        bdf[df.A > 1]
+
+    # Different expr source plan
+    bdf = bd.from_pandas(df)
+    bdf2 = bd.from_pandas(df)
+    S = bdf2.A > 0
+    with pytest.warns(BodoLibFallbackWarning):
+        bdf[S]
+
 
 def test_df_setitem_fallback_warning():
     """Make sure DataFrame.__setitem__() raises a warning when falling back to Pandas."""


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Makes sure filter and binary expression arguments have the same source plans. It matches the source plans when one side is just a projection on the other. Fixes an issue in TPC-H Q22.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Avoids some segfaults and other issues.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.