### PR TITLE
Support Series.isin(Series) and filter with isin

### DIFF
--- a/bodo/libs/_chunked_table_builder.cpp
+++ b/bodo/libs/_chunked_table_builder.cpp
@@ -1242,7 +1242,37 @@ void AbstractChunkedTableBuilder::AppendJoinOutput(
     const std::span<const int64_t> build_idxs,
     const std::span<const int64_t> probe_idxs,
     const std::vector<uint64_t>& build_kept_cols,
-    const std::vector<uint64_t>& probe_kept_cols) {
+    const std::vector<uint64_t>& probe_kept_cols, bool is_mark_join) {
+    if (is_mark_join) {
+        // Add the mark column to probe table and append to output buffer.
+        std::vector<std::shared_ptr<array_info>> out_arrs;
+        std::vector<std::string> col_names;
+        out_arrs.reserve(probe_kept_cols.size() + 1);
+        for (const auto& c : probe_kept_cols) {
+            out_arrs.emplace_back(probe_table->columns[c]);
+            if (probe_table->column_names.size() > 0) {
+                col_names.push_back(probe_table->column_names[c]);
+            }
+        }
+        std::shared_ptr<array_info> mark_arr = alloc_nullable_array_no_nulls(
+            probe_table->nrows(), Bodo_CTypes::_BOOL);
+        uint8_t* mark_data =
+            mark_arr->data1<bodo_array_type::NULLABLE_INT_BOOL, uint8_t>();
+        memset(mark_data, 0, probe_table->nrows() * sizeof(uint8_t));
+        for (const auto& idx : probe_idxs) {
+            SetBitTo(mark_data, idx, true);
+        }
+        out_arrs.push_back(mark_arr);
+        if (probe_table->column_names.size() > 0) {
+            col_names.push_back("");
+        }
+        std::shared_ptr<table_info> mark_table = std::make_shared<table_info>(
+            out_arrs, probe_table->nrows(), col_names, probe_table->metadata);
+
+        this->AppendBatch(mark_table);
+        return;
+    }
+
     if (build_idxs.size() != probe_idxs.size()) {
         throw std::runtime_error(
             "AbstractChunkedTableBuilder::AppendJoinOutput: Length of "
@@ -1679,38 +1709,6 @@ void AbstractChunkedTableBuilder::AppendJoinOutput(
 
 #undef NUM_ROWS_CAN_APPEND_COL
 #undef APPEND_ROWS_COL
-}
-
-void AbstractChunkedTableBuilder::AppendMarkJoinOutput(
-    std::shared_ptr<table_info> probe_table,
-    const std::span<const int64_t> probe_idxs,
-    const std::vector<uint64_t>& probe_kept_cols) {
-    // Add the mark column to probe table and append to output buffer.
-    std::vector<std::shared_ptr<array_info>> out_arrs;
-    std::vector<std::string> col_names;
-    out_arrs.reserve(probe_kept_cols.size() + 1);
-    for (const auto& c : probe_kept_cols) {
-        out_arrs.emplace_back(probe_table->columns[c]);
-        if (probe_table->column_names.size() > 0) {
-            col_names.push_back(probe_table->column_names[c]);
-        }
-    }
-    std::shared_ptr<array_info> mark_arr =
-        alloc_nullable_array_no_nulls(probe_table->nrows(), Bodo_CTypes::_BOOL);
-    uint8_t* mark_data =
-        mark_arr->data1<bodo_array_type::NULLABLE_INT_BOOL, uint8_t>();
-    memset(mark_data, 0, probe_table->nrows() * sizeof(uint8_t));
-    for (const auto& idx : probe_idxs) {
-        SetBitTo(mark_data, idx, true);
-    }
-    out_arrs.push_back(mark_arr);
-    if (probe_table->column_names.size() > 0) {
-        col_names.push_back("");
-    }
-    std::shared_ptr<table_info> mark_table = std::make_shared<table_info>(
-        out_arrs, probe_table->nrows(), col_names, probe_table->metadata);
-
-    this->AppendBatch(mark_table);
 }
 
 void AbstractChunkedTableBuilder::Finalize(bool shrink_to_fit) {

--- a/bodo/libs/_chunked_table_builder.cpp
+++ b/bodo/libs/_chunked_table_builder.cpp
@@ -1681,6 +1681,38 @@ void AbstractChunkedTableBuilder::AppendJoinOutput(
 #undef APPEND_ROWS_COL
 }
 
+void AbstractChunkedTableBuilder::AppendMarkJoinOutput(
+    std::shared_ptr<table_info> probe_table,
+    const std::span<const int64_t> probe_idxs,
+    const std::vector<uint64_t>& probe_kept_cols) {
+    // Add the mark column to probe table and append to output buffer.
+    std::vector<std::shared_ptr<array_info>> out_arrs;
+    std::vector<std::string> col_names;
+    out_arrs.reserve(probe_kept_cols.size() + 1);
+    for (const auto& c : probe_kept_cols) {
+        out_arrs.emplace_back(probe_table->columns[c]);
+        if (probe_table->column_names.size() > 0) {
+            col_names.push_back(probe_table->column_names[c]);
+        }
+    }
+    std::shared_ptr<array_info> mark_arr =
+        alloc_nullable_array_no_nulls(probe_table->nrows(), Bodo_CTypes::_BOOL);
+    uint8_t* mark_data =
+        mark_arr->data1<bodo_array_type::NULLABLE_INT_BOOL, uint8_t>();
+    memset(mark_data, 0, probe_table->nrows() * sizeof(uint8_t));
+    for (const auto& idx : probe_idxs) {
+        SetBitTo(mark_data, idx, true);
+    }
+    out_arrs.push_back(mark_arr);
+    if (probe_table->column_names.size() > 0) {
+        col_names.push_back("");
+    }
+    std::shared_ptr<table_info> mark_table = std::make_shared<table_info>(
+        out_arrs, probe_table->nrows(), col_names, probe_table->metadata);
+
+    this->AppendBatch(mark_table);
+}
+
 void AbstractChunkedTableBuilder::Finalize(bool shrink_to_fit) {
     // Finalize the active chunk:
     if (this->active_chunk_size > 0) {

--- a/bodo/libs/_chunked_table_builder.h
+++ b/bodo/libs/_chunked_table_builder.h
@@ -1329,14 +1329,19 @@ class AbstractChunkedTableBuilder {
      * @param probe_kept_cols Indices of the columns from the probe table.
      * @param is_mark_join If true, this is a mark join and we only append
      * the probe table rows and mark column.
+     * @param mark_output_rows If is_mark_join is true, this is the boolean
+     * row selection for which rows to append from the probe table.
+     * Necessary since shuffle and inactive partition rows in probe input
+     * should not be appended. Pass nullptr if all rows should be appended.
      */
-    void AppendJoinOutput(std::shared_ptr<table_info> build_table,
-                          std::shared_ptr<table_info> probe_table,
-                          const std::span<const int64_t> build_idxs,
-                          const std::span<const int64_t> probe_idxs,
-                          const std::vector<uint64_t>& build_kept_cols,
-                          const std::vector<uint64_t>& probe_kept_cols,
-                          bool is_mark_join = false);
+    void AppendJoinOutput(
+        std::shared_ptr<table_info> build_table,
+        std::shared_ptr<table_info> probe_table,
+        const std::span<const int64_t> build_idxs,
+        const std::span<const int64_t> probe_idxs,
+        const std::vector<uint64_t>& build_kept_cols,
+        const std::vector<uint64_t>& probe_kept_cols, bool is_mark_join = false,
+        std::shared_ptr<std::vector<bool>> mark_output_rows = nullptr);
 
     /**
      * @brief Finalize this chunked table. This will finalize

--- a/bodo/libs/_chunked_table_builder.h
+++ b/bodo/libs/_chunked_table_builder.h
@@ -1327,25 +1327,16 @@ class AbstractChunkedTableBuilder {
      * @param probe_idxs Corresponding indices from the probe table.
      * @param build_kept_cols Indices of the columns from the build table.
      * @param probe_kept_cols Indices of the columns from the probe table.
+     * @param is_mark_join If true, this is a mark join and we only append
+     * the probe table rows and mark column.
      */
     void AppendJoinOutput(std::shared_ptr<table_info> build_table,
                           std::shared_ptr<table_info> probe_table,
                           const std::span<const int64_t> build_idxs,
                           const std::span<const int64_t> probe_idxs,
                           const std::vector<uint64_t>& build_kept_cols,
-                          const std::vector<uint64_t>& probe_kept_cols);
-
-    /**
-     * @brief Similar to AppendJoinOutput, but specifically for
-     * Mark Join output.
-     *
-     * @param probe_table Probe/Right table to insert rows from.
-     * @param probe_idxs Corresponding indices from the probe table.
-     * @param probe_kept_cols Indices of the columns from the probe table.
-     */
-    void AppendMarkJoinOutput(std::shared_ptr<table_info> probe_table,
-                              const std::span<const int64_t> probe_idxs,
-                              const std::vector<uint64_t>& probe_kept_cols);
+                          const std::vector<uint64_t>& probe_kept_cols,
+                          bool is_mark_join = false);
 
     /**
      * @brief Finalize this chunked table. This will finalize

--- a/bodo/libs/_chunked_table_builder.h
+++ b/bodo/libs/_chunked_table_builder.h
@@ -1336,6 +1336,18 @@ class AbstractChunkedTableBuilder {
                           const std::vector<uint64_t>& probe_kept_cols);
 
     /**
+     * @brief Similar to AppendJoinOutput, but specifically for
+     * Mark Join output.
+     *
+     * @param probe_table Probe/Right table to insert rows from.
+     * @param probe_idxs Corresponding indices from the probe table.
+     * @param probe_kept_cols Indices of the columns from the probe table.
+     */
+    void AppendMarkJoinOutput(std::shared_ptr<table_info> probe_table,
+                              const std::span<const int64_t> probe_idxs,
+                              const std::vector<uint64_t>& probe_kept_cols);
+
+    /**
      * @brief Finalize this chunked table. This will finalize
      * the active chunk. If the active chunk is empty, it will
      * be discarded and its memory will be freed.

--- a/bodo/libs/streaming/_join.cpp
+++ b/bodo/libs/streaming/_join.cpp
@@ -3693,11 +3693,11 @@ bool join_probe_consume_batch(HashJoinState* join_state,
         }
         std::shared_ptr<array_info> mark_arr = alloc_nullable_array_no_nulls(
             in_table->nrows(), Bodo_CTypes::_BOOL);
-        bool* mark_data =
-            mark_arr->data1<bodo_array_type::NULLABLE_INT_BOOL, bool>();
-        memset(mark_data, 0, in_table->nrows() * sizeof(bool));
+        uint8_t* mark_data =
+            mark_arr->data1<bodo_array_type::NULLABLE_INT_BOOL, uint8_t>();
+        memset(mark_data, 0, in_table->nrows() * sizeof(uint8_t));
         for (const auto& idx : probe_idxs) {
-            mark_data[idx] = true;
+            SetBitTo(mark_data, idx, true);
         }
         out_arrs.push_back(mark_arr);
         if (in_table->column_names.size() > 0) {

--- a/bodo/libs/streaming/_join.h
+++ b/bodo/libs/streaming/_join.h
@@ -704,6 +704,8 @@ class JoinState {
     const bool force_broadcast;
     // Matches Pandas behavior by treating NA values as equal.
     const bool is_na_equal;
+    // Mark join is used for Series.isin in dataframe library
+    const bool is_mark_join;
     // Note: This isn't constant because we may change it
     // via broadcast decisions.
     bool build_parallel;
@@ -777,7 +779,7 @@ class JoinState {
               bool probe_table_outer_, cond_expr_fn_t cond_func_,
               bool build_parallel_, bool probe_parallel_,
               int64_t output_batch_size_, int64_t sync_iter_, int64_t op_id_,
-              bool is_na_equal_ = false);
+              bool is_na_equal_ = false, bool is_mark_join_ = false);
 
     virtual ~JoinState() {}
 
@@ -978,7 +980,7 @@ class HashJoinState : public JoinState {
                   // pool size. Else we'll use the provided size.
                   int64_t op_pool_size_bytes = -1,
                   size_t max_partition_depth_ = JOIN_MAX_PARTITION_DEPTH,
-                  bool is_na_equal_ = false);
+                  bool is_na_equal_ = false, bool is_mark_join_ = false);
 
     ~HashJoinState() { MPI_Comm_free(&this->shuffle_comm); }
 

--- a/bodo/libs/streaming/_join.h
+++ b/bodo/libs/streaming/_join.h
@@ -284,7 +284,7 @@ class JoinPartition {
         const std::shared_ptr<::arrow::MemoryManager> op_mm_,
         bodo::OperatorScratchPool* op_scratch_pool_,
         const std::shared_ptr<::arrow::MemoryManager> op_scratch_mm_,
-        bool is_na_equal_ = false);
+        bool is_na_equal_ = false, bool is_mark_join_ = false);
 
     // The types of the columns in the build table and probe tables.
     const std::shared_ptr<bodo::Schema> build_table_schema;
@@ -399,6 +399,7 @@ class JoinPartition {
 
     // Matches Pandas behavior by treating NA values as equal.
     const bool is_na_equal;
+    const bool is_mark_join;
 
     /// @brief Get number of bits in the 'top_bitmask'.
     size_t get_num_top_bits() const { return this->num_top_bits; }

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -635,6 +635,14 @@ duckdb::unique_ptr<duckdb::LogicalComparisonJoin> make_comparison_join(
     comp_join->children.push_back(std::move(lhs_duck));
     comp_join->children.push_back(std::move(rhs_duck));
 
+    // Generate a table index for mark column output similar to DuckDB:
+    // https://github.com/duckdb/duckdb/blob/d29a92f371179170688b4df394478f389bf7d1a6/src/planner/binder/query_node/plan_subquery.cpp#L160
+    if (join_type == duckdb::JoinType::MARK) {
+        auto binder = get_duckdb_binder();
+        auto mark_index = binder.get()->GenerateTableIndex();
+        comp_join->mark_index = mark_index;
+    }
+
     return comp_join;
 }
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -57,6 +57,7 @@ from bodo.pandas.plan import (
     execute_plan,
     get_proj_expr_single,
     is_colref_projection,
+    is_single_colref_projection,
     is_single_projection,
     make_col_ref_exprs,
 )
@@ -996,6 +997,10 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
 
         # Filter operation
         if isinstance(key, BodoSeries) and key._plan.pa_schema.types[0] == pa.bool_():
+            # Pattern match df1[df1.A.isin(df2.B)] case which is a semi-join
+            if (out_plan := get_isin_filter_plan(self._plan, key._plan)) is not None:
+                return wrap_plan(out_plan)
+
             key_expr = get_proj_expr_single(key._plan)
             key_expr = key_expr.replace_source(self._plan)
             if key_expr is None:
@@ -1474,6 +1479,48 @@ def _get_set_column_plan(
         return None
 
     return _add_proj_expr_to_plan(df_plan, value_plan, key)
+
+
+def get_isin_filter_plan(source_plan: LazyPlan, key_plan: LazyPlan) -> LazyPlan | None:
+    """
+    Pattern match df1[df1.A.isin(df2.B)] case and return a semi-join plan to implement
+    it. Returns None if the plan pattern does not match.
+    """
+    # Match df1.A.isin(df2.B) case which is a mark join generated in our Series.isin()
+    if not (
+        is_single_colref_projection(key_plan)
+        and isinstance(key_plan.source, LogicalComparisonJoin)
+        and key_plan.source.join_type == plan_optimizer.CJoinType.MARK
+        and is_single_colref_projection(key_plan.source.left_plan)
+        and key_plan.source.left_plan.source == source_plan
+    ):
+        return None
+
+    left_key_ind = key_plan.source.left_plan.exprs[0].col_index
+    planComparisonJoin = LogicalComparisonJoin(
+        source_plan.empty_data,
+        source_plan,
+        key_plan.source.right_plan,
+        plan_optimizer.CJoinType.INNER,
+        [(left_key_ind, 0)],
+    )
+
+    # Ignore right column in output
+    exprs = make_col_ref_exprs(
+        list(
+            range(
+                len(source_plan.empty_data.columns)
+                + get_n_index_arrays(source_plan.empty_data.index)
+            )
+        ),
+        planComparisonJoin,
+    )
+    proj_plan = LogicalProjection(
+        source_plan.empty_data,
+        planComparisonJoin,
+        exprs,
+    )
+    return proj_plan
 
 
 def validate_on(val):

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -39,7 +39,8 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
         duckdb::vector<duckdb::JoinCondition>& conditions,
         const std::shared_ptr<bodo::Schema> build_table_schema,
         const std::shared_ptr<bodo::Schema> probe_table_schema)
-        : has_non_equi_cond(false) {
+        : has_non_equi_cond(false),
+          is_mark_join(logical_join.join_type == duckdb::JoinType::MARK) {
         duckdb::vector<duckdb::ColumnBinding> left_bindings =
             logical_join.children[0]->GetColumnBindings();
         duckdb::vector<duckdb::ColumnBinding> right_bindings =
@@ -65,15 +66,18 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
             }
         }
 
-        if (logical_join.right_projection_map.empty()) {
-            for (duckdb::idx_t i = 0;
-                 i < logical_join.children[1]->GetColumnBindings().size();
-                 i++) {
-                this->bound_right_inds.insert(i);
-            }
-        } else {
-            for (const auto& c : logical_join.right_projection_map) {
-                this->bound_right_inds.insert(c);
+        // Mark join does not output the build table columns
+        if (!this->is_mark_join) {
+            if (logical_join.right_projection_map.empty()) {
+                for (duckdb::idx_t i = 0;
+                     i < logical_join.children[1]->GetColumnBindings().size();
+                     i++) {
+                    this->bound_right_inds.insert(i);
+                }
+            } else {
+                for (const auto& c : logical_join.right_projection_map) {
+                    this->bound_right_inds.insert(c);
+                }
             }
         }
 
@@ -187,7 +191,8 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
             // TODO: support forcing broadcast by the planner
             false, join_func, true, true, get_streaming_batch_size(), -1,
             //  TODO: support query profiling
-            -1, -1, JOIN_MAX_PARTITION_DEPTH, /*is_na_equal*/ true);
+            -1, -1, JOIN_MAX_PARTITION_DEPTH, /*is_na_equal*/ true,
+            is_mark_join);
 
         this->initOutputSchema(build_table_schema_reordered,
                                probe_table_schema_reordered,
@@ -227,6 +232,17 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
                 probe_table_schema_reordered->column_names[i_col]);
         }
 
+        // Add the mark output column if this is a mark join.
+        if (this->is_mark_join) {
+            if (!build_kept_cols.empty()) {
+                throw std::runtime_error(
+                    "Mark join should not output build table columns.");
+            }
+            output_schema->append_column(std::make_unique<bodo::DataType>(
+                bodo_array_type::NULLABLE_INT_BOOL, Bodo_CTypes::_BOOL));
+            col_names.push_back("");
+        }
+
         for (uint64_t i_col : build_kept_cols) {
             std::unique_ptr<bodo::DataType> col_type =
                 build_table_schema_reordered->column_types[i_col]->copy();
@@ -252,6 +268,11 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
                 "Join output schema has different number of columns than "
                 "LogicalComparisonJoin");
         }
+
+        // See
+        // https://github.com/bodo-ai/Bodo/blob/546cb5a45f5bc8e3922f5060e7f778cc744a0930/bodo/libs/streaming/_join.cpp#L4062
+        this->join_state_->InitOutputBuffer(this->build_kept_cols,
+                                            this->probe_kept_cols);
     }
 
     /**
@@ -339,10 +360,6 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
         if (has_non_equi_cond) {
             PhysicalExpression::cur_join_expr = physExprTree.get();
         }
-        // See
-        // https://github.com/bodo-ai/Bodo/blob/546cb5a45f5bc8e3922f5060e7f778cc744a0930/bodo/libs/streaming/_join.cpp#L4062
-        this->join_state_->InitOutputBuffer(this->build_kept_cols,
-                                            this->probe_kept_cols);
 
         bool request_input = true;
 
@@ -503,6 +520,8 @@ class PhysicalJoin : public PhysicalSourceSink, public PhysicalSink {
 
     bool has_non_equi_cond;
     std::shared_ptr<PhysicalExpression> physExprTree;
+
+    bool is_mark_join = false;
 };
 
 #undef CONSUME_PROBE_BATCH

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -197,7 +197,17 @@ class LogicalDistinct(LogicalOperator):
 class LogicalComparisonJoin(LogicalOperator):
     """Logical operator for comparison-based joins."""
 
-    pass
+    @property
+    def left_plan(self):
+        return self.args[0]
+
+    @property
+    def right_plan(self):
+        return self.args[1]
+
+    @property
+    def join_type(self):
+        return self.args[2]
 
 
 class LogicalSetOperation(LogicalOperator):

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -933,7 +933,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         new_metadata = pd.Series(
             dtype=pd.ArrowDtype(pa.bool_()),
-            name=None,
+            name=self.name,
             index=self.head(0).index,
         )
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -938,6 +938,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         if isinstance(values, BodoSeries):
             empty_left = _empty_like(self)
+            empty_left.name = None
             # Mark column is after the left columns in DuckDB, see:
             # https://github.com/duckdb/duckdb/blob/d29a92f371179170688b4df394478f389bf7d1a6/src/planner/operator/logical_join.cpp#L20
             empty_join_out = pd.concat(
@@ -953,7 +954,9 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             )
 
             # Can't use make_col_ref_exprs since output type is not in input schema
-            empty_col_data = arrow_to_empty_df(pa.schema([pa.bool_()]))
+            empty_col_data = arrow_to_empty_df(
+                pa.schema([pa.field("mark", pa.bool_())])
+            )
             n_indices = get_n_index_arrays(new_metadata.index)
             mark_col = ColRefExpression(
                 empty_col_data, planComparisonJoin, n_indices + 1

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -932,7 +932,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
         new_metadata = pd.Series(
             dtype=pd.ArrowDtype(pa.bool_()),
-            name=self.name,
+            name=None,
             index=self.head(0).index,
         )
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -970,6 +970,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
 
             return wrap_plan(proj_plan)
 
+        # It's just a map function if 'values' is not a BodoSeries
+        return _get_series_python_func_plan(
+            self._plan, new_metadata, "isin", (values,), {}
+        )
+
 
 class BodoStringMethods:
     """Support Series.str string processing methods same as Pandas."""

--- a/bodo/tests/test_df_lib/test_direct_series_methods.py
+++ b/bodo/tests/test_df_lib/test_direct_series_methods.py
@@ -32,6 +32,8 @@ def test_series_isin(index_val, use_index1, use_index2):
         py_out,
         check_pandas_types=False,
         sort_output=True,
+        # We don't track RangeIndex in output
+        reset_index=isinstance(S2.index, pd.RangeIndex),
     )
 
 

--- a/bodo/tests/test_df_lib/test_direct_series_methods.py
+++ b/bodo/tests/test_df_lib/test_direct_series_methods.py
@@ -1,5 +1,37 @@
 import pandas as pd
+import pytest
 from test_series_generator import _generate_series_test
+
+import bodo.pandas as bd
+from bodo.pandas.plan import assert_executed_plan_count
+from bodo.tests.utils import _test_equal
+
+
+@pytest.mark.parametrize("use_index1", [True, False])
+@pytest.mark.parametrize("use_index2", [True, False])
+def test_series_isin(index_val, use_index1, use_index2):
+    S1 = pd.Series([1, 2, 3, 4, 5] * 3)
+    S2 = pd.Series([2, 8, 8, 1, 3, 11] * 4)
+    if use_index1:
+        S1.index = index_val[: len(S1)]
+
+    if use_index2:
+        S2.index = index_val[: len(S2)]
+
+    py_out = S2.isin(S1)
+
+    with assert_executed_plan_count(0):
+        bdf1 = bd.from_pandas(pd.DataFrame({"A": S1}))
+        bdf2 = bd.from_pandas(pd.DataFrame({"B": S2}))
+
+        bd_out = bdf2["B"].isin(bdf1["A"])
+
+    _test_equal(
+        bd_out.copy(),
+        py_out,
+        check_pandas_types=False,
+        sort_output=True,
+    )
 
 
 def _install_series_direct_tests():

--- a/bodo/tests/test_df_lib/test_direct_series_methods.py
+++ b/bodo/tests/test_df_lib/test_direct_series_methods.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from test_end_to_end import index_val  # noqa
 from test_series_generator import _generate_series_test
 
 import bodo.pandas as bd

--- a/bodo/tests/test_df_lib/test_direct_series_methods.py
+++ b/bodo/tests/test_df_lib/test_direct_series_methods.py
@@ -27,6 +27,7 @@ def test_series_isin(index_val, use_index1, use_index2):
 
         bd_out = bdf2["B"].isin(bdf1["A"])
 
+    bd_out.name = None  # Drop name to match pandas output
     _test_equal(
         bd_out.copy(),
         py_out,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -2189,15 +2189,14 @@ def test_series_concat(datapath):
 
 
 def test_isin(datapath):
-    bodo_df1 = bd.read_parquet(datapath("dataframe_library/df1.parquet"))
-    bodo_df2 = bd.read_parquet(datapath("dataframe_library/df2.parquet"))
-    bodo_df3 = (bodo_df1["D"] + 100).isin(bodo_df2["E"])
+    with assert_executed_plan_count(0):
+        bodo_df1 = bd.read_parquet(datapath("dataframe_library/df1.parquet"))
+        bodo_df2 = bd.read_parquet(datapath("dataframe_library/df2.parquet"))
+        bodo_df3 = (bodo_df1["D"] + 100).isin(bodo_df2["E"])
 
-    py_df1 = pd.read_parquet(datapath("dataframe_library/df1.parquet"))
-    py_df2 = pd.read_parquet(datapath("dataframe_library/df2.parquet"))
-    py_df3 = (py_df1["D"] + 100).isin(py_df2["E"])
-
-    assert bodo_df3.is_lazy_plan()
+        py_df1 = pd.read_parquet(datapath("dataframe_library/df1.parquet"))
+        py_df2 = pd.read_parquet(datapath("dataframe_library/df2.parquet"))
+        py_df3 = (py_df1["D"] + 100).isin(py_df2["E"])
 
     _test_equal(
         bodo_df3,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -2202,7 +2202,7 @@ def test_isin(datapath):
         bodo_df3,
         py_df3,
         check_pandas_types=False,
-        sort_output=False,
+        sort_output=True,
         reset_index=True,
     )
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1910,6 +1910,34 @@ def test_filter_source_matching():
     )
 
 
+def test_filter_series_isin():
+    """Test dataframe filter with isin case"""
+    with assert_executed_plan_count(0):
+        df1 = pd.DataFrame(
+            {
+                "A": [1.4, 2.1, 3.3],
+                "B": ["A", "B", "C"],
+                "C": [1, 2, 3],
+                "D": [True, False, True],
+            }
+        )
+        df2 = pd.DataFrame(
+            {
+                "A": ["A", "B", "C", "D"],
+                "B": [11, 2, 2, 4],
+            }
+        )
+
+        bdf1 = bd.from_pandas(df1)
+        bdf2 = bd.from_pandas(df2)
+        bodo_out = bdf1[bdf1.C.isin(bdf2.B)]
+        py_out = df1[df1.C.isin(df2.B)]
+
+    _test_equal(
+        bodo_out, py_out, check_pandas_types=False, sort_output=True, reset_index=True
+    )
+
+
 def test_rename(datapath, index_val):
     """Very simple test for df.apply() for sanity checking."""
     with assert_executed_plan_count(0):

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -2188,7 +2188,6 @@ def test_series_concat(datapath):
     )
 
 
-@pytest.mark.skip("disabled due to submit_func_to_workers: already running")
 def test_isin(datapath):
     bodo_df1 = bd.read_parquet(datapath("dataframe_library/df1.parquet"))
     bodo_df2 = bd.read_parquet(datapath("dataframe_library/df2.parquet"))

--- a/bodo/tests/test_df_lib/test_tpch.py
+++ b/bodo/tests/test_df_lib/test_tpch.py
@@ -48,7 +48,6 @@ def test_tpch_q03():
     run_tpch_query_test(tpch.tpch_q03)
 
 
-@pytest.mark.skip("hanging?")
 def test_tpch_q04():
     run_tpch_query_test(tpch.tpch_q04)
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Implements standalone Series.isin(Series) as a mark join and filter with isin as a semi-join which matches SQL behavior for things like EXIST subqueries. Fixes TPCH-Q4.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
New functionality per above.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.