### PR TITLE
[BSE-5017] Suppress DataFrame fallback warnings

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -206,6 +206,10 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             "attrs",
             "flags",
             "columns",
+            "ndim",
+            "axes",
+            "iloc",
+            "empty",
         ]
 
         cls = object.__getattribute__(self, "__class__")

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -68,6 +68,7 @@ from bodo.pandas.utils import (
     BodoLibFallbackWarning,
     BodoLibNotImplementedException,
     check_args_fallback,
+    fallback_wrapper,
     get_lazy_manager_class,
     get_n_index_arrays,
     get_scalar_udf_result_type,
@@ -205,10 +206,6 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             "attrs",
             "flags",
             "columns",
-            "ndim",
-            "axes",
-            "iloc",
-            "empty",
         ]
 
         cls = object.__getattribute__(self, "__class__")
@@ -225,7 +222,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             warnings.warn(BodoLibFallbackWarning(msg))
-            return object.__getattribute__(self, name)
+            return fallback_wrapper(self, object.__getattribute__(self, name))
 
         return object.__getattribute__(self, name)
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds `fallback_wrapper` to `BodoDataFrame.__getattribute__` to suppress fallback warnings caused by internal method calls.  

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.