### PR TITLE
[BSE-5004] Match auto-generated method output dtype to pandas

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -2296,11 +2296,11 @@ def _get_series_func_plan(
         n_cols, n_cols + get_n_index_arrays(source_data.empty_data.index)
     )
 
-    if func in {"dt.dayofweek", "dt.hour", "dt.month", "dt.date"}:
+    if func in {"dt.dayofweek", "dt.day_of_week", "dt.hour", "dt.month", "dt.date"}:
         if func == "dt.dayofweek":
             func = "dt.day_of_week"
         func_name = func.split(".")[1]
-        func_args = ()  # TODO: expand on this to enable arrow compute calls with args
+        func_args = ()  # TODO: expand this to enable arrow compute calls with args
         is_cfunc = False
         has_state = False
         expr = ArrowScalarFuncExpression(
@@ -2753,31 +2753,31 @@ series_str_methods = [
 dt_accessors = [
     # idx = 0: Series(Int64)
     (
-        # NOTE: These methods are int32 for regular types in Pandas but int64 for
-        # ArrowDtype as of Pandas 2.3.
+        # NOTE: The methods below (e.g., hour, month, dayofweek) return int32 in Pandas by default.
+        # In Bodo, the output dtype is int64 because we use PyArrow Compute.
         [
-            "year",
-            "month",
-            "day",
             "hour",
-            "minute",
-            "second",
-            "microsecond",
-            "nanosecond",
+            "month",
             "dayofweek",
             "day_of_week",
-            "weekday",
-            "dayofyear",
-            "day_of_year",
-            "daysinmonth",
-            "days_in_month",
-            "quarter",
         ],
         pd.ArrowDtype(pa.int64()),
     ),
     # idx = 0: Series(Int32)
     (
         [
+            "quarter",
+            "year",
+            "day",
+            "minute",
+            "second",
+            "microsecond",
+            "nanosecond",
+            "weekday",
+            "dayofyear",
+            "day_of_year",
+            "daysinmonth",
+            "days_in_month",
             "days",
             "seconds",
             "microseconds",


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Change output dtypes of a subset of auto-generated dt accessors, `dt.quarter`, `dt.days` to name a few, from int64 to int32 to match pandas behavior. `dt.hour`, `dt.month`, and `dt.dayofweek` are exceptions, since they are processed via Arrow Compute, which returns int64. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, covered by existing unit tests.
## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
BodoSeries behavior matches pandas behavior more closely. 

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.