### PR TITLE
Avoid extra agg/merge in TPCH Q22

### DIFF
--- a/benchmarks/tpch/dataframe_lib.py
+++ b/benchmarks/tpch/dataframe_lib.py
@@ -921,12 +921,10 @@ def tpch_q22(customer, orders, pd=pd):
         customer_filtered, on="C_CUSTKEY", how="inner"
     )
     customer_selected = customer_selected.loc[:, ["CNTRYCODE", "C_ACCTBAL"]]
-    agg1 = customer_selected.groupby(["CNTRYCODE"], as_index=False, sort=False).size()
-    agg1.columns = ["CNTRYCODE", "NUMCUST"]
-    agg2 = customer_selected.groupby(["CNTRYCODE"], as_index=False, sort=False).agg(
-        TOTACCTBAL=pd.NamedAgg(column="C_ACCTBAL", aggfunc="sum")
+    total = customer_selected.groupby(["CNTRYCODE"], as_index=False, sort=False).agg(
+        ["size", "sum"]
     )
-    total = agg1.merge(agg2, on="CNTRYCODE", how="inner")
+    total.columns = ["CNTRYCODE", "NUMCUST", "TOTACCTBAL"]
     total = total.sort_values(by=["CNTRYCODE"], ascending=[True])
     return total
 


### PR DESCRIPTION
Removes the extra agg and merge in the SQL to Pandas translation of TPC-H Q22. We can avoid the subquery caching issue intended for Q22 for now.

https://github.com/bodo-ai/Bodo/blob/dcbb26af8eac979d85d410315be05de6ebe5ed95/BodoSQL/bodosql/tests/test_tpch_second_half.py#L615

The "not exists" translation also looks suboptimal but leaving for future PRs if necessary.