### PR TITLE
Add check for distributed function before calling `get_nodes_first_ranks`

### DIFF
--- a/bodo/numba_compat.py
+++ b/bodo/numba_compat.py
@@ -1489,7 +1489,10 @@ def Dispatcher_compile(self, sig):
                 # avoid calling get_nodes_first_ranks for the case where only one rank is
                 # calling the function, which will hang.
                 is_distributed_impl = cres.metadata.get("distributed_diagnostics", None) is not None
-                if not is_distributed_impl or (bodo.get_rank() in bodo.libs.distributed_api.get_nodes_first_ranks()):
+                if (
+                    not is_distributed_impl
+                    or (bodo.get_rank() in bodo.libs.distributed_api.get_nodes_first_ranks())
+                ):
                     self._cache.save_overload(sig, cres)
             return cres.entry_point
 


### PR DESCRIPTION
## Changes included in this PR

In some of our tests we have this pattern of calling a function that is not distributed or a numba njit from only one rank, which causes hangs because `bodo.libs.distributed_api.get_nodes_first_ranks` is expected to be called from all ranks.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.