### PR TITLE
Make sure TPCH results are run vs Pandas

### DIFF
--- a/benchmarks/tpch/dataframe_lib.py
+++ b/benchmarks/tpch/dataframe_lib.py
@@ -5,11 +5,13 @@ import inspect
 import time
 from collections.abc import Callable
 
-import bodo.pandas as pd
+import pandas as pd
+
+import bodo.pandas as bd
 
 
 @functools.lru_cache
-def load_lineitem(data_folder: str, pd=pd):
+def load_lineitem(data_folder: str, pd=bd):
     print("Loading lineitem")
     data_path = data_folder + "/lineitem.pq"
     df = pd.read_parquet(data_path)
@@ -21,7 +23,7 @@ def load_lineitem(data_folder: str, pd=pd):
 
 
 @functools.lru_cache
-def load_part(data_folder: str, pd=pd):
+def load_part(data_folder: str, pd=bd):
     print("Loading part")
     data_path = data_folder + "/part.pq"
     df = pd.read_parquet(data_path)
@@ -30,7 +32,7 @@ def load_part(data_folder: str, pd=pd):
 
 
 @functools.lru_cache
-def load_orders(data_folder: str, pd=pd):
+def load_orders(data_folder: str, pd=bd):
     print("Loading orders")
     data_path = data_folder + "/orders.pq"
     df = pd.read_parquet(data_path)
@@ -40,7 +42,7 @@ def load_orders(data_folder: str, pd=pd):
 
 
 @functools.lru_cache
-def load_customer(data_folder: str, pd=pd):
+def load_customer(data_folder: str, pd=bd):
     print("Loading customer")
     data_path = data_folder + "/customer.pq"
     df = pd.read_parquet(data_path)
@@ -49,7 +51,7 @@ def load_customer(data_folder: str, pd=pd):
 
 
 @functools.lru_cache
-def load_nation(data_folder: str, pd=pd):
+def load_nation(data_folder: str, pd=bd):
     print("Loading nation")
     data_path = data_folder + "/nation.pq"
     df = pd.read_parquet(data_path)
@@ -58,7 +60,7 @@ def load_nation(data_folder: str, pd=pd):
 
 
 @functools.lru_cache
-def load_region(data_folder: str, pd=pd):
+def load_region(data_folder: str, pd=bd):
     print("Loading region")
     data_path = data_folder + "/region.pq"
     df = pd.read_parquet(data_path)
@@ -67,7 +69,7 @@ def load_region(data_folder: str, pd=pd):
 
 
 @functools.lru_cache
-def load_supplier(data_folder: str, pd=pd):
+def load_supplier(data_folder: str, pd=bd):
     print("Loading supplier")
     data_path = data_folder + "/supplier.pq"
     df = pd.read_parquet(data_path)
@@ -76,7 +78,7 @@ def load_supplier(data_folder: str, pd=pd):
 
 
 @functools.lru_cache
-def load_partsupp(data_folder: str, pd=pd):
+def load_partsupp(data_folder: str, pd=bd):
     print("Loading partsupp")
     data_path = data_folder + "/partsupp.pq"
     df = pd.read_parquet(data_path)
@@ -104,7 +106,7 @@ def collect_datasets(func: Callable):
     return func
 
 
-def tpch_q01(lineitem, pd=pd):
+def tpch_q01(lineitem, pd=bd):
     date = pd.Timestamp("1998-09-02")
     lineitem_filtered = lineitem.loc[
         :,
@@ -159,7 +161,7 @@ def tpch_q01(lineitem, pd=pd):
     return total
 
 
-def tpch_q02(part, partsupp, supplier, nation, region, pd=pd):
+def tpch_q02(part, partsupp, supplier, nation, region, pd=bd):
     nation_filtered = nation.loc[:, ["N_NATIONKEY", "N_NAME", "N_REGIONKEY"]]
     region_filtered = region[(region["R_NAME"] == "EUROPE")]
     region_filtered = region_filtered.loc[:, ["R_REGIONKEY"]]
@@ -264,7 +266,7 @@ def tpch_q02(part, partsupp, supplier, nation, region, pd=pd):
     return total
 
 
-def tpch_q03(lineitem, orders, customer, pd=pd):
+def tpch_q03(lineitem, orders, customer, pd=bd):
     date = pd.Timestamp("1995-03-04")
     lineitem_filtered = lineitem.loc[
         :, ["L_ORDERKEY", "L_EXTENDEDPRICE", "L_DISCOUNT", "L_SHIPDATE"]
@@ -293,7 +295,7 @@ def tpch_q03(lineitem, orders, customer, pd=pd):
     return res.head(10)
 
 
-def tpch_q04(lineitem, orders, pd=pd):
+def tpch_q04(lineitem, orders, pd=bd):
     date1 = pd.Timestamp("1993-11-01")
     date2 = pd.Timestamp("1993-08-01")
     lsel = lineitem.L_COMMITDATE < lineitem.L_RECEIPTDATE
@@ -309,7 +311,7 @@ def tpch_q04(lineitem, orders, pd=pd):
     return total
 
 
-def tpch_q05(lineitem, orders, customer, nation, region, supplier, pd=pd):
+def tpch_q05(lineitem, orders, customer, nation, region, supplier, pd=bd):
     date1 = pd.Timestamp("1996-01-01")
     date2 = pd.Timestamp("1997-01-01")
     rsel = region.R_NAME == "ASIA"
@@ -329,7 +331,7 @@ def tpch_q05(lineitem, orders, customer, nation, region, supplier, pd=pd):
     return total
 
 
-def tpch_q06(lineitem, pd=pd):
+def tpch_q06(lineitem, pd=bd):
     date1 = pd.Timestamp("1996-01-01")
     date2 = pd.Timestamp("1997-01-01")
     lineitem_filtered = lineitem.loc[
@@ -347,7 +349,7 @@ def tpch_q06(lineitem, pd=pd):
     return total
 
 
-def tpch_q07(lineitem, supplier, orders, customer, nation, pd=pd):
+def tpch_q07(lineitem, supplier, orders, customer, nation, pd=bd):
     """This version is faster than q07_old. Keeping the old one for reference"""
     lineitem_filtered = lineitem[
         (lineitem["L_SHIPDATE"] >= pd.Timestamp("1995-01-01"))
@@ -434,7 +436,7 @@ def tpch_q07(lineitem, supplier, orders, customer, nation, pd=pd):
     return total
 
 
-def tpch_q08(part, lineitem, supplier, orders, customer, nation, region, pd=pd):
+def tpch_q08(part, lineitem, supplier, orders, customer, nation, region, pd=bd):
     part_filtered = part[(part["P_TYPE"] == "ECONOMY ANODIZED STEEL")]
     part_filtered = part_filtered.loc[:, ["P_PARTKEY"]]
     lineitem_filtered = lineitem.loc[:, ["L_PARTKEY", "L_SUPPKEY", "L_ORDERKEY"]]
@@ -496,7 +498,7 @@ def tpch_q08(part, lineitem, supplier, orders, customer, nation, region, pd=pd):
     return total
 
 
-def tpch_q09(lineitem, orders, part, nation, partsupp, supplier, pd=pd):
+def tpch_q09(lineitem, orders, part, nation, partsupp, supplier, pd=bd):
     psel = part.P_NAME.str.contains("ghost")
     fpart = part[psel]
     jn1 = lineitem.merge(fpart, left_on="L_PARTKEY", right_on="P_PARTKEY")
@@ -515,7 +517,7 @@ def tpch_q09(lineitem, orders, part, nation, partsupp, supplier, pd=pd):
     return total
 
 
-def tpch_q10(lineitem, orders, customer, nation, pd=pd):
+def tpch_q10(lineitem, orders, customer, nation, pd=bd):
     date1 = pd.Timestamp("1994-11-01")
     date2 = pd.Timestamp("1995-02-01")
     osel = (orders.O_ORDERDATE >= date1) & (orders.O_ORDERDATE < date2)
@@ -543,7 +545,7 @@ def tpch_q10(lineitem, orders, customer, nation, pd=pd):
     return total.head(20)
 
 
-def tpch_q11(partsupp, supplier, nation, pd=pd):
+def tpch_q11(partsupp, supplier, nation, pd=bd):
     partsupp_filtered = partsupp.loc[:, ["PS_PARTKEY", "PS_SUPPKEY"]]
     partsupp_filtered["TOTAL_COST"] = (
         partsupp["PS_SUPPLYCOST"] * partsupp["PS_AVAILQTY"]
@@ -568,7 +570,7 @@ def tpch_q11(partsupp, supplier, nation, pd=pd):
     return total
 
 
-def tpch_q12(lineitem, orders, pd=pd):
+def tpch_q12(lineitem, orders, pd=bd):
     date1 = pd.Timestamp("1994-01-01")
     date2 = pd.Timestamp("1995-01-01")
     sel = (
@@ -595,7 +597,7 @@ def tpch_q12(lineitem, orders, pd=pd):
     return total
 
 
-def tpch_q13(customer, orders, pd=pd):
+def tpch_q13(customer, orders, pd=bd):
     customer_filtered = customer.loc[:, ["C_CUSTKEY"]]
     orders_filtered = orders[
         ~orders["O_COMMENT"].str.contains(r"special[\S|\s]*requests")
@@ -614,7 +616,7 @@ def tpch_q13(customer, orders, pd=pd):
     return total
 
 
-def tpch_q14(lineitem, part, pd=pd):
+def tpch_q14(lineitem, part, pd=bd):
     startDate = pd.Timestamp("1994-03-01")
     endDate = pd.Timestamp("1994-04-01")
     p_type_like = "PROMO"
@@ -632,7 +634,7 @@ def tpch_q14(lineitem, part, pd=pd):
     return total
 
 
-def tpch_q15(lineitem, supplier, pd=pd):
+def tpch_q15(lineitem, supplier, pd=bd):
     lineitem_filtered = lineitem[
         (lineitem["L_SHIPDATE"] >= pd.Timestamp("1996-01-01"))
         & (
@@ -661,7 +663,7 @@ def tpch_q15(lineitem, supplier, pd=pd):
     return total
 
 
-def tpch_q16(part, partsupp, supplier, pd=pd):
+def tpch_q16(part, partsupp, supplier, pd=bd):
     part_filtered = part[
         (part["P_BRAND"] != "Brand#45")
         & (~part["P_TYPE"].str.contains("^MEDIUM POLISHED"))
@@ -694,7 +696,7 @@ def tpch_q16(part, partsupp, supplier, pd=pd):
     return total
 
 
-def tpch_q17(lineitem, part, pd=pd):
+def tpch_q17(lineitem, part, pd=bd):
     left = lineitem.loc[:, ["L_PARTKEY", "L_QUANTITY", "L_EXTENDEDPRICE"]]
     right = part[((part["P_BRAND"] == "Brand#23") & (part["P_CONTAINER"] == "MED BOX"))]
     right = right.loc[:, ["P_PARTKEY"]]
@@ -718,7 +720,7 @@ def tpch_q17(lineitem, part, pd=pd):
     return total
 
 
-def tpch_q18(lineitem, orders, customer, pd=pd):
+def tpch_q18(lineitem, orders, customer, pd=bd):
     gb1 = lineitem.groupby("L_ORDERKEY", as_index=False, sort=False)["L_QUANTITY"].sum()
     fgb1 = gb1[gb1.L_QUANTITY > 300]
     jn1 = fgb1.merge(orders, left_on="L_ORDERKEY", right_on="O_ORDERKEY")
@@ -732,7 +734,7 @@ def tpch_q18(lineitem, orders, customer, pd=pd):
     return total.head(100)
 
 
-def tpch_q19(lineitem, part, pd=pd):
+def tpch_q19(lineitem, part, pd=bd):
     Brand31 = "Brand#31"
     Brand43 = "Brand#43"
     SMBOX = "SM BOX"
@@ -807,7 +809,7 @@ def tpch_q19(lineitem, part, pd=pd):
     return total
 
 
-def tpch_q20(lineitem, part, nation, partsupp, supplier, pd=pd):
+def tpch_q20(lineitem, part, nation, partsupp, supplier, pd=bd):
     date1 = pd.Timestamp("1996-01-01")
     date2 = pd.Timestamp("1997-01-01")
     psel = part.P_NAME.str.startswith("azure")
@@ -834,7 +836,7 @@ def tpch_q20(lineitem, part, nation, partsupp, supplier, pd=pd):
     return total
 
 
-def tpch_q21(lineitem, orders, supplier, nation, pd=pd):
+def tpch_q21(lineitem, orders, supplier, nation, pd=bd):
     lineitem_filtered = lineitem.loc[
         :, ["L_ORDERKEY", "L_SUPPKEY", "L_RECEIPTDATE", "L_COMMITDATE"]
     ]
@@ -898,7 +900,7 @@ def tpch_q21(lineitem, orders, supplier, nation, pd=pd):
     return total
 
 
-def tpch_q22(customer, orders, pd=pd):
+def tpch_q22(customer, orders, pd=bd):
     customer_filtered = customer.loc[:, ["C_ACCTBAL", "C_CUSTKEY"]]
     customer_filtered["CNTRYCODE"] = customer["C_PHONE"].str.slice(0, 2)
     customer_filtered = customer_filtered[

--- a/bodo/tests/test_df_lib/test_tpch.py
+++ b/bodo/tests/test_df_lib/test_tpch.py
@@ -19,13 +19,12 @@ def run_tpch_query_test(query_func, plan_executions=0):
         plan_executions (int, optional): Expected number of LazyPlans to be executed.
           Defaults to 0.
     """
+    pd_kwargs = {"pd": pd}
     pd_args = [
-        getattr(tpch, f"load_{key}")(datapath)
+        getattr(tpch, f"load_{key}")(datapath, **pd_kwargs)
         for key in tpch._query_to_datasets[int(query_func.__name__[-2:])]
     ]
     bd_args = [bd.from_pandas(df) for df in pd_args]
-
-    pd_kwargs = {"pd": pd}
     pd_result = query_func(*pd_args, **pd_kwargs)
 
     with assert_executed_plan_count(plan_executions):


### PR DESCRIPTION
## Changes included in this PR

Previously an `import bodo.pandas as pd` at the top of `dataframes_lib.py` was preventing us from comparing results against Pandas

## Testing strategy

Run tests, Q17 and Q20 are failing now

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.