### PR TITLE
Add support for running str.match in arrow compute.

### DIFF
--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -137,7 +137,8 @@ extern std::function<bool(int)> less_equal_test;
  *
  */
 std::shared_ptr<array_info> do_arrow_compute_unary(
-    std::shared_ptr<ExprResult> left_res, const std::string &comparator);
+    std::shared_ptr<ExprResult> left_res, const std::string &comparator,
+    const arrow::compute::FunctionOptions *func_options = nullptr);
 
 /**
  * @brief Convert two ExprResults to arrow and run compute operation on them.

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -739,6 +739,11 @@ class ArrowScalarFuncExpression(Expression):
         """Return the function name."""
         return self.args[2]
 
+    @property
+    def function_args(self):
+        """Return the function args."""
+        return self.args[3]
+
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
         """Update the source and column index of the function expression."""
         if self.source != new_source_plan:

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -676,11 +676,12 @@ cdef class ArrowScalarFuncExpression(Expression):
         object out_schema,
         LogicalOperator source,
         vector[int] input_column_indices,
-        str function_name):
+        str function_name,
+        object args):
 
         self.out_schema = out_schema
         self.c_expression = make_scalar_func_expr(
-            source.c_logical_operator, out_schema, None, input_column_indices, False, False, function_name.encode())
+            source.c_logical_operator, out_schema, args, input_column_indices, False, False, function_name.encode())
 
     def __str__(self):
         return f"ArrowScalarFuncExpression({self.function_name})"

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -2728,6 +2728,7 @@ def _get_series_func_plan(
         "str.swapcase",
         "str.title",
         "str.reverse",
+        "str.match",
     )
 
     def get_arrow_func(name):
@@ -2739,13 +2740,15 @@ def _get_series_func_plan(
         if name.startswith("str.is"):
             body = name.split(".")[1]
             return "utf8_" + body[:2] + "_" + body[2:]
+        if name == "str.match":
+            return "match_substring_regex"
         if name.startswith("str."):
             return "utf8_" + name.split(".")[1]
         return name.split(".")[1]
 
     if func in arrow_compute_list:
         func_name = get_arrow_func(func)
-        func_args = ()  # TODO: expand this to enable arrow compute calls with args
+        func_args = tuple(args)
         is_cfunc = False
         has_state = False
         expr = ArrowScalarFuncExpression(
@@ -2753,6 +2756,7 @@ def _get_series_func_plan(
             source_data,
             (col_index,) + tuple(index_cols),
             func_name,
+            func_args,
         )
     else:
         # Empty func_name separates Python calls from Arrow calls.

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -3764,3 +3764,18 @@ def test_join_non_equi_key_not_in_output():
         reset_index=True,
         sort_output=True,
     )
+
+
+def test_series_str_match():
+    s = pd.Series(["abc", "a1c", "zzz", None], dtype="string")
+    bs = bd.Series(s)
+
+    # Match strings that start with 'a' and end with 'c'
+    pmask = s.str.match(r"a.*c")
+    bmask = bs.str.match(r"a.*c")
+
+    _test_equal(
+        bmask,
+        pmask,
+        check_pandas_types=False,
+    )


### PR DESCRIPTION
## Changes included in this PR

Add support for running str.match in arrow compute.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [X] I have installed + ran pre-commit hooks.