### PR TITLE
Turn off verbose mode in CI

### DIFF
--- a/bodo/tests/conftest.py
+++ b/bodo/tests/conftest.py
@@ -25,6 +25,7 @@ import pytest
 from numba.core.runtime import rtsys
 
 import bodo
+import bodo.user_logging
 import bodo.utils.allocation_tracking
 from bodo.mpi4py import MPI
 from bodo.tests.iceberg_database_helpers.utils import DATABASE_NAME
@@ -905,3 +906,10 @@ def tmp_abfs_path(abfs_fs):
             abfs_fs.rm(f"engine-unit-tests-tmp-blob/{folder_name}", recursive=True)
 
     cleanup()
+
+
+@pytest.fixture(scope="module")
+def verbose_mode_on():
+    bodo.set_verbose_level(2)
+    yield
+    bodo.user_logging.restore_default_bodo_verbose_level()

--- a/bodo/tests/test_streaming/test_groupby_acc_regression.py
+++ b/bodo/tests/test_streaming/test_groupby_acc_regression.py
@@ -51,9 +51,6 @@ from bodo.utils.typing import ColNamesMetaType, MetaType
 # Skip for all CI
 pytestmark = pytest_perf_regression
 
-# Codegen change: turn verbose mode on
-bodo.set_verbose_level(2)
-
 global_2 = MetaType((0, 1, 2, 3, 4))
 global_3 = MetaType((0, 1, 2, 3))
 global_1 = MetaType((4,))
@@ -218,7 +215,7 @@ def impl(conn_str):  # Codegen change: add conn_str
 
 # Codegen change: call the function
 @pytest_mark_snowflake
-def test_simple_groupby_acc():
+def test_simple_groupby_acc(verbose_mode_on):
     # Get snowflake connection string from environment variables
     # (SF_USERNAME and SF_PASSWORD).
     # Use SF10 since that has sufficient data and compute,

--- a/bodo/tests/test_streaming/test_groupby_update_regression.py
+++ b/bodo/tests/test_streaming/test_groupby_update_regression.py
@@ -51,9 +51,6 @@ from bodo.utils.typing import ColNamesMetaType, MetaType
 # Skip for all CI
 pytestmark = pytest_perf_regression
 
-# Codegen change: turn verbose mode on
-bodo.set_verbose_level(2)
-
 global_2 = MetaType((0, 1, 2))
 global_3 = MetaType((1, 2))
 global_1 = MetaType((0,))
@@ -195,7 +192,7 @@ def impl(conn_str):  # Codegen change: add conn_str
 
 # Codegen change: call the function
 @pytest_mark_snowflake
-def test_simple_groupby_update():
+def test_simple_groupby_update(verbose_mode_on):
     # Get snowflake connection string from environment variables
     # (SF_USERNAME and SF_PASSWORD).
     # Use SF10 since that has sufficient data and compute,

--- a/bodo/tests/test_streaming/test_join_regression.py
+++ b/bodo/tests/test_streaming/test_join_regression.py
@@ -53,9 +53,6 @@ from bodo.utils.typing import ColNamesMetaType, MetaType
 # Skip for all CI
 pytestmark = pytest_perf_regression
 
-# Codegen change: turn verbose mode on
-bodo.set_verbose_level(2)
-
 global_2 = MetaType((0,))
 global_3 = ColNamesMetaType(("O_ORDERKEY", "O_CUSTKEY", "O_ORDERPRIORITY", "O_COMMENT"))
 global_1 = MetaType((0, 1, 5, 8))
@@ -314,7 +311,7 @@ def impl(conn_str):  # Codegen change: add conn_str
     "build_outer,probe_outer",
     [(False, False), (False, True), (True, False), (True, True)],
 )
-def test_simple_hash_join(build_outer, probe_outer):
+def test_simple_hash_join(build_outer, probe_outer, verbose_mode_on):
     # Reset the global variables as per the parametrized inputs
     global global_build_outer, global_probe_outer
     global_build_outer = build_outer

--- a/bodo/tests/test_streaming/test_nested_loop_join_regression.py
+++ b/bodo/tests/test_streaming/test_nested_loop_join_regression.py
@@ -73,9 +73,6 @@ from bodo.utils.typing import ColNamesMetaType, MetaType
 # Skip for all CI
 pytestmark = pytest_perf_regression
 
-# Codegen change: turn verbose mode on
-bodo.set_verbose_level(2)
-
 # Codegen change
 # @param: number of rows
 num_rows = 10000
@@ -978,7 +975,7 @@ def test_pure_nested_loop_join(build_outer, probe_outer):
     [(False, False), (False, True), (True, False), (True, True)],
 )
 # pure cross join without condition
-def test_nested_loop_join_unbalanced(build_outer, probe_outer):
+def test_nested_loop_join_unbalanced(build_outer, probe_outer, verbose_mode_on):
     # Reset the global variables as per the parametrized inputs
     global global_build_outer, global_probe_outer
     global_build_outer = build_outer


### PR DESCRIPTION
## Changes included in this PR

Spawn/DataFrame CI logs are polluted with verbose logging which is not necessary unless something in spawn mode is broken (maybe we can turn it on with a flag?). 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.