### PR TITLE
Support "not Series.isin"

### DIFF
--- a/benchmarks/tpch/dataframe_lib.py
+++ b/benchmarks/tpch/dataframe_lib.py
@@ -558,7 +558,6 @@ def tpch_q15(lineitem, supplier, pd=bodo.pandas):
     return result_df
 
 
-# TODO [BSE-5105] Support not isin inside of selection"
 def tpch_q16(part, partsupp, supplier, pd=bodo.pandas):
     """Adapted from:
     https://github.com/coiled/benchmarks/blob/13ebb9c72b1941c90b602e3aaea82ac18fafcddc/tests/tpch/dask_queries.py
@@ -571,7 +570,7 @@ def tpch_q16(part, partsupp, supplier, pd=bodo.pandas):
 
     complaint_suppkeys = supplier[supplier["IS_COMPLAINT"]]["S_SUPPKEY"]
 
-    jn1 = partsupp[not partsupp["PS_SUPPKEY"].isin(complaint_suppkeys)]
+    jn1 = partsupp[~partsupp["PS_SUPPKEY"].isin(complaint_suppkeys)]
     jn2 = jn1.merge(part, left_on="PS_PARTKEY", right_on="P_PARTKEY")
     jn2 = jn2[
         (jn2["P_BRAND"] != var1)

--- a/bodo/libs/streaming/_join.cpp
+++ b/bodo/libs/streaming/_join.cpp
@@ -693,6 +693,7 @@ inline size_t handle_probe_input_for_partition(
  * @tparam build_table_outer
  * @tparam probe_table_outer
  * @tparam non_equi_condition
+ * @tparam is_anti_join
  * @param cond_func Condition function to use. `nullptr` for the
  * all-equality conditions case.
  * @param[in, out] partition Partition that this row belongs to.
@@ -726,7 +727,7 @@ inline size_t handle_probe_input_for_partition(
  * AppendJoinOutput.
  */
 template <bool build_table_outer, bool probe_table_outer,
-          bool non_equi_condition>
+          bool non_equi_condition, bool is_anti_join>
 inline void produce_probe_output(
     cond_expr_fn_t cond_func, JoinPartition* partition, const size_t i_row,
     const size_t batch_start_row, const bodo::vector<int64_t>& group_ids,
@@ -756,6 +757,12 @@ inline void produce_probe_output(
             build_idxs.push_back(-1);
             probe_idxs.push_back(i_row);
         }
+        return;
+    }
+
+    if (is_anti_join && probe_table_outer) {
+        // In the anti join case, if we have a match in the build table, we
+        // don't want to output anything for this probe row.
         return;
     }
 
@@ -790,8 +797,10 @@ inline void produce_probe_output(
         if (build_table_outer) {
             SetBitTo(partition_build_table_matched_->data(), j_build, true);
         }
-        build_idxs.push_back(j_build);
-        probe_idxs.push_back(i_row);
+        if (!is_anti_join) {
+            build_idxs.push_back(j_build);
+            probe_idxs.push_back(i_row);
+        }
 
         // Produce output in a chunked builder periodically to avoid OOM
         // (not used in mark join case to avoid appending duplicate output rows)
@@ -862,7 +871,7 @@ void generate_build_table_outer_rows_for_partition(
 }
 
 template <bool build_table_outer, bool probe_table_outer,
-          bool non_equi_condition>
+          bool non_equi_condition, bool is_anti_join>
 void JoinPartition::FinalizeProbeForInactivePartition(
     cond_expr_fn_t cond_func, const std::vector<uint64_t>& build_kept_cols,
     const std::vector<uint64_t>& probe_kept_cols,
@@ -929,7 +938,7 @@ void JoinPartition::FinalizeProbeForInactivePartition(
         start_produce_probe = start_timer();
         for (size_t i_row = 0; i_row < this->probe_table->nrows(); i_row++) {
             produce_probe_output<build_table_outer, probe_table_outer,
-                                 non_equi_condition>(
+                                 non_equi_condition, is_anti_join>(
                 cond_func, this, i_row, 0, group_ids, build_idxs, probe_idxs,
                 build_table_info_ptrs, probe_table_info_ptrs, build_col_ptrs,
                 probe_col_ptrs, build_null_bitmaps, probe_null_bitmaps,
@@ -2444,7 +2453,7 @@ void HashJoinState::AppendProbeBatchToInactivePartition(
 }
 
 template <bool build_table_outer, bool probe_table_outer,
-          bool non_equi_condition>
+          bool non_equi_condition, bool is_anti_join>
 void HashJoinState::FinalizeProbeForInactivePartitions(
     const std::vector<uint64_t>& build_kept_cols,
     const std::vector<uint64_t>& probe_kept_cols) {
@@ -2467,9 +2476,9 @@ void HashJoinState::FinalizeProbeForInactivePartitions(
             end_timer(start_pin);
         this->partitions[i]
             ->FinalizeProbeForInactivePartition<
-                build_table_outer, probe_table_outer, non_equi_condition>(
-                this->cond_func, build_kept_cols, probe_kept_cols,
-                this->output_buffer);
+                build_table_outer, probe_table_outer, non_equi_condition,
+                is_anti_join>(this->cond_func, build_kept_cols, probe_kept_cols,
+                              this->output_buffer);
         // Free the partition
         this->partitions[i].reset();
         if (this->debug_partitioning) {
@@ -3448,7 +3457,7 @@ bool join_build_consume_batch(HashJoinState* join_state,
  * due to iterations between syncs
  */
 template <bool build_table_outer, bool probe_table_outer,
-          bool non_equi_condition, bool use_bloom_filter>
+          bool non_equi_condition, bool use_bloom_filter, bool is_anti_join>
 bool join_probe_consume_batch(HashJoinState* join_state,
                               std::shared_ptr<table_info> in_table,
                               const std::vector<uint64_t> build_kept_cols,
@@ -3630,7 +3639,7 @@ bool join_probe_consume_batch(HashJoinState* join_state,
     time_pt start_produce_probe = start_timer();
     for (size_t i_row = 0; i_row < in_table->nrows(); i_row++) {
         produce_probe_output<build_table_outer, probe_table_outer,
-                             non_equi_condition>(
+                             non_equi_condition, is_anti_join>(
             join_state->cond_func, active_partition.get(), i_row, 0, group_ids,
             build_idxs, probe_idxs, build_table_info_ptrs,
             probe_table_info_ptrs, build_col_ptrs, probe_col_ptrs,
@@ -3780,7 +3789,7 @@ bool join_probe_consume_batch(HashJoinState* join_state,
                     for (size_t i_row = 0; i_row < nrows; i_row++) {
                         produce_probe_output<build_table_outer,
                                              probe_table_outer,
-                                             non_equi_condition>(
+                                             non_equi_condition, is_anti_join>(
                             join_state->cond_func, active_partition.get(),
                             i_row + batch_start_row, batch_start_row, group_ids,
                             build_idxs, probe_idxs, build_table_info_ptrs,
@@ -3825,7 +3834,7 @@ bool join_probe_consume_batch(HashJoinState* join_state,
                     for (size_t i_row = 0; i_row < nrows; i_row++) {
                         produce_probe_output<build_table_outer,
                                              probe_table_outer,
-                                             non_equi_condition>(
+                                             non_equi_condition, is_anti_join>(
                             join_state->cond_func, active_partition.get(),
                             i_row + batch_start_row, batch_start_row, group_ids,
                             build_idxs, probe_idxs, build_table_info_ptrs,
@@ -3939,13 +3948,115 @@ bool join_probe_consume_batch(HashJoinState* join_state,
         // This will pin the partitions (one at a time), generate all the
         // output from it and then free it.
         join_state->FinalizeProbeForInactivePartitions<
-            build_table_outer, probe_table_outer, non_equi_condition>(
-            build_kept_cols, probe_kept_cols);
+            build_table_outer, probe_table_outer, non_equi_condition,
+            is_anti_join>(build_kept_cols, probe_kept_cols);
         // Finalize the probe step:
         join_state->FinalizeProbe();
     }
     return fully_done;
 }
+
+/** Add template definitions for join_probe_consume_batch for anti-join, since
+only used in the DataFrame library code and not available to the compiler here.
+Generated using:
+
+In [36]: temp = """
+    ...: template bool join_probe_consume_batch<{}, {}, {}, {}, true>(
+    ...:     HashJoinState* join_state,
+    ...:                               std::shared_ptr<table_info> in_table,
+    ...:                               const std::vector<uint64_t>
+build_kept_cols,
+    ...:                               const std::vector<uint64_t>
+probe_kept_cols,
+    ...:                               bool local_is_last);
+    ...: """
+
+In [37]: for b1 in ("true", "false"):
+    ...:     for b2 in ("true", "false"):
+    ...:         for b3 in ("true", "false"):
+    ...:             for b4 in ("true", "false"):
+    ...:                 print(temp.format(b1, b2, b3, b4))
+*/
+
+template bool join_probe_consume_batch<true, true, true, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<true, true, true, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<true, true, false, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<true, true, false, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<true, false, true, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<true, false, true, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<true, false, false, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<true, false, false, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, true, true, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, true, true, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, true, false, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, true, false, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, false, true, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, false, true, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, false, false, true, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
+
+template bool join_probe_consume_batch<false, false, false, false, true>(
+    HashJoinState* join_state, std::shared_ptr<table_info> in_table,
+    const std::vector<uint64_t> build_kept_cols,
+    const std::vector<uint64_t> probe_kept_cols, bool local_is_last);
 
 /**
  * @brief Initialize a new streaming join state for specified array types
@@ -4131,7 +4242,7 @@ table_info* join_probe_consume_batch_py_entry(
         use_bloom_filter == use_bloom_filter_exp) {                         \
         is_last = join_probe_consume_batch<                                 \
             build_table_outer_exp, probe_table_outer_exp,                   \
-            has_non_equi_cond_exp, use_bloom_filter_exp>(                   \
+            has_non_equi_cond_exp, use_bloom_filter_exp, false>(            \
             join_state, std::move(input_table), std::move(build_kept_cols), \
             std::move(probe_kept_cols), is_last);                           \
     }

--- a/bodo/libs/streaming/_join.h
+++ b/bodo/libs/streaming/_join.h
@@ -575,6 +575,7 @@ class JoinPartition {
      * @tparam build_table_outer
      * @tparam probe_table_outer
      * @tparam non_equi_condition
+     * @tparam is_anti_join
      * @param cond_func Condition function for the non-equi condition case,
      * nullptr otherwise.
      * @param build_kept_cols Which columns to generate in the output on the
@@ -589,7 +590,7 @@ class JoinPartition {
      *
      */
     template <bool build_table_outer, bool probe_table_outer,
-              bool non_equi_condition>
+              bool non_equi_condition, bool is_anti_join>
     void FinalizeProbeForInactivePartition(
         cond_expr_fn_t cond_func, const std::vector<uint64_t>& build_kept_cols,
         const std::vector<uint64_t>& probe_kept_cols,
@@ -1155,13 +1156,14 @@ class HashJoinState : public JoinState {
      * @tparam build_table_outer
      * @tparam probe_table_outer
      * @tparam non_equi_condition
+     * @tparam is_anti_join
      * @param build_kept_cols Which columns to generate in the output on the
      * build side.
      * @param probe_kept_cols Which columns to generate in the output on the
      * probe side.
      */
     template <bool build_table_outer, bool probe_table_outer,
-              bool non_equi_condition>
+              bool non_equi_condition, bool is_anti_join>
     void FinalizeProbeForInactivePartitions(
         const std::vector<uint64_t>& build_kept_cols,
         const std::vector<uint64_t>& probe_kept_cols);
@@ -1472,7 +1474,7 @@ bool join_build_consume_batch(HashJoinState* join_state,
  * due to iterations between syncs
  */
 template <bool build_table_outer, bool probe_table_outer,
-          bool non_equi_condition, bool use_bloom_filter>
+          bool non_equi_condition, bool use_bloom_filter, bool is_anti_join>
 bool join_probe_consume_batch(HashJoinState* join_state,
                               std::shared_ptr<table_info> in_table,
                               const std::vector<uint64_t> build_kept_cols,

--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -1738,7 +1738,7 @@ def get_isin_filter_plan(source_plan: LazyPlan, key_plan: LazyPlan) -> LazyPlan 
         key_plan = LogicalProjection(
             key_plan.empty_data,
             key_expr.source,
-            [key_expr.source_expr],
+            (key_expr.source_expr,) + key_plan.exprs[1:],
         )
 
     # Match df1.A.isin(df2.B) case which is a mark join generated in our Series.isin()

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -2032,6 +2032,43 @@ def test_filter_series_isin():
     )
 
 
+def test_filter_series_not_isin(index_val):
+    """Test dataframe filter with not isin case"""
+    with assert_executed_plan_count(0):
+        df1 = pd.DataFrame(
+            {
+                "A": [1.4, 2.1, 3.3],
+                "B": ["A", "B", "C"],
+                "C": [1, 2, 3],
+                "D": [True, False, True],
+            },
+            index=index_val[:3],
+        )
+        df2 = pd.DataFrame(
+            {
+                "A": ["A", "B", "C", "D"],
+                "B": [11, 2, 2, 4],
+            }
+        )
+
+        bdf1 = bd.from_pandas(df1)
+        bdf2 = bd.from_pandas(df2)
+        bodo_out = bdf1[~bdf1.C.isin(bdf2.B)]
+        py_out = df1[~df1.C.isin(df2.B)]
+
+        # Reverse the order so the planner flips sides to put smaller table in build
+        # side creating right-anti join.
+        bodo_out2 = bdf2[~bdf2.B.isin(bdf1.C)]
+        py_out2 = df2[~df2.B.isin(df1.C)]
+
+    _test_equal(
+        bodo_out, py_out, check_pandas_types=False, sort_output=True, reset_index=True
+    )
+    _test_equal(
+        bodo_out2, py_out2, check_pandas_types=False, sort_output=True, reset_index=True
+    )
+
+
 def test_rename(datapath, index_val):
     """Very simple test for df.apply() for sanity checking."""
     with assert_executed_plan_count(0):

--- a/bodo/tests/test_df_lib/test_tpch.py
+++ b/bodo/tests/test_df_lib/test_tpch.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import pytest
 
 import benchmarks.tpch.dataframe_lib as tpch
 import bodo.pandas as bd
@@ -114,7 +113,6 @@ def test_tpch_q15():
     run_tpch_query_test(tpch.tpch_q15, plan_executions=1)
 
 
-@pytest.mark.skip("TODO [BSE-5105]: Support not isin inside of selection")
 def test_tpch_q16():
     run_tpch_query_test(tpch.tpch_q16)
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for `df1[~df1.A.isin(df2.A)]` using anti-join in the backend. Enables the new TPC-H Q16 code.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
New functionality.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.