### PR TITLE
Disable native type inference code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,29 +507,32 @@ if(NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
 endif()
 install(TARGETS memory_tester DESTINATION "bodo/tests/")
 
-# ---------------------- Cython Target - bodo.transforms.type_inference.native_typer -----------------------
-add_custom_command(
-  OUTPUT bodo/transforms/type_inference/native_typer.cpp
-  DEPENDS bodo/transforms/type_inference/native_typer.pyx
-  VERBATIM
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  COMMAND "${CYTHON_EXECUTABLE}" --cplus -3 --output-file "bodo/transforms/type_inference/native_typer.cpp" "bodo/transforms/type_inference/native_typer.pyx"
-  COMMAND "${CMAKE_COMMAND}" -E copy "bodo/transforms/type_inference/native_typer.cpp" "${CMAKE_CURRENT_BINARY_DIR}/bodo/transforms/type_inference/native_typer.cpp"
-  COMMENT "Cythonizing Source bodo/transforms/type_inference/native_typer.pyx into bodo/transforms/type_inference/native_typer.cpp"
-)
 
-python_add_library(
-  native_typer
-  MODULE WITH_SOABI
-    "bodo/transforms/type_inference/native_typer.cpp"
-    "bodo/transforms/type_inference/type.cpp"
-    "bodo/transforms/type_inference/typeinfer.cpp"
-    "bodo/transforms/type_inference/ir.cpp"
-)
-target_include_directories(native_typer PRIVATE ${BASE_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}/bodo/transforms/type_inference/" "${CMAKE_CURRENT_BINARY_DIR}/bodo/transforms/type_inference/")
-target_link_directories(native_typer PRIVATE ${CONDA_LIB_DIR})
-target_link_libraries(native_typer PRIVATE fmt::fmt)
-install(TARGETS native_typer DESTINATION "bodo/transforms/type_inference/")
+# TODO[BSE-5071]: Re-enable native typer when its coverage improved
+# # ---------------------- Cython Target - bodo.transforms.type_inference.native_typer -----------------------
+# add_custom_command(
+#   OUTPUT bodo/transforms/type_inference/native_typer.cpp
+#   DEPENDS bodo/transforms/type_inference/native_typer.pyx
+#   VERBATIM
+#   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+#   COMMAND "${CYTHON_EXECUTABLE}" --cplus -3 --output-file "bodo/transforms/type_inference/native_typer.cpp" "bodo/transforms/type_inference/native_typer.pyx"
+#   COMMAND "${CMAKE_COMMAND}" -E copy "bodo/transforms/type_inference/native_typer.cpp" "${CMAKE_CURRENT_BINARY_DIR}/bodo/transforms/type_inference/native_typer.cpp"
+#   COMMENT "Cythonizing Source bodo/transforms/type_inference/native_typer.pyx into bodo/transforms/type_inference/native_typer.cpp"
+# )
+
+# python_add_library(
+#   native_typer
+#   MODULE WITH_SOABI
+#     "bodo/transforms/type_inference/native_typer.cpp"
+#     "bodo/transforms/type_inference/type.cpp"
+#     "bodo/transforms/type_inference/typeinfer.cpp"
+#     "bodo/transforms/type_inference/ir.cpp"
+# )
+# target_include_directories(native_typer PRIVATE ${BASE_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}/bodo/transforms/type_inference/" "${CMAKE_CURRENT_BINARY_DIR}/bodo/transforms/type_inference/")
+# target_link_directories(native_typer PRIVATE ${CONDA_LIB_DIR})
+# target_link_libraries(native_typer PRIVATE fmt::fmt)
+# install(TARGETS native_typer DESTINATION "bodo/transforms/type_inference/")
+
 
 # ---------------------- Cython Target - plan_optimizer -----------------------
 add_custom_command(

--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -121,8 +121,10 @@ ll.add_symbol("broadcast_table_py_entry", hdist.broadcast_table_py_entry)
 
 DEFAULT_ROOT = 0
 
+
 # Wrapper for getting process rank from C (MPI rank currently)
-get_rank = hdist.get_rank_py_wrapper
+def get_rank():
+    return hdist.get_rank_py_wrapper()
 
 
 # XXX same as _distributed.h::BODO_ReduceOps::ReduceOpsEnum
@@ -147,6 +149,11 @@ _get_size = types.ExternalFunction("c_get_size", types.int32())
 _barrier = types.ExternalFunction("c_barrier", types.int32())
 _get_cpu_id = types.ExternalFunction("get_cpu_id", types.int32())
 get_remote_size = types.ExternalFunction("c_get_remote_size", types.int32(types.int64))
+
+
+@infer_global(get_rank)
+class GetRankInfer(ConcreteTemplate):
+    cases = [signature(types.int32)]
 
 
 @lower_builtin(

--- a/bodo/tests/test_compiler/test_ir.py
+++ b/bodo/tests/test_compiler/test_ir.py
@@ -5,7 +5,8 @@ from numba.core import ir
 
 import bodo
 
-pytestmarker = pytest.mark.compiler
+# TODO[BSE-5071]: Re-enable native typer when its coverage improved
+pytestmark = [pytest.mark.compiler, pytest.mark.skip]
 
 
 def normalize_ir(fir: ir.FunctionIR):

--- a/bodo/tests/test_compiler/test_native_type_inference.py
+++ b/bodo/tests/test_compiler/test_native_type_inference.py
@@ -12,9 +12,9 @@ from bodo.tests.user_logging_utils import (
     set_logging_stream,
 )
 from bodo.tests.utils import check_func
-from bodo.transforms.type_inference.native_typer import check_compatible_types
 
-pytestmark = pytest.mark.compiler
+# TODO[BSE-5071]: Re-enable native typer when its coverage improved
+pytestmark = [pytest.mark.compiler, pytest.mark.skip]
 
 
 def check_native_type_inferrer(impl, args):
@@ -97,6 +97,7 @@ def test_conversion_rules(memory_leak_check):
     """
     Make sure conversion rules are initialized correctly in native typer
     """
+    from bodo.transforms.type_inference.native_typer import check_compatible_types
 
     conv = check_compatible_types(types.boolean, types.int8)
     assert conv == Conversion.safe, (

--- a/bodo/transforms/type_inference/typeinfer.py
+++ b/bodo/transforms/type_inference/typeinfer.py
@@ -1,4 +1,3 @@
-import numba
 from numba.core.typing.templates import (
     AbstractTemplate,
     Registry,
@@ -51,5 +50,6 @@ class BodoRegistry(Registry):
         self.function_map["bodo.get_rank"] = func_type
 
 
-bodo_registry = BodoRegistry()
-numba.core.registry.cpu_target.typing_context.install_registry(bodo_registry)
+# TODO[BSE-5071]: Re-enable native typer when its coverage improved
+# bodo_registry = BodoRegistry()
+# numba.core.registry.cpu_target.typing_context.install_registry(bodo_registry)


### PR DESCRIPTION
As title. Saves some package size and minor import time.