### PR TITLE
Add queryprofilecollector to read parquet.

### DIFF
--- a/bodo/pandas/physical/write_parquet.h
+++ b/bodo/pandas/physical/write_parquet.h
@@ -105,6 +105,8 @@ class PhysicalWriteParquet : public PhysicalSink {
     void Finalize() override {
         std::vector<MetricBase> metrics_out;
         this->ReportMetrics(metrics_out);
+        QueryProfileCollector::Default().SubmitOperatorName(getOpId(),
+                                                            ToString());
         QueryProfileCollector::Default().RegisterOperatorStageMetrics(
             QueryProfileCollector::MakeOperatorStageID(getOpId(), 1),
             std::move(metrics_out));


### PR DESCRIPTION
## Changes included in this PR

Collect statistics for read parquet reporting through the QueryProfileCollector mechanism.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.