### PR TITLE
Add PhysicalProjectionMetrics

### DIFF
--- a/bodo/pandas/physical/project.h
+++ b/bodo/pandas/physical/project.h
@@ -15,7 +15,6 @@
 struct PhysicalProjectionMetrics {
     using stat_t = MetricBase::StatValue;
     using time_t = MetricBase::TimerValue;
-    using blob_t = MetricBase::BlobValue;
     stat_t output_row_count = 0;
     stat_t n_exprs = 0;
 

--- a/bodo/tests/test_df_lib/test_query_profiler.py
+++ b/bodo/tests/test_df_lib/test_query_profiler.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pyarrow as pa
+
+import bodo.pandas as pd
+from bodo.tests.utils import temp_env_override
+
+
+def test_df_lib_project_metrics_collection(memory_leak_check, tmp_path):
+    """
+    Test that generated query profile has the metrics that we expect
+    to be reported by DataFrame library project.
+    """
+
+    df = pd.DataFrame(
+        {
+            "A": pa.array(list(np.arange(200)) * 160, type="Int64"),
+            "B": pa.array(
+                [None, "apple", "pie", "egg", "salad", "banana", "kiwi", "pudding"]
+                * 4000,
+                type=pa.dictionary(pa.int32(), pa.string()),
+            ),
+            "C": pa.array(list(np.arange(100)) * 320, type="Int64"),
+        }
+    )
+
+    with temp_env_override(
+        {"BODO_TRACING_LEVEL": "1", "BODO_TRACING_OUTPUT_DIR": str(tmp_path)}
+    ):
+        df["D"] = df["A"] + df["C"]
+        df.execute_plan()
+
+    # TODO check that the query profile is generated
+    # and the expected metrics are present
+    # with open(tmp_path / "query_profile.json") as f:
+    #    profile_json = json.load(f)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Integrate PhysicalProjection with the QueryProfiler
## Testing strategy
N/A
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Additional fields in query profiler
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.