### PR TITLE
Make sure Bodo JIT is imported before Numba JIT use

### DIFF
--- a/bodo/libs/distributed_api.py
+++ b/bodo/libs/distributed_api.py
@@ -1518,23 +1518,15 @@ def gen_bcast_scalar_impl(val, root=DEFAULT_ROOT, comm=0):
 
     # TODO: other types like boolean
     typ_val = numba_to_c_type(val)
-    # TODO: fix np.full and refactor
-    func_text = (
-        f"def bcast_scalar_impl(val, root={DEFAULT_ROOT}, comm=0):\n"
-        "  send = np.empty(1, dtype)\n"
-        "  send[0] = val\n"
-        f"  c_bcast(send.ctypes, np.int32(1), np.int32({typ_val}), np.int32(root), comm)\n"
-        "  return send[0]\n"
-    )
-
     dtype = numba.np.numpy_support.as_dtype(val)
-    loc_vars = {}
-    exec(
-        func_text,
-        {"bodo": bodo, "np": np, "c_bcast": c_bcast, "dtype": dtype},
-        loc_vars,
-    )
-    bcast_scalar_impl = loc_vars["bcast_scalar_impl"]
+
+    # TODO: fix np.full and refactor
+    def bcast_scalar_impl(val, root=DEFAULT_ROOT, comm=0):
+        send = np.empty(1, dtype)
+        send[0] = val
+        c_bcast(send.ctypes, np.int32(1), np.int32(typ_val), np.int32(root), comm)
+        return send[0]
+
     return bcast_scalar_impl
 
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Avoids memory management related crashes.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Tested manually (not easy to add unit test).

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

Error if Numba JIT is used before Bodo use.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.