### PR TITLE
Expose pandas.Timestamp in bodo.pandas

### DIFF
--- a/bodo/pandas/__init__.py
+++ b/bodo/pandas/__init__.py
@@ -9,7 +9,7 @@ from bodo.pandas.base import *
 from bodo.pandas.utils import fallback_wrapper
 import os
 
-# Pandas Scalars, types, non performance critical objects.
+# Non-performance critical scalars
 from pandas import Timestamp
 
 DataFrame = BodoDataFrame

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -2,6 +2,8 @@
 Tests dataframe library frontend (no triggering of execution).
 """
 
+import warnings
+
 import pandas as pd
 import pytest
 from test_end_to_end import index_val  # noqa
@@ -403,3 +405,14 @@ def test_from_pandas_errorchecking():
     # Duplicate column names
     with pytest.raises(BodoLibNotImplementedException):
         bd.from_pandas(df3)
+
+
+def test_timestamp_now():
+    """Test basic Timestamp features works and doesn't issue performance warnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        bd.Timestamp("2025-01-01 00:00:00")
+
+        # Test static methods works
+        bd.Timestamp.now()


### PR DESCRIPTION
## Changes included in this PR

Currently, everything not supported in the DataFrame library is wrapped with `fallback_wrapper`. This creates issues for Timestamp (and potentially other scalar types): 
1. extra warnings for non performance critical scalar ops e.g. Timestamp.day_of_week
2. Static methods of that object will throw an error e.g. Timestamp.now()

This PR just exposes the actual pandas.Timestamp type to Bodo DataFrames and can be extended to [other scalars and types that are not performance critical as well](https://pandas.pydata.org/pandas-docs/stable/reference/arrays.html). 
## Testing strategy
New unit tests added.
<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

`pd.Timestamp.now()` works. 
`pd.Timestamp(x)` doesn't warn.

## Checklist
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [ ] I have installed + ran pre-commit hooks.