### PR TITLE
Avoid fallback warnings when printing BodoDataFrames

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -328,7 +328,11 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # count query before the actual plan which is unnecessary.
         if self._exec_state == ExecState.PLAN:
             self.execute_plan()
-        return super().__repr__()
+
+        # Avoid fallback warnings for prints
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BodoLibFallbackWarning)
+            return super().__repr__()
 
     @property
     def index(self):

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -610,7 +610,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         # count query before the actual plan which is unnecessary.
         if self._exec_state == ExecState.PLAN:
             self.execute_plan()
-        return super().__repr__()
+
+        # Avoid fallback warnings for prints
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BodoLibFallbackWarning)
+            return super().__repr__()
 
     @property
     def index(self):

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -2,6 +2,7 @@ import datetime
 import operator
 import os
 import tempfile
+import warnings
 
 import numba
 import numpy as np
@@ -3427,3 +3428,18 @@ def test_set_column_names():
 
     _test_equal(bdf.head(0), pdf.head(0), check_pandas_types=False)
     _test_equal(bdf, pdf, check_pandas_types=False)
+
+
+def test_print_no_warn():
+    """Make sure printing a BodoDataFrame or BodoSeries doesn't throw irrelevant
+    fallback warnings
+    """
+    df = bd.DataFrame({"A": np.arange(100) % 30, "B": np.arange(100)})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        print(df)
+
+    S = bd.Series(np.arange(100) % 30)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        print(S)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Printing BodoDataFrames sometimes throws irrelevant fallback warnings like below. This PR fixes it.

```
/Users/ehsan/dev/Bodo/bodo/pandas/utils.py:1121: BodoLibFallbackWarning: take is not implemented in Bodo Dataframe Library yet. Falling back to Pandas (may be slow or run out of memory).
```

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Avoids warning.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.