### PR TITLE
[BSE-4984] Fix pd.read_iceberg().rename()

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -252,13 +252,17 @@ def read_iceberg(
         col_idxs = {
             arrow_schema.get_field_index(field_name) for field_name in selected_fields
         }
-        exprs = make_col_ref_exprs(col_idxs, plan)
         empty_df = empty_df[list(selected_fields)]
-        plan = LogicalProjection(
-            empty_df,
-            plan,
-            exprs,
-        )
+    else:
+        # Adds logical projection layer to enable rename.
+        col_idxs = range(len(empty_df.columns))
+
+    exprs = make_col_ref_exprs(col_idxs, plan)
+    plan = LogicalProjection(
+        empty_df,
+        plan,
+        exprs,
+    )
 
     if limit is not None:
         plan = LogicalLimit(

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -681,9 +681,23 @@ def test_rename():
     table = catalog.load_table("sf1000.nation")
 
     pdf = table.scan().to_pandas()
-    # pdf = pdf.rename(columns={'N_NATIONKEY': 'NATIONKEY', 'N_NAME': 'NAME', 'N_REGIONKEY': 'N_REGIONKEY', 'N_COMMENT': 'COMMENT'})
+    pdf = pdf.rename(
+        columns={
+            "N_NATIONKEY": "NATIONKEY",
+            "N_NAME": "NAME",
+            "N_REGIONKEY": "N_REGIONKEY",
+            "N_COMMENT": "COMMENT",
+        }
+    )
     bdf = bpd.read_iceberg_table(table)
-    # bdf = bdf.rename(columns={'N_NATIONKEY': 'NATIONKEY', 'N_NAME': 'NAME', 'N_REGIONKEY': 'N_REGIONKEY', 'N_COMMENT': 'COMMENT'})
+    bdf = bdf.rename(
+        columns={
+            "N_NATIONKEY": "NATIONKEY",
+            "N_NAME": "NAME",
+            "N_REGIONKEY": "N_REGIONKEY",
+            "N_COMMENT": "COMMENT",
+        }
+    )
 
     _test_equal(
         bdf,

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -670,7 +670,7 @@ def test_write_s3_tables_location():
         catalog.purge_table(table_id)
 
 
-def test_rename():
+def test_read_iceberg_rename():
     location = "arn:aws:s3tables:us-east-2:427443013497:bucket/tpch"
     region = "us-east-2"
     catalog_properties = {

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -668,3 +668,27 @@ def test_write_s3_tables_location():
     finally:
         # Clean up the table after the test
         catalog.purge_table(table_id)
+
+
+def test_rename():
+    location = "arn:aws:s3tables:us-east-2:427443013497:bucket/tpch"
+    region = "us-east-2"
+    catalog_properties = {
+        S3TABLES_TABLE_BUCKET_ARN: location,
+        S3TABLES_REGION: region,
+    }
+    catalog = S3TablesCatalog(None, **catalog_properties)
+    table = catalog.load_table("sf1000.nation")
+
+    pdf = table.scan().to_pandas()
+    # pdf = pdf.rename(columns={'N_NATIONKEY': 'NATIONKEY', 'N_NAME': 'NAME', 'N_REGIONKEY': 'N_REGIONKEY', 'N_COMMENT': 'COMMENT'})
+    bdf = bpd.read_iceberg_table(table)
+    # bdf = bdf.rename(columns={'N_NATIONKEY': 'NATIONKEY', 'N_NAME': 'NAME', 'N_REGIONKEY': 'N_REGIONKEY', 'N_COMMENT': 'COMMENT'})
+
+    _test_equal(
+        bdf,
+        pdf,
+        check_pandas_types=False,
+        sort_output=True,
+        reset_index=True,
+    )


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Iceberg read sets a custom `pa_schema` field due to metadata, which gets lost during plan object copy necessary for column renaming. 
This PR adds a projection layer in `read_iceberg` to preserve the schema and enable column renaming. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, adds rename tests to iceberg tests. 

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Renaming output DataFrame of read_iceberg is enabled. 

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.