### PR TITLE
Make Iceberg import lazy

### DIFF
--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -324,9 +324,7 @@ import bodo.io
 # Rexport HDFS Locations
 import bodo.io.np_io
 import bodo.io.csv_iterator_ext
-import bodo.io.iceberg
 import bodo.io.snowflake_write
-import bodo.io.iceberg.stream_iceberg_write
 import bodo.io.stream_parquet_write
 
 from bodo.libs.distributed_api import (

--- a/bodo/io/iceberg/write.py
+++ b/bodo/io/iceberg/write.py
@@ -57,13 +57,7 @@ except ImportError:
     Transaction = None
 
 this_module = sys.modules[__name__]
-_, iceberg_catalog_type = install_py_obj_class(
-    types_name="iceberg_catalog_type",
-    module=this_module,
-    python_type=Catalog,
-    class_name="IcebergCatalogType",
-    model_name="IcebergCatalogModel",
-)
+
 _, transaction_type = install_py_obj_class(
     types_name="transaction_type",
     module=this_module,

--- a/bodo/ir/iceberg_ext.py
+++ b/bodo/ir/iceberg_ext.py
@@ -937,9 +937,9 @@ class IcebergFilterVisitor(FilterVisitor[str]):
         A string representation of the FilterExpr object.
     """
 
-    import pyiceberg.expressions as pie
-
     def __init__(self, filter_map):
+        import pyiceberg.expressions as pie  # noqa
+
         self.filter_map = filter_map
 
     def visit_scalar(self, scalar: bif.Scalar) -> str:

--- a/bodo/ir/iceberg_ext.py
+++ b/bodo/ir/iceberg_ext.py
@@ -875,12 +875,6 @@ def get_filters_pyobject(filter_str, vars):  # pragma: no cover
     pass
 
 
-try:
-    import pyiceberg.expressions as pie
-except ImportError:
-    pie = None
-
-
 def literal(val) -> Literal:
     """
     Wrapper over PyIceberg's literal function for constructing filters.
@@ -902,8 +896,7 @@ def literal(val) -> Literal:
 @overload(get_filters_pyobject, no_unliteral=True)
 def overload_get_filters_pyobject(filters_str, var_tup):
     """generate a pyobject for filter expression to pass to C++"""
-    if pie is None:
-        raise_bodo_error("pyiceberg not found")
+    import pyiceberg.expressions as pie
 
     filter_str_val = get_overload_const_str(filters_str)
     var_unpack = ", ".join(f"f{i}" for i in range(len(var_tup)))
@@ -943,6 +936,8 @@ class IcebergFilterVisitor(FilterVisitor[str]):
     Returns:
         A string representation of the FilterExpr object.
     """
+
+    import pyiceberg.expressions as pie
 
     def __init__(self, filter_map):
         self.filter_map = filter_map
@@ -1059,7 +1054,7 @@ def add_rtjf_iceberg_filter(
     """
     For each column in filtered_cols create a FilterExpr containing it's bounds and combine them all with file_filters
     """
-    assert pie is not None
+    import pyiceberg.expressions as pie
 
     is_empty = bodo.ir.sql_ext.is_empty_build_table(state_var)
     with bodo.no_warning_objmode(combined_filters="parquet_predicate_type"):

--- a/bodo/ir/iceberg_ext.py
+++ b/bodo/ir/iceberg_ext.py
@@ -27,8 +27,6 @@ from bodo.hiframes.table import TableType
 from bodo.io import arrow_cpp  # type: ignore
 from bodo.io.arrow_reader import ArrowReaderType
 from bodo.io.helpers import pyarrow_schema_type, pyiceberg_catalog_type
-from bodo.io.iceberg.catalog import conn_str_to_catalog
-from bodo.io.iceberg.common import IcebergConnectionType
 from bodo.io.parquet_pio import ParquetFilterScalarsListType, ParquetPredicateType
 from bodo.ir.connector import Connector, log_limit_pushdown
 from bodo.ir.filter import Filter, FilterVisitor
@@ -603,6 +601,8 @@ def iceberg_distributed_run(
     is_independent: bool = False,
     meta_head_only_info=None,
 ):
+    from bodo.io.iceberg.common import IcebergConnectionType
+
     # Add debug info about column pruning
     if bodo.user_logging.get_verbose_level() >= 1:
         op_id_msg = (
@@ -1223,6 +1223,8 @@ def _gen_iceberg_reader_chunked_py(
         This is used for "remapping" the build columns in rtjf_interval_cols to the
         correct indices.
     """
+    from bodo.io.iceberg.catalog import conn_str_to_catalog
+
     source_pyarrow_schema = pyarrow_schema
     assert source_pyarrow_schema is not None, (
         "SQLReader node must contain a source_pyarrow_schema if reading from Iceberg"
@@ -1454,6 +1456,8 @@ def _gen_iceberg_reader_py(
         dict_encode_in_bodo: Whether the dict-encoding should be done in Bodo
             instead of Arrow.
     """
+    from bodo.io.iceberg.catalog import conn_str_to_catalog
+
     # a unique int used to create global variables with unique names
     call_id = next_label()
 

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -468,6 +468,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         import pyiceberg.partitioning
         import pyiceberg.table.sorting
 
+        import bodo.io.iceberg
+        import bodo.io.iceberg.stream_iceberg_write
         from bodo.pandas.base import _empty_like
         from bodo.utils.typing import CreateTableMetaType
 

--- a/bodo/transforms/typing_pass.py
+++ b/bodo/transforms/typing_pass.py
@@ -3747,6 +3747,8 @@ class TypingTransforms:
         self, assign: ir.Assign, rhs: ir.Expr, func_name, label
     ):
         """transform pd.read_sql_table into a SQL node"""
+        import bodo.io.iceberg
+
         func_str = "pandas.read_sql_table"
         lhs = assign.target
         kws = dict(rhs.kws)

--- a/bodo/utils/pandas_coverage_tracking.py
+++ b/bodo/utils/pandas_coverage_tracking.py
@@ -4,6 +4,7 @@ This script will be run during the import bodo step if specified by _check_panda
 """
 
 import numba
+import requests
 from numba.core.target_extension import dispatcher_registry
 
 from bodo.pandas_compat import _check_pandas_change
@@ -32,7 +33,6 @@ PANDAS_URLS: dict[str, str] = {
 
 def get_pandas_refs_from_url(url: str) -> list:
     """Gets all API refs from an index page `url`."""
-    import requests
     from bs4 import BeautifulSoup
 
     result = []

--- a/bodo/utils/pandas_coverage_tracking.py
+++ b/bodo/utils/pandas_coverage_tracking.py
@@ -4,7 +4,6 @@ This script will be run during the import bodo step if specified by _check_panda
 """
 
 import numba
-import requests
 from numba.core.target_extension import dispatcher_registry
 
 from bodo.pandas_compat import _check_pandas_change
@@ -33,6 +32,7 @@ PANDAS_URLS: dict[str, str] = {
 
 def get_pandas_refs_from_url(url: str) -> list:
     """Gets all API refs from an index page `url`."""
+    import requests
     from bs4 import BeautifulSoup
 
     result = []


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Reduces import time for a bit for dataframe library use.

## Testing strategy

Ran some Iceberg tests manually (DF/JIT/SQL) since Iceberg test are disabled on CI.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Just import time.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.