### PR TITLE
Use Bodo DataFrames in warnings and other places

### DIFF
--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -187,7 +187,7 @@ sql_plan_cache_loc = os.environ.get("BODO_SQL_PLAN_CACHE_DIR")
 
 # ---------------------------- DataFrame Library Config ----------------------------
 
-# Flag to enable bodo dataframe library (bodo.pandas). When disabled, these classes
+# Flag to enable Bodo DataFrames (bodo.pandas). When disabled, these classes
 # will fallback to Pandas.
 dataframe_library_enabled = os.environ.get("BODO_ENABLE_DATAFRAME_LIBRARY", "1") != "0"
 

--- a/bodo/pandas/__init__.py
+++ b/bodo/pandas/__init__.py
@@ -38,7 +38,7 @@ def add_fallback():
             # Export the pandas functions that aren't implemented by bodo
             # into bodo.pandas.
             msg = (
-                f"{func} is not implemented in Bodo Dataframe Library yet. "
+                f"{func} is not implemented in Bodo DataFrames yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             setattr(current_module, func, fallback_wrapper(pandas, getattr(pandas, func), func, msg))

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -212,7 +212,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
             and hasattr(pd.DataFrame, name)
         ):
             msg = (
-                f"{name} is not implemented in Bodo Dataframe Library yet. "
+                f"{name} is not implemented in Bodo DataFrames yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             return fallback_wrapper(

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -324,7 +324,7 @@ class SeriesGroupBy:
         except AttributeError:
             msg = (
                 f"SeriesGroupBy.{name} is not "
-                "implemented in Bodo dataframe library yet. "
+                "implemented in Bodo DataFrames yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             warnings.warn(BodoLibFallbackWarning(msg))

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -183,7 +183,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             and hasattr(pd.Series, name)
         ):
             msg = (
-                f"Series.{name} is not implemented in Bodo Dataframe Library yet. "
+                f"Series.{name} is not implemented in Bodo DataFrames yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             return fallback_wrapper(
@@ -1299,7 +1299,7 @@ class BodoStringMethods:
         except AttributeError:
             msg = (
                 f"StringMethods.{name} is not "
-                "implemented in Bodo dataframe library for the specified arguments yet. "
+                "implemented in Bodo DataFrames for the specified arguments yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             if not name.startswith("_"):
@@ -1906,7 +1906,7 @@ class BodoDatetimeProperties:
         except AttributeError:
             msg = (
                 f"Series.dt.{name} is not "
-                "implemented in Bodo dataframe library yet. "
+                "implemented in Bodo DataFrames yet. "
                 "Falling back to Pandas (may be slow or run out of memory)."
             )
             if not name.startswith("_"):

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -402,7 +402,7 @@ def check_args_fallback(
                     # Fallback to Python. Call the same method in the base class.
                     msg = (
                         f"{func.__name__} is not "
-                        "implemented in Bodo dataframe library for the specified arguments yet. "
+                        "implemented in Bodo DataFrames for the specified arguments yet. "
                         "Falling back to Pandas (may be slow or run out of memory)."
                     )
                     if except_msg:
@@ -474,7 +474,7 @@ def check_args_fallback(
                         base_class = self.__class__.__bases__[0]
                     msg = (
                         f"{base_class.__name__}.{func.__name__} is not "
-                        "implemented in Bodo dataframe library for the specified arguments yet. "
+                        "implemented in Bodo DataFrames for the specified arguments yet. "
                         "Falling back to Pandas (may be slow or run out of memory)."
                     )
                     if except_msg:

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1119,7 +1119,7 @@ def test_parquet_read_partitioned(datapath):
         bodo_out = bd.read_parquet(path)
         py_out = pd.read_parquet(path)
 
-    # NOTE: Bodo dataframe library currently reads partitioned columns as
+    # NOTE: Bodo DataFrames currently reads partitioned columns as
     # dictionary-encoded strings but Pandas reads them as categorical.
     _test_equal(
         bodo_out.copy(),

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -1026,7 +1026,7 @@ def check_func_df_lib(
         check_categorical,
         atol,
         rtol,
-        # We'll get a different type from the Bodo DataFrame library
+        # We'll get a different type from Bodo DataFrames
         check_pandas_types=False,
     )
 

--- a/docs/docs/api_docs/dataframe_lib/series/index.md
+++ b/docs/docs/api_docs/dataframe_lib/series/index.md
@@ -4,7 +4,7 @@ Bodo DataFrames supports Pandas Series methods and accessors that are listed bel
 !!! note
     If the user code encounters an unsupported Pandas API or an unsupported parameter, Bodo
 	 Bodo DataFrames gracefully falls back to native Pandas. See [overview][overview] of
-	 the Bodo DataFrames for more info.
+	 Bodo DataFrames for more info.
 
 ## AI Functions
 - [`bodo.pandas.BodoSeries.ai.tokenize`][bodoseriesaitokenize]

--- a/docs/docs/dataframe_library/index.md
+++ b/docs/docs/dataframe_library/index.md
@@ -27,7 +27,7 @@ relevant dataframes is larger than the memory of the node on which
 you started the application then this fallback may fail.  In either
 case, this fallback process requires the copying of all the distributed
 data for the dataframe back to the starting node which can be a very
-time consuming process.  The Bodo dataframe library can thus operate
+time consuming process. Bodo DataFrames can thus operate
 in one of three modes: 1) automatic fallback is disabled and an error
 is generated if fallback would be necessary to execute the operation,
 2) automatic fallback is enabled but a performance warning is generated

--- a/docs/docs/release_notes/2025.05.md
+++ b/docs/docs/release_notes/2025.05.md
@@ -2,7 +2,7 @@
 
 ### 🎉 Highlights
 
-In this release, we are excited to introduce the first experimental version of the Bodo DataFrame library which is a drop-in replacement for Pandas. The current release has an initial feature set including parquet read, filtering, projection, UDFs, lazy evaluation, query plan optimization, and streaming parallel execution (both local and clusters). See our blog [“Rethinking DataFrames”](https://www.bodo.ai/blog/rethinking-dataframes-easy-as-pandas-fast-as-a-data-warehouse) for more details and refer to our [docs page][dataframe-lib] for supported features and examples.
+In this release, we are excited to introduce the first experimental version of Bodo DataFrames which is a drop-in replacement for Pandas. The current release has an initial feature set including parquet read, filtering, projection, UDFs, lazy evaluation, query plan optimization, and streaming parallel execution (both local and clusters). See our blog [“Rethinking DataFrames”](https://www.bodo.ai/blog/rethinking-dataframes-easy-as-pandas-fast-as-a-data-warehouse) for more details and refer to our [docs page][dataframe-lib] for supported features and examples.
 
 ### ✨ New Features
 


### PR DESCRIPTION
Replaces "Bodo Dataframe Library" with "Bodo DataFrames" in warnings and other places for consistency.