### PR TITLE
Remove constexpr

### DIFF
--- a/bodo/libs/streaming/_join.cpp
+++ b/bodo/libs/streaming/_join.cpp
@@ -961,7 +961,7 @@ void JoinPartition::FinalizeProbeForInactivePartition(
     }
 
     // Add unmatched rows from build table to output table
-    if constexpr (build_table_outer) {
+    if (build_table_outer) {
         time_pt start_build_outer = start_timer();
         // If an inactive partition exists, this means that the build side is
         // distributed and therefore no reduction is required.


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Looks like this is a bug in msvc, it's saying a template value isn't constant so removing the constexpr, gcc and clang should recognize it's a constant anyways.

## Testing strategy
PR CI/release pipeline
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
N/A
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.