### PR TITLE
Expand Arrow computed Series methods

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -2314,7 +2314,21 @@ def _get_series_func_plan(
         "dt.weekday",
         "dt.dayofyear",
         "dt.day_of_year",
-        # TODO: consider including methods like str.islower and routing to ascii_is_*
+        # string methods that correspond to utf8_{name}
+        "str.isalnum",
+        "str.isalpha",
+        "str.isdecimal",
+        "str.isdigit",
+        "str.isnumeric",
+        "str.isupper",
+        "str.isspace",
+        "str.capitalize",
+        "str.length",
+        "str.lower",
+        "str.upper",
+        "str.swapcase",
+        "str.title",
+        "str.reverse",
     )
 
     def get_arrow_func(name):
@@ -2323,6 +2337,11 @@ def _get_series_func_plan(
             return "day_of_week"
         if name == "dt.dayofyear":
             return "day_of_year"
+        if name.startswith("str.is"):
+            body = name.split(".")[1]
+            return "utf8_" + body[:2] + "_" + body[2:]
+        if name.startswith("str."):
+            return "utf8_" + name.split(".")[1]
         return name.split(".")[1]
 
     if func in arrow_compute_list:

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -2780,7 +2780,7 @@ series_str_methods = [
 dt_accessors = [
     # idx = 0: Series(Int64)
     (
-        # NOTE: The methods below (e.g., hour, month, dayofweek) return int32 in Pandas by default.
+        # NOTE: The methods below return int32 in Pandas by default.
         # In Bodo, the output dtype is int64 because we use PyArrow Compute.
         [
             "hour",


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Route all Arrow Compute-supported Series.dt accessors and Series.str methods with no arguments to Arrow Compute path (`ArrowScalarFuncExpression`). 
For Series.str methods, `utf8_{method_name}` methods in Arrow Compute are selected, which is safer than `ascii_{method_name}` counterparts since the latter fails on non-ascii values. 

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
PR CI, existing test covers all changes. 

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Slight performance enhancement of Series.dt accessors. 
## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.