### PR TITLE
Fix groupby UDF tests

### DIFF
--- a/bodo/tests/test_df_lib/test_groupby_udf.py
+++ b/bodo/tests/test_df_lib/test_groupby_udf.py
@@ -259,7 +259,8 @@ def test_agg_null_keys(dropna, as_index):
     with assert_executed_plan_count(0):
         bdf2 = bdf.groupby("A", dropna=dropna, as_index=as_index).agg(lambda x: x.sum())
 
-    # If as_index=False then we sort the output
+    # If as_index=False, then the output before sorting will use a RangeIndex,
+    # which will result in mismatched indexes after sorting, so we need to reset the index.
     _test_equal(bdf2, df2, sort_output=True, reset_index=(not as_index))
 
 


### PR DESCRIPTION
## Changes included in this PR

When `as_index=False`, the default RangeIndex is used. Since the Bodo output is unsorted, sorting the output so that it matches pandas potentially will result in a different index.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.