### PR TITLE
Fix segfault in runtime join filter caching test

### DIFF
--- a/bodo/libs/streaming/join.py
+++ b/bodo/libs/streaming/join.py
@@ -20,6 +20,7 @@ from numba.extending import intrinsic, lower_builtin, models, register_model
 
 import bodo
 from bodo.ext import stream_join_cpp
+from bodo.libs import array_ext
 from bodo.libs.array import (
     array_info_type,
     cpp_table_to_py_table,
@@ -47,6 +48,7 @@ if TYPE_CHECKING:  # pragma: no cover
     pass
 
 
+ll.add_symbol("retrieve_table_py_entry", array_ext.retrieve_table_py_entry)
 ll.add_symbol("join_state_init_py_entry", stream_join_cpp.join_state_init_py_entry)
 ll.add_symbol(
     "join_build_consume_batch_py_entry",
@@ -1563,9 +1565,6 @@ def _retrieve_table(typingctx, cpp_table, row_bitmask):
     and returns a new table after applying the bitmask. If the bitmask is
     all True copying is skipped.
     """
-    from bodo.libs import array_ext
-
-    ll.add_symbol("retrieve_table_py_entry", array_ext.retrieve_table_py_entry)
 
     def codegen(context, builder, sig, args):
         fnty = lir.FunctionType(

--- a/bodo/utils/cg_helpers.py
+++ b/bodo/utils/cg_helpers.py
@@ -91,9 +91,6 @@ def is_na_value(builder, context, val, C_NA):
     """check if Python object 'val' is an NA value (None, or np.nan or pd.NA).
     passing pd.NA in as C_NA to avoid getattr overheads inside loops.
     """
-    from bodo.libs import array_ext
-
-    ll.add_symbol("is_na_value", array_ext.is_na_value)
     pyobj = context.get_argument_type(types.pyobject)
     arr_isna_fnty = lir.FunctionType(lir.IntType(32), [pyobj, pyobj])
     arr_isna_fn = cgutils.get_or_insert_function(


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
`python -u -m bodosql.runtests_caching BodoSQL_Streaming_Caching_Tests 2 bodosql/tests/caching_tests/test_snowflake_catalog_caching.py::test_snowflake_runtime_join_filter_caching`

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.