### PR TITLE
BSE-5058: Fix llm_generate and embed in Jupyter

### DIFF
--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1572,7 +1572,7 @@ class BodoSeriesAiMethods:
                         lambda: pd.Series(
                             asyncio.run(all_tasks(series, client, generation_kwargs))
                         )
-                    )
+                    ).result()
             except RuntimeError:
                 # If no running loop, run the async function directly
                 return pd.Series(
@@ -1719,7 +1719,7 @@ class BodoSeriesAiMethods:
                         lambda: pd.Series(
                             asyncio.run(all_tasks(series, client, embedding_kwargs))
                         )
-                    )
+                    ).result()
             except RuntimeError:
                 # If no running loop, run the async function directly
                 return pd.Series(

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1565,16 +1565,22 @@ class BodoSeriesAiMethods:
                 tasks = [per_row(row, client, generation_kwargs) for row in series]
                 return await asyncio.gather(*tasks, return_exceptions=True)
 
+            # Check if there is a running event loop to determine if we need to run in a thread pool
+            # or if we can run the async function directly.
+            run_in_threadpool = False
             try:
                 asyncio.get_running_loop()
+                run_in_threadpool = True
+            except RuntimeError:
+                pass
+            if run_in_threadpool:
                 with ThreadPoolExecutor(1) as pool:
                     return pool.submit(
                         lambda: pd.Series(
                             asyncio.run(all_tasks(series, client, generation_kwargs))
                         )
                     ).result()
-            except RuntimeError:
-                # If no running loop, run the async function directly
+            else:
                 return pd.Series(
                     asyncio.run(all_tasks(series, client, generation_kwargs))
                 )
@@ -1712,16 +1718,22 @@ class BodoSeriesAiMethods:
                 tasks = [per_row(row, client, embedding_kwargs) for row in series]
                 return await asyncio.gather(*tasks, return_exceptions=True)
 
+            # Check if there is a running event loop to determine if we need to run in a thread pool
+            # or if we can run the async function directly.
+            run_in_threadpool = False
             try:
                 asyncio.get_running_loop()
+                run_in_threadpool = True
+            except RuntimeError:
+                pass
+            if run_in_threadpool:
                 with ThreadPoolExecutor(1) as pool:
                     return pool.submit(
                         lambda: pd.Series(
                             asyncio.run(all_tasks(series, client, embedding_kwargs))
                         )
                     ).result()
-            except RuntimeError:
-                # If no running loop, run the async function directly
+            else:
                 return pd.Series(
                     asyncio.run(all_tasks(series, client, embedding_kwargs))
                 )


### PR DESCRIPTION
## Changes included in this PR
Jupyter already uses an asyncio event loop running which means we can't use asyncio.run. If we detect a running event loop just run the coroutines in a new thread.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Existing tests
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
As title
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.