### PR TITLE
Support Parquet read in BodoSQL C++ backend

### DIFF
--- a/BodoSQL/bodosql/tests/test_types/test_table_path.py
+++ b/BodoSQL/bodosql/tests/test_types/test_table_path.py
@@ -102,6 +102,7 @@ def test_table_path_pq_constructor(reorder_io, memory_leak_check):
 @pytest.mark.parametrize("reorder_io", [True, False, None])
 @pytest.mark.slow
 @pytest.mark.parquet
+@pytest.mark.bodosql_cpp
 def test_table_path_pq_bodosqlContext_python(
     reorder_io, parquet_filepaths, memory_leak_check
 ):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Marked the relevant unit test to run in BodoSQL C++ backend tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.