### PR TITLE
BSE-5033: Add spawn process on workers

### DIFF
--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -414,6 +414,7 @@ from bodo.hiframes.pd_categorical_ext import (
 from bodo.utils.typing import register_type
 from bodo.libs.logging_ext import LoggingLoggerType
 from bodo.hiframes.table import TableType
+from bodo.spawn.spawner import spawn_process_on_workers, stop_process_on_workers
 
 
 import bodo.compiler  # isort:skip

--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -4564,11 +4564,10 @@ def bcast_impl(data, comm_ranks, root=DEFAULT_ROOT, comm=0):  # pragma: no cover
 node_ranks = None
 
 
-def get_host_ranks():  # pragma: no cover
+def get_host_ranks(comm: MPI.Comm = MPI.COMM_WORLD):  # pragma: no cover
     """Get dict holding hostname and its associated ranks"""
     global node_ranks
     if node_ranks is None:
-        comm = MPI.COMM_WORLD
         hostname = MPI.Get_processor_name()
         rank_host = comm.allgather(hostname)
         node_ranks = defaultdict(list)
@@ -4586,9 +4585,9 @@ def create_subcomm_mpi4py(comm_ranks):  # pragma: no cover
     return new_comm
 
 
-def get_nodes_first_ranks():  # pragma: no cover
+def get_nodes_first_ranks(comm: MPI.Comm = MPI.COMM_WORLD):  # pragma: no cover
     """Get first rank in each node"""
-    host_ranks = get_host_ranks()
+    host_ranks = get_host_ranks(comm)
     return np.array([ranks[0] for ranks in host_ranks.values()], dtype="int32")
 
 

--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -896,7 +896,9 @@ def spawn_process_on_workers(
     cwd: str | None = None,
 ) -> WorkerProcess:
     """Get the global spawner and spawn a process on all workers and returns a WorkerProcess object"""
-    assert bodo.spawn_mode, "Cannot spawn worker processes outside of Bodo spawn mode"
+    assert bodo.spawn_mode or bodo.tests.utils.test_spawn_mode_enabled, (
+        "Cannot spawn worker processes outside of Bodo spawn mode"
+    )
 
     spawner = get_spawner()
     return spawner.spawn_process_on_workers(command, env, cwd)

--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -896,9 +896,6 @@ def spawn_process_on_workers(
     cwd: str | None = None,
 ) -> WorkerProcess:
     """Get the global spawner and spawn a process on all workers and returns a WorkerProcess object"""
-    assert bodo.spawn_mode or bodo.tests.utils.test_spawn_mode_enabled, (
-        "Cannot spawn worker processes outside of Bodo spawn mode"
-    )
 
     spawner = get_spawner()
     return spawner.spawn_process_on_workers(command, env, cwd)

--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -833,8 +833,10 @@ class Spawner:
         assert not self._is_running, "spawn_process_on_workers: already running"
 
         self._is_running = True
-        self.worker_intercomm.bcast(CommandType.SPAWN_PROCESS.value, self.bcast_root)
-        self.worker_intercomm.bcast((command, env, cwd), self.bcast_root)
+        self.worker_intercomm.bcast(
+            CommandType.SPAWN_PROCESS.value, root=self.bcast_root
+        )
+        self.worker_intercomm.bcast((command, env, cwd), root=self.bcast_root)
         worker_process = self.worker_intercomm.recv(source=0)
         self._is_running = False
         self._run_del_queue()
@@ -845,8 +847,11 @@ class Spawner:
         assert not self._is_running, "stop_process_on_workers: already running"
 
         self._is_running = True
-        self.worker_intercomm.bcast(CommandType.STOP_PROCESS.value, self.bcast_root)
-        self.worker_intercomm.bcast(worker_process, self.bcast_root)
+        self.worker_intercomm.bcast(
+            CommandType.STOP_PROCESS.value, root=self.bcast_root
+        )
+        self.worker_intercomm.bcast(worker_process, root=self.bcast_root)
+        self.worker_intercomm.recv(source=0)  # Wait for confirmation
         self._is_running = False
         self._run_del_queue()
 

--- a/bodo/spawn/utils.py
+++ b/bodo/spawn/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import typing as pt
+import uuid
 from enum import Enum
 from time import sleep
 
@@ -25,6 +26,8 @@ class CommandType(str, Enum):
     DELETE_RESULT = "delete_result"
     REGISTER_TYPE = "register_type"
     SET_CONFIG = "set_config"
+    SPAWN_PROCESS = "spawn_process"
+    STOP_PROCESS = "stop_process"
 
 
 def poll_for_barrier(comm: MPI.Comm, poll_freq: float | None = 0.1):
@@ -77,3 +80,13 @@ def set_global_config(config_name: str, config_value: pt.Any):
     exec(f"import {mod_name}; mod = {mod_name}", globals(), locs)
     mod = locs["mod"]
     setattr(mod, attr, config_value)
+
+
+class WorkerProcess:
+    _uuid: uuid.UUID
+    _rank_to_pid: dict[int, int] = {}
+
+    def __init__(self, rank_to_pid: dict[int, int] = {}):
+        """Initialize WorkerProcess with a mapping of ranks to PIDs."""
+        self._uuid = uuid.uuid4()
+        self._rank_to_pid = rank_to_pid

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -485,9 +485,7 @@ def handle_spawn_process(
     """Handle spawning a new process and return the process handle"""
     pid = None
     popen = None
-    if bodo.get_rank() not in bodo.libs.distributed_api.get_nodes_first_ranks(
-        comm_world
-    ):
+    if bodo.get_rank() in bodo.libs.distributed_api.get_nodes_first_ranks(comm_world):
         debug_worker_msg(logger, f"Spawning process with command {command}")
         popen = subprocess.Popen(
             command,

--- a/bodo/spawn/worker.py
+++ b/bodo/spawn/worker.py
@@ -8,6 +8,7 @@ import logging
 import os
 import signal
 import socket
+import subprocess
 import sys
 import typing as pt
 import uuid
@@ -33,6 +34,7 @@ from bodo.spawn.spawner import BodoSQLContextMetadata, env_var_prefix
 from bodo.spawn.utils import (
     ArgMetadata,
     CommandType,
+    WorkerProcess,
     debug_msg,
     poll_for_barrier,
     set_global_config,
@@ -104,6 +106,7 @@ def _recv_arg(
 
 
 RESULT_REGISTRY: dict[str, pt.Any] = {}
+PROCESS_REGISTRY: dict[uuid.UUID, subprocess.Popen | None] = {}
 
 # Once >3.12 is our minimum version we can use the below instead
 # type is_distributed_t = bool + list[is_distributed_t] | tuple[is_distributed_t]
@@ -472,6 +475,79 @@ def exec_func_handler(
     os.environ = original_env_var
 
 
+def handle_spawn_process(
+    command: str | list[str],
+    env: dict[str, str],
+    cwd: str | None,
+    comm_world: MPI.Intracomm,
+    logger: logging.Logger,
+):
+    """Handle spawning a new process and return the process handle"""
+    debug_worker_msg(logger, f"Spawning process with command {command}")
+    pid = None
+    popen = None
+    if bodo.get_rank() not in bodo.libs.distributed_api.get_nodes_first_rank():
+        popen = subprocess.Popen(
+            command,
+            env=env,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        pid = popen.pid
+        debug_worker_msg(logger, f"Spawned process with pid {pid}")
+    ranks_to_pids = comm_world.gather((bodo.get_rank(), pid), root=0)
+
+    worker_process = None
+    if bodo.get_rank() == 0:
+        ranks_to_pids = {r: p for r, p in ranks_to_pids if p is not None}
+
+        worker_process = WorkerProcess(ranks_to_pids)
+
+    worker_process = comm_world.bcast(worker_process, root=0)
+
+    PROCESS_REGISTRY[worker_process._uuid] = popen
+    return worker_process
+
+
+def handle_stop_process(
+    worker_process: WorkerProcess,
+    logger: logging.Logger,
+):
+    """Handle stopping a process and return the process handle"""
+    debug_worker_msg(logger, f"Stopping process with uuid {worker_process._uuid}")
+    if worker_process._uuid not in PROCESS_REGISTRY:
+        raise ValueError(f"Process with uuid {worker_process._uuid} not found")
+
+    popen = PROCESS_REGISTRY.pop(worker_process._uuid)
+    # The process is managed by a different rank
+    if popen is None:
+        return
+
+    if popen.poll() is None:
+        debug_worker_msg(logger, f"Killing process with pid {popen.pid}")
+        popen.terminate()
+        # Wait for the process to terminate
+        try:
+            popen.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            debug_worker_msg(
+                logger, f"Process with pid {popen.pid} did not stop in time"
+            )
+            # If the process does not stop, we can try to forcefully terminate it
+            popen.kill()
+            debug_worker_msg(
+                logger, f"Process with pid {popen.pid} forcefully terminated"
+            )
+        else:
+            debug_worker_msg(
+                logger, f"Process with pid {popen.pid} stopped successfully"
+            )
+    else:
+        debug_worker_msg(logger, f"Process with pid {popen.pid} already stopped")
+
+
 class StdoutQueue:
     """Replacement for stdout/stderr that sends output to the spawner via a ZeroMQ socket."""
 
@@ -539,6 +615,11 @@ def worker_loop(
             debug_worker_msg(logger, "Exiting...")
             if out_socket:
                 out_socket.close()
+
+            for worker_process_uuid in PROCESS_REGISTRY.keys():
+                worker_process = WorkerProcess()
+                worker_process._uuid = worker_process_uuid
+                handle_stop_process(worker_process, logger)
             return
         elif command == CommandType.BROADCAST.value:
             bodo.libs.distributed_api.bcast(None, root=0, comm=spawner_intercomm)
@@ -573,6 +654,12 @@ def worker_loop(
             (config_name, config_value) = spawner_intercomm.bcast(None, 0)
             set_global_config(config_name, config_value)
             debug_worker_msg(logger, f"Set config {config_name}={config_value}")
+        elif command == CommandType.SPAWN_PROCESS.value:
+            command, env, cwd = spawner_intercomm.bcast(None, 0)
+            return handle_spawn_process(command, env, cwd, comm_world, logger)
+        elif command == CommandType.STOP_PROCESS.value:
+            worker_process = spawner_intercomm.bcast(None, 0)
+            return handle_stop_process(worker_process, logger)
         else:
             raise ValueError(f"Unsupported command '{command}!")
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title, adds method to start and stop processes on spawned workers

## Testing strategy
New test
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
N/A, will add docs/example when the embedding/generation are merged
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.