### PR TITLE
Lower Python call overheads in execution pipelines

### DIFF
--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1205,5 +1205,10 @@ std::string cpp_table_get_first_field_name(int64_t cpp_table) {
     return (table->column_names.size() > 0) ? table->column_names[0] : "";
 }
 
+void cpp_table_delete(int64_t cpp_table) {
+    table_info *table = reinterpret_cast<table_info *>(cpp_table);
+    delete table;
+}
+
 #undef CHECK_ARROW
 #undef CHECK_ARROW_AND_ASSIGN

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1153,7 +1153,7 @@ int64_t pyarrow_array_to_cpp_table(PyObject *arrow_array, std::string name,
         arrow_array_to_bodo(array, nullptr)};
 
     // Add Index arrays if any
-    for (int64_t i = 1; i < in_table->ncols(); i++) {
+    for (size_t i = 1; i < in_table->ncols(); i++) {
         out_arrs.push_back(in_table->columns[i]);
     }
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1141,11 +1141,68 @@ int64_t pyarrow_to_cpp_table(PyObject *pyarrow_table) {
     return reinterpret_cast<int64_t>(new table_info(*out_table));
 }
 
-PyObject *cpp_table_to_pyarrow(int64_t cpp_table) {
-    std::shared_ptr<table_info> table =
-        std::shared_ptr<table_info>(reinterpret_cast<table_info *>(cpp_table));
-    std::shared_ptr<arrow::Table> arrow_table = bodo_table_to_arrow(table);
+int64_t pyarrow_array_to_cpp_table(PyObject *arrow_array, std::string name,
+                                   int64_t in_cpp_table) {
+    // Unwrap Arrow array from Python object
+    std::shared_ptr<arrow::Array> array =
+        arrow::py::unwrap_array(arrow_array).ValueOrDie();
+    std::shared_ptr<table_info> in_table = std::shared_ptr<table_info>(
+        reinterpret_cast<table_info *>(in_cpp_table));
+
+    std::vector<std::shared_ptr<array_info>> out_arrs = {
+        arrow_array_to_bodo(array, nullptr)};
+
+    // Add Index arrays if any
+    for (int64_t i = 1; i < in_table->ncols(); i++) {
+        out_arrs.push_back(in_table->columns[i]);
+    }
+
+    std::shared_ptr<table_info> out_table =
+        std::make_shared<table_info>(out_arrs);
+
+    out_table->column_names = {name};
+
+    // Add Index column names if any
+    if (in_table->column_names.size() > 1) {
+        out_table->column_names.insert(out_table->column_names.end(),
+                                       in_table->column_names.begin() + 1,
+                                       in_table->column_names.end());
+    }
+    out_table->metadata = in_table->metadata;
+
+    return reinterpret_cast<int64_t>(new table_info(*out_table));
+}
+
+PyObject *cpp_table_to_pyarrow(int64_t cpp_table, bool delete_cpp_table) {
+    table_info *table = reinterpret_cast<table_info *>(cpp_table);
+    std::shared_ptr<arrow::Table> arrow_table = bodo_table_to_arrow(
+        std::shared_ptr<table_info>(new table_info(*table)));
+    if (delete_cpp_table) {
+        delete table;
+    }
     return arrow::py::wrap_table(arrow_table);
+}
+
+PyObject *cpp_table_to_pyarrow_array(int64_t cpp_table) {
+    table_info *table = reinterpret_cast<table_info *>(cpp_table);
+    if (table->ncols() == 0) {
+        throw std::runtime_error(
+            "cpp_table_to_pyarrow_array expects a table with more than one "
+            "column");
+    }
+    std::shared_ptr<array_info> array = table->columns[0];
+    std::shared_ptr<arrow::Array> arrow_array = to_arrow(array);
+    return arrow::py::wrap_array(arrow_array);
+}
+
+std::string cpp_table_get_first_field_name(int64_t cpp_table) {
+    table_info *table = reinterpret_cast<table_info *>(cpp_table);
+    if (table->ncols() == 0) {
+        throw std::runtime_error(
+            "cpp_table_get_first_field_name expects a table with more than one "
+            "column");
+    }
+    return (table->column_names.size() > 0) ? table->column_names[0] : "";
 }
 
 #undef CHECK_ARROW

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -492,3 +492,10 @@ PyObject *cpp_table_to_pyarrow_array(int64_t cpp_table);
  * @return std::string name of the first field
  */
 std::string cpp_table_get_first_field_name(int64_t cpp_table);
+
+/**
+ * @brief Delete a Bodo C++ table pointer.
+ *
+ * @param cpp_table C++ table pointer cast to int64_t
+ */
+void cpp_table_delete(int64_t cpp_table);

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -6,6 +6,7 @@
 #include <Python.h>
 #include <arrow/type.h>
 #include <fmt/format.h>
+#include <cstdint>
 #include <utility>
 #include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/function/function.hpp"
@@ -451,9 +452,43 @@ int planCountNodes(std::unique_ptr<duckdb::LogicalOperator> &op);
 int64_t pyarrow_to_cpp_table(PyObject *pyarrow_table);
 
 /**
+ * @brief Convert a PyArrow array to a C++ table pointer with column names and
+ * metadata set properly.
+ * Uses in_cpp_table for appending Index arrays if any and pandas metadata.
+ * Deletes in_cpp_table after use.
+ *
+ * @param arrow_array input Arrow array object
+ * @param name column name
+ * @param in_cpp_table C++ table pointer cast to int64_t
+ * @return int64_t C++ table pointer cast to int64_t
+ */
+int64_t pyarrow_array_to_cpp_table(PyObject *arrow_array, std::string name,
+                                   int64_t in_cpp_table);
+
+/**
  * @brief convert a Bodo C++ table pointer to a PyArrow table object.
  *
  * @param cpp_table C++ table pointer cast to int64_t
+ * @param delete_cpp_table whether to delete the C++ table after conversion
  * @return PyObject* PyArrow table object
  */
-PyObject *cpp_table_to_pyarrow(int64_t cpp_table);
+PyObject *cpp_table_to_pyarrow(int64_t cpp_table, bool delete_cpp_table = true);
+
+/**
+ * @brief Convert the first column of a Bodo C++ table to a PyArrow array
+ * object. NOTE: does not delete the C++ table.
+ *
+ * @param cpp_table C++ table pointer cast to int64_t
+ * @return PyObject* PyArrow array object
+ */
+PyObject *cpp_table_to_pyarrow_array(int64_t cpp_table);
+
+/**
+ * @brief Get the name of the first field in a Bodo C++ table.
+ * Returns an empty string if the table has no column names.
+ * NOTE: does not delete the C++ table.
+ *
+ * @param cpp_table C++ table pointer cast to int64_t
+ * @return std::string name of the first field
+ */
+std::string cpp_table_get_first_field_name(int64_t cpp_table);

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -338,6 +338,7 @@ cdef extern from "_plan.h" nogil:
     cdef object cpp_table_to_pyarrow_array(int64_t cpp_table) except +
     cdef c_string cpp_table_get_first_field_name(int64_t cpp_table) except +
     cdef object cpp_table_to_pyarrow(int64_t cpp_table, c_bool delete_cpp_table) except +
+    cdef void cpp_table_delete(int64_t cpp_table) except +
 
 
 def join_type_to_string(CJoinType join_type):
@@ -898,10 +899,13 @@ cpdef cpp_table_to_arrow(cpp_table, delete_cpp_table=True):
     return cpp_table_to_pyarrow(cpp_table, delete_cpp_table)
 
 
-cpdef cpp_table_to_arrow_array(cpp_table):
+cpdef cpp_table_to_arrow_array(cpp_table, delete_cpp_table=True):
     """Convert the first column of C++ table to Arrow array and column name.
     """
-    return cpp_table_to_pyarrow_array(cpp_table), cpp_table_get_first_field_name(cpp_table).decode()
+    out = cpp_table_to_pyarrow_array(cpp_table), cpp_table_get_first_field_name(cpp_table).decode()
+    if delete_cpp_table:
+        cpp_table_delete(cpp_table)
+    return out
 
 
 cpdef py_optimize_plan(object plan):

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -334,7 +334,10 @@ cdef extern from "_plan.h" nogil:
     cdef vector[int] get_projection_pushed_down_columns(unique_ptr[CLogicalOperator] proj) except +
     cdef int planCountNodes(unique_ptr[CLogicalOperator] root) except +
     cdef int64_t pyarrow_to_cpp_table(object arrow_table) except +
-    cdef object cpp_table_to_pyarrow(int64_t cpp_table) except +
+    cdef int64_t pyarrow_array_to_cpp_table(object arrow_array, c_string name, int64_t in_cpp_table) except +
+    cdef object cpp_table_to_pyarrow_array(int64_t cpp_table) except +
+    cdef c_string cpp_table_get_first_field_name(int64_t cpp_table) except +
+    cdef object cpp_table_to_pyarrow(int64_t cpp_table, c_bool delete_cpp_table) except +
 
 
 def join_type_to_string(CJoinType join_type):
@@ -880,10 +883,25 @@ cpdef arrow_to_cpp_table(arrow_table):
     return pyarrow_to_cpp_table(arrow_table)
 
 
-cpdef cpp_table_to_arrow(cpp_table):
+cpdef arrow_array_to_cpp_table(object arr, str name, in_cpp_table):
+    """Convert an Arrow array to a C++ table pointer with column names and
+    metadata set properly.
+    Uses in_cpp_table for appending Index arrays if any and pandas metadata.
+    Deletes in_cpp_table after use.
+    """
+    return pyarrow_array_to_cpp_table(arr, name.encode(), in_cpp_table)
+
+
+cpdef cpp_table_to_arrow(cpp_table, delete_cpp_table=True):
     """Convert a C++ table pointer to Arrow table.
     """
-    return cpp_table_to_pyarrow(cpp_table)
+    return cpp_table_to_pyarrow(cpp_table, delete_cpp_table)
+
+
+cpdef cpp_table_to_arrow_array(cpp_table):
+    """Convert the first column of C++ table to Arrow array and column name.
+    """
+    return cpp_table_to_pyarrow_array(cpp_table), cpp_table_get_first_field_name(cpp_table).decode()
 
 
 cpdef py_optimize_plan(object plan):

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -2159,8 +2159,10 @@ series_str_methods = [
 
 # Maps Series.dt accessors to return types
 dt_accessors = [
-    # idx = 0: Series(Int)
+    # idx = 0: Series(Int64)
     (
+        # NOTE: These methods are int32 for regular types in Pandas but int64 for
+        # ArrowDtype as of Pandas 2.3.
         [
             "year",
             "month",
@@ -2178,6 +2180,12 @@ dt_accessors = [
             "daysinmonth",
             "days_in_month",
             "quarter",
+        ],
+        pd.ArrowDtype(pa.int64()),
+    ),
+    # idx = 0: Series(Int32)
+    (
+        [
             "days",
             "seconds",
             "microseconds",

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -113,7 +113,7 @@ def cpp_table_to_series(
         as_df = cpp_table_to_df(cpp_table, arrow_schema, use_arrow_dtypes, delete_input)
         return as_df.iloc[:, 0]
 
-    arrow_arr, name = plan_optimizer.cpp_table_to_arrow_array(cpp_table)
+    arrow_arr, name = plan_optimizer.cpp_table_to_arrow_array(cpp_table, delete_input)
     arrow_type = arrow_arr.type if arrow_schema is None else arrow_schema[0].type
 
     return _arrow_array_to_pd(arrow_arr, arrow_type, use_arrow_dtypes, name=name)

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -532,7 +532,7 @@ def run_func_on_table(cpp_table, result_type, in_args):
         if out.dtype != pd.ArrowDtype(result_type):
             out = out.astype(pd.ArrowDtype(result_type))
     else:
-        out = _empty_pd_array(result_type)
+        out = pd.Series(_empty_pd_array(result_type), index=out.index, name=out.name)
 
     if out.name is None:
         out.name = "OUT"

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -691,7 +691,8 @@ def arrow_table_to_pandas(arrow_table, arrow_schema=None, use_arrow_dtypes=True)
         {
             i: _arrow_to_pd_array(arrow_table.columns[i], field.type, use_arrow_dtypes)
             for i, field in enumerate(arrow_schema)
-        }
+        },
+        copy=False,
     )
     # Set column names separately to handle duplicate names ("field.name:" in a
     # dictionary would replace duplicated values)

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -109,8 +109,8 @@ def cpp_table_to_series(
 
     arrow_table = plan_optimizer.cpp_table_to_arrow(cpp_table)
 
-    assert len(arrow_table.columns) == 1, (
-        f"cpp_table_to_series: Expected 1 column, got {len(arrow_table.columns)}"
+    assert len(arrow_table.columns) >= 1, (
+        f"cpp_table_to_series: Expected 1 or more columns, got {len(arrow_table.columns)}"
     )
 
     if arrow_schema is None:

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -101,19 +101,20 @@ def cpp_table_to_series(
     """Convert a C++ table (table_info) to a pandas Series."""
     from bodo.ext import plan_optimizer
 
-    arrow_table = plan_optimizer.cpp_table_to_arrow(cpp_table)
-
-    if arrow_schema is None:
-        arrow_schema = arrow_table.schema
-
-    # We need to preserve Index for query output (see execute_plan)
+    # We need to preserve Index for query output which provides arrow_schema also
+    # (see execute_plan)
     if not ignore_index and schema_has_index_arrays(arrow_schema):
         as_df = cpp_table_to_df(cpp_table, arrow_schema, use_arrow_dtypes)
         return as_df.iloc[:, 0]
 
+    arrow_table = plan_optimizer.cpp_table_to_arrow(cpp_table)
+
     assert len(arrow_table.columns) == 1, (
         f"cpp_table_to_series: Expected 1 column, got {len(arrow_table.columns)}"
     )
+
+    if arrow_schema is None:
+        arrow_schema = arrow_table.schema
 
     arr = _arrow_to_pd_array(
         arrow_table.columns[0], arrow_schema[0].type, use_arrow_dtypes


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Lowers the overheads of UDF calls in most cases by avoiding unnecessary conversion to dataframes.

I see almost 2x speedup with the benchmark code I ran on my local Mac (single core):

```python
import bodo.pandas as bd
import time
import pandas as pd

N = 50_000_000
df = pd.DataFrame({"hours": pd.date_range("1980-01-01", periods=N, freq="s")})
bdf = bd.from_pandas(df)
start = time.perf_counter()
new_S = bdf.hours.dt.year
new_S.execute_plan()
print("Bodo UDF took", time.perf_counter() - start, "seconds")
```

Output on main: `Bodo UDF took 5.318414875000599 seconds`
Output on this branch: `Bodo UDF took 2.958851125000365 seconds`

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None, just performance.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.