### PR TITLE
Fix plot accessor fallback

### DIFF
--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -1198,11 +1198,7 @@ def fallback_wrapper(self, attr, name, msg):
     """
 
     # Avoid wrapping indexers & accessors
-    if (
-        callable(attr)
-        and not hasattr(attr, "__getitem__")
-        and not hasattr(attr, "__getattr__")
-    ):
+    if inspect.isfunction(attr) or inspect.isbuiltin(attr):
 
         def silenced_method(*args, **kwargs):
             jit_fallback = JITFallback(self, name)


### PR DESCRIPTION
## Changes included in this PR

I ran into this issue when I wanted to make a plot from a DataFrame e.g. (`df.groupby("label").size().plot.bar()`) and got:
```
>>> df = pd.DataFrame({"A": [1,2,3,4,5,6], "B": [1,1,1,2,2,2]})
>>> df.groupby("B").size().plot.bar()
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    df.groupby("B").size().plot.bar()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'function' object has no attribute 'bar'
>>> 
```
I guess someone could do `df.groupby("label").size().plot(kind="bar")`, but we should wrap plot so that you can still access it's attributes and call it.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.