### PR TITLE
Make Snowflake connector import lazy

### DIFF
--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -325,7 +325,6 @@ import bodo.io
 import bodo.io.np_io
 import bodo.io.csv_iterator_ext
 import bodo.io.iceberg
-import bodo.io.snowflake_write
 import bodo.io.iceberg.stream_iceberg_write
 import bodo.io.stream_parquet_write
 

--- a/bodo/libs/streaming/base.py
+++ b/bodo/libs/streaming/base.py
@@ -68,3 +68,43 @@ class StreamingStateType(types.Type):
                 raise numba.NumbaError(
                     f"{fn_name}: unknown input table type in streaming state"
                 )
+
+
+def is_streaming_build_funcs(func):
+    """
+    Check if a function is a streaming build function (join/groupby/IO etc.).
+    Imports are in this function to make them lazy (since not necessary in DataFrame
+    library).
+    """
+
+    from bodo.io.iceberg.stream_iceberg_write import iceberg_writer_append_table
+    from bodo.io.snowflake_write import snowflake_writer_append_table
+    from bodo.io.stream_parquet_write import parquet_writer_append_table
+    from bodo.libs.streaming.groupby import (
+        groupby_build_consume_batch,
+        groupby_grouping_sets_build_consume_batch,
+    )
+    from bodo.libs.streaming.join import (
+        join_build_consume_batch,
+        join_probe_consume_batch,
+    )
+    from bodo.libs.streaming.sort import sort_build_consume_batch
+    from bodo.libs.streaming.union import union_consume_batch
+    from bodo.libs.streaming.window import window_build_consume_batch
+    from bodo.libs.table_builder import table_builder_append
+
+    streaming_build_funcs = (
+        groupby_build_consume_batch,
+        groupby_grouping_sets_build_consume_batch,
+        join_build_consume_batch,
+        join_probe_consume_batch,
+        window_build_consume_batch,
+        union_consume_batch,
+        table_builder_append,
+        sort_build_consume_batch,
+        snowflake_writer_append_table,
+        iceberg_writer_append_table,
+        parquet_writer_append_table,
+    )
+
+    return func in streaming_build_funcs

--- a/bodo/numba_compat.py
+++ b/bodo/numba_compat.py
@@ -2935,36 +2935,7 @@ numba.core.lowering.Lower._lower_call_ExternalFunction = _lower_call_ExternalFun
 def CallConstraint_resolve(self, typeinfer, typevars, fnty):
     from bodo.transforms.type_inference.native_typer import bodo_resolve_call
     from bodo.transforms.type_inference.typeinfer import BodoFunction
-    from bodo.libs.streaming.base import StreamingStateType
-    from bodo.libs.streaming.groupby import (
-        groupby_build_consume_batch,
-        groupby_grouping_sets_build_consume_batch,
-    )
-    from bodo.libs.streaming.join import (
-        join_build_consume_batch,
-        join_probe_consume_batch,
-    )
-    from bodo.libs.streaming.window import window_build_consume_batch
-    from bodo.libs.streaming.union import union_consume_batch
-    from bodo.libs.streaming.sort import sort_build_consume_batch
-    from bodo.libs.table_builder import table_builder_append
-    from bodo.io.snowflake_write import snowflake_writer_append_table
-    from bodo.io.iceberg.stream_iceberg_write import iceberg_writer_append_table
-    from bodo.io.stream_parquet_write import parquet_writer_append_table
-
-    streaming_build_funcs = (
-        groupby_build_consume_batch,
-        groupby_grouping_sets_build_consume_batch,
-        join_build_consume_batch,
-        join_probe_consume_batch,
-        window_build_consume_batch,
-        union_consume_batch,
-        table_builder_append,
-        sort_build_consume_batch,
-        snowflake_writer_append_table,
-        iceberg_writer_append_table,
-        parquet_writer_append_table,
-    )
+    from bodo.libs.streaming.base import StreamingStateType, is_streaming_build_funcs
 
     assert fnty
     context = typeinfer.context
@@ -2980,7 +2951,7 @@ def CallConstraint_resolve(self, typeinfer, typevars, fnty):
         # Forbids imprecise type except array of undefined dtype
         if not a.is_precise() and not isinstance(a, types.Array):
             # Bodo change: allow streaming state type to be imprecise
-            if getattr(fnty, "typing_key", None) in streaming_build_funcs and isinstance(a, StreamingStateType):
+            if isinstance(a, StreamingStateType) and is_streaming_build_funcs(getattr(fnty, "typing_key", None)):
                 continue
             return
 
@@ -3041,7 +3012,7 @@ def CallConstraint_resolve(self, typeinfer, typevars, fnty):
     typeinfer.add_type(self.target, sig.return_type, loc=self.loc)
 
     # Bodo change: update streaming state type
-    if getattr(fnty, "typing_key", None) in streaming_build_funcs and pos_args[0] != sig.args[0]:
+    if pos_args[0] != sig.args[0] and is_streaming_build_funcs(getattr(fnty, "typing_key", None)):
         typeinfer.add_type(self.args[0].name, sig.args[0], loc=self.loc)
 
     # If the function is a bound function and its receiver type


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Reduces import time for a bit for dataframe library use.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Just import time.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.