### PR TITLE
Set precision/scale for decimal arrays in gather/scatter

### DIFF
--- a/bodo/libs/_distributed.cpp
+++ b/bodo/libs/_distributed.cpp
@@ -257,6 +257,11 @@ std::shared_ptr<array_info> gather_array(std::shared_ptr<array_info> in_arr,
                                mpi_root, comm, all_gather),
                 "_distributed.cpp::gather_array: MPI error on MPI_Gengatherv:");
         }
+        // Set scale and precision for decimal type
+        if ((dtype == Bodo_CTypes::DECIMAL) && (is_receiver || all_gather)) {
+            out_arr->scale = in_arr->scale;
+            out_arr->precision = in_arr->precision;
+        }
     } else if (arr_type == bodo_array_type::INTERVAL) {
         MPI_Datatype mpi_typ = get_MPI_typ(dtype);
         // Computing the total number of rows.
@@ -647,6 +652,11 @@ std::shared_ptr<array_info> scatter_array(
                                rows_disps.data(), mpi_typ, data1_ptr, n_loc,
                                mpi_typ, mpi_root, comm),
                 "_distributed.cpp::c_scatterv: MPI error on MPI_Scatterv:");
+        }
+        // Set scale and precision for decimal type
+        if (dtype == Bodo_CTypes::DECIMAL) {
+            out_arr->scale = in_arr->scale;
+            out_arr->precision = in_arr->precision;
         }
     } else if (arr_type == bodo_array_type::INTERVAL) {
         MPI_Datatype mpi_typ = get_MPI_typ(dtype);


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes some issues in tests with no-JIT gather/scatter.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing tests.

## User facing changes

Bug fix.
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.