### PR TITLE
Change anthropic model and use messages API

### DIFF
--- a/bodo/ai/utils.py
+++ b/bodo/ai/utils.py
@@ -16,8 +16,9 @@ def get_default_bedrock_request_formatter(modelId: str) -> Callable[[str], str]:
     elif "anthropic.claude" in modelId:
         return lambda input: json.dumps(
             {
-                "prompt": f"\n\nHuman: {input}\n\nAssistant:",
-                "max_tokens_to_sample": 4000,
+                "messages": [{"role": "user", "content": input}],
+                "max_tokens": 4000,
+                "anthropic_version": "bedrock-2023-05-31",
             }
         )
     elif "openai" in modelId:
@@ -43,7 +44,7 @@ def get_default_bedrock_response_formatter(
     elif "amazon.titan-embed" in modelId:
         return lambda output: json.loads(output)["embedding"]
     elif "anthropic.claude" in modelId:
-        return lambda output: json.loads(output)["completion"]
+        return lambda output: json.loads(output)["content"][0]["text"]
     elif "openai" in modelId:
         return lambda output: json.loads(output)["choices"][0]["message"]["content"]
 

--- a/bodo/tests/test_df_lib/test_ai_funcs.py
+++ b/bodo/tests/test_df_lib/test_ai_funcs.py
@@ -319,7 +319,7 @@ def test_llm_generate_bedrock_custom_formatters():
     "modelId",
     [
         "us.amazon.nova-lite-v1:0",
-        "anthropic.claude-v2:1",
+        "anthropic.claude-3-haiku-20240307-v1:0",
         "amazon.titan-text-lite-v1",
     ],
 )


### PR DESCRIPTION
## Changes included in this PR
Bedrock end of lifed Claude 2 which we were using in testing. This PR upgrades to Claude 3 and since all subsequent anthropic models use a new API it updates the request and response formatters

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Unit tests/PR CI
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.