### PR TITLE
Avoid confusing warning in rename(copy=False)

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -399,10 +399,7 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         # Most cases of copy=False we have are the idiom A=A.rename(copy=False) where there is still
         # only one possible reference to the data so we can treat this case like copy=True since for us
         # we only materialize as needed and so copying isn't an overhead.
-        if copy == False:
-            warnings.warn(
-                "BodoDataFrame::rename copy=False argument ignored assuming A=A.rename(copy=False) idiom."
-            )
+
         renamed_plan = orig_plan.replace_empty_data(
             orig_plan.empty_data.rename(columns=columns)
         )


### PR DESCRIPTION
This warning was confusing to me when running NYC Taxi demo and I think does more harm than good. `copy` keyword is changing semantics and actually going away in Pandas, and it's semantics are not very clear to begin with. I think users just try to avoid copy if possible for performance reasons, not correctness of single copy of mutable data.