### PR TITLE
Fix multi index spawn test

### DIFF
--- a/bodo/pandas/frame.py
+++ b/bodo/pandas/frame.py
@@ -69,10 +69,10 @@ from bodo.pandas.plan import (
 )
 from bodo.pandas.series import BodoSeries
 from bodo.pandas.utils import (
-    BODO_NONE_DUMMY,
     BodoCompilationFailedWarning,
     BodoLibFallbackWarning,
     BodoLibNotImplementedException,
+    _fix_multi_index_names,
     _get_empty_series_arrow,
     check_args_fallback,
     fallback_wrapper,
@@ -343,10 +343,8 @@ class BodoDataFrame(pd.DataFrame, BodoLazyWrapper):
         self.execute_plan()
         index = super().index
 
-        # We use BODO_NONE_DUMMY as a placeholder for missing multi-index names
-        # so that they round trip correctly from Arrow.
         if isinstance(index, pd.MultiIndex):
-            index.names = [None if n == BODO_NONE_DUMMY else n for n in index.names]
+            index.names = _fix_multi_index_names(index.names)
 
         return index
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -74,6 +74,7 @@ from bodo.pandas.utils import (
     BodoCompilationFailedWarning,
     BodoLibFallbackWarning,
     BodoLibNotImplementedException,
+    _fix_multi_index_names,
     _get_empty_series_arrow,
     arrow_to_empty_df,
     check_args_fallback,
@@ -596,6 +597,11 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
     @property
     def index(self):
         self.execute_plan()
+        index = super().index
+
+        if isinstance(index, pd.MultiIndex):
+            index.names = _fix_multi_index_names(index.names)
+
         return super().index
 
     @index.setter

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -843,6 +843,12 @@ def _is_generated_index_name(name):
     return re.match(pattern, name) is not None
 
 
+def _fix_multi_index_names(names: list[str]) -> list[str]:
+    """Replace instances of BODO_NONE_DUMMY in MultiIndex names with None
+    to ensure missing index names round trip correctly from Arrow."""
+    return [None if n == BODO_NONE_DUMMY else n for n in names]
+
+
 def _reconstruct_pandas_index(df, arrow_schema):
     """Reconstruct the pandas Index from the metadata in Arrow schema (some columns may
     be moved to Index/MultiIndex).
@@ -879,7 +885,7 @@ def _reconstruct_pandas_index(df, arrow_schema):
 
     # Reconstruct the row index
     if len(index_arrays) > 1:
-        index_names = [None if n == BODO_NONE_DUMMY else n for n in index_names]
+        index_names = _fix_multi_index_names(index_names)
         index = pd.MultiIndex.from_arrays(index_arrays, names=index_names)
     elif len(index_arrays) == 1:
         index = index_arrays[0]


### PR DESCRIPTION
## Changes included in this PR

Previous PR used "_bodo_none_dummy_" as a placeholder for multi-index level names that are None due to issues round-tripping from Arrow. For the Series case there was one place where the naming wasn't undid.

## Testing strategy

Pr CI, tests/test_spawn/test_input_output.py::test_distributed_input_output_series[multi_index]
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.