### PR TITLE
Patch mpi libs pip

### DIFF
--- a/buildscripts/bodo/pip/manylinux/patch_libs_for_pip.py
+++ b/buildscripts/bodo/pip/manylinux/patch_libs_for_pip.py
@@ -52,7 +52,7 @@ def patch_lib(fpath):
     # set rpath that points to libmpi location (of mpi4py_mpich package).
     # Note that this is a relative path and requires mpi4py_mpich package to be
     # installed in same site-packages folder as Bodo when running Bodo
-    RPATH = "$ORIGIN/../../..:$ORIGIN/../bodo.libs:$ORIGIN/../lib64:$ORIGIN/../pyarrow"
+    RPATH = "$ORIGIN/../../..:$ORIGIN/../../../../..:$ORIGIN/../bodo.libs:$ORIGIN/../lib64:$ORIGIN/../pyarrow"
     check_call(["patchelf", "--force-rpath", "--set-rpath", RPATH, fpath])
 
 


### PR DESCRIPTION
## Changes included in this PR
Patch libmpi/libpmpi inside of MPI.so to point to the correct location.

## Testing strategy
https://github.com/bodo-ai/Bodo/actions/runs/17219250148
(Windows issue is fixed in a separate PR, BodoSQL issue either will be fixed in another PR since it seemed unrelated)
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.