### PR TITLE
Support lazy BodoScalar binary operations

### DIFF
--- a/benchmarks/tpch/dataframe_lib.py
+++ b/benchmarks/tpch/dataframe_lib.py
@@ -521,7 +521,6 @@ def tpch_q14(lineitem, part, pd=bodo.pandas):
     total_revenue = (jn1["L_EXTENDEDPRICE"] * (1 - jn1["L_DISCOUNT"])).sum()
 
     # aggregate promo revenue calculation
-    # TODO[BSE-5113]: support division of BodoScalars in plans
     ratio = 100.00 * total_promo_revenue / total_revenue
     result_df = pd.DataFrame({"PROMO_REVENUE": [round(ratio, 2)]})
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1850,6 +1850,40 @@ def test_series_cmp_binops(datapath, index_val):
     )
 
 
+def test_scalar_arith_binops(datapath, index_val):
+    """Test various cases of BodoScalar binary operations."""
+
+    df = pd.DataFrame({"A": [1, 2, 3], "B": ["aa", "bb", "c"], "C": [4, 5, 6]})
+    df.index = index_val[: len(df)]
+
+    bdf = bd.from_pandas(df)
+
+    # Simple expression with constant
+    with assert_executed_plan_count(0):
+        S = df["A"].sum() + 1
+        bodo_S = bdf["A"].sum() + 1
+
+    _test_equal(bodo_S, S)
+
+    # Two BodoScalar expressions
+    with assert_executed_plan_count(0):
+        S = df["A"].sum() + df["C"].sum()
+        bodo_S = bdf["A"].sum() + bdf["C"].sum()
+
+    _test_equal(bodo_S, S)
+
+    # BodoScalar/Series expressions
+    with assert_executed_plan_count(0):
+        S = df["A"].sum() + df["C"]
+        bodo_S = bdf["A"].sum() + bdf["C"]
+
+    _test_equal(
+        bodo_S,
+        S,
+        check_pandas_types=False,
+    )
+
+
 def test_map_partitions_df():
     """Simple tests for map_partition on lazy DataFrame."""
     with assert_executed_plan_count(0):

--- a/bodo/tests/test_df_lib/test_tpch.py
+++ b/bodo/tests/test_df_lib/test_tpch.py
@@ -108,8 +108,7 @@ def test_tpch_q13():
 
 
 def test_tpch_q14():
-    # TODO[BSE-5113]: support division of BodoScalars in plans
-    run_tpch_query_test(tpch.tpch_q14, plan_executions=2)
+    run_tpch_query_test(tpch.tpch_q14, plan_executions=1)
 
 
 def test_tpch_q15():


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support for BodoScalar binary operations in the plan by reusing BodoSeries implementations.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
More optimized execution in some cases like TPC-H Q14.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.