### PR TITLE
Monkey-patch Pandas explode bug for Arrow large list type

### DIFF
--- a/bodo/pandas_compat.py
+++ b/bodo/pandas_compat.py
@@ -167,6 +167,49 @@ if _check_pandas_change:
 pd.core.arrays.arrow.array.ArrowExtensionArray._str_find = _str_find
 
 
+def _explode(self):
+    """
+    See Series.explode.__doc__.
+    """
+    # child class explode method supports only list types; return
+    # default implementation for non list types.
+    if not hasattr(self.dtype, "pyarrow_dtype") or (
+        # Bodo change: check is_large_list as well
+        not (
+            pa.types.is_list(self.dtype.pyarrow_dtype)
+            or pa.types.is_large_list(self.dtype.pyarrow_dtype)
+        )
+    ):
+        return super()._explode()
+    values = self
+    counts = pa.compute.list_value_length(values._pa_array)
+    counts = counts.fill_null(1).to_numpy()
+    fill_value = pa.scalar([None], type=self._pa_array.type)
+    mask = counts == 0
+    if mask.any():
+        values = values.copy()
+        values[mask] = fill_value
+        counts = counts.copy()
+        counts[mask] = 1
+    values = values.fillna(fill_value)
+    values = type(self)(pa.compute.list_flatten(values._pa_array))
+    return values, counts
+
+
+if _check_pandas_change:
+    lines = inspect.getsource(pd.core.arrays.arrow.array.ArrowExtensionArray._explode)
+    if (
+        hashlib.sha256(lines.encode()).hexdigest()
+        != "6c1b05ccc4da39ec3b7d7dfd79a9d9e47968db3b2eb4c615d21d490b21f9b421"
+    ):  # pragma: no cover
+        warnings.warn(
+            "pd.core.arrays.arrow.array.ArrowExtensionArray._explode has changed"
+        )
+
+
+pd.core.arrays.arrow.array.ArrowExtensionArray._explode = _explode
+
+
 # Bodo change: add missing str_map() for ArrowExtensionArray that is used in operations
 # like zfill.
 def arrow_arr_str_map(self, f, na_value=None, dtype=None, convert=True):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes a Pandas bug for Narwhals tests.

## Testing strategy

<!-- 
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes). 

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions. 

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode: 
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode): 
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Narwhals tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md) 
- [x] I have installed + ran pre-commit hooks.