### PR TITLE
[GPU] create scalar fix for tpch q8.

### DIFF
--- a/bodo/pandas/_pipeline.cpp
+++ b/bodo/pandas/_pipeline.cpp
@@ -14,17 +14,17 @@ using hrclock = std::chrono::high_resolution_clock;
 #endif
 
 #if defined(DEBUG_PIPELINE) && (DEBUG_PIPELINE >= 1)
-#define DEBUG_PIPELINE_BEFORE_CONSUME(rank, sink, prev_op_result, out)       \
-    do {                                                                     \
-        for (unsigned i = 0; i < idx; ++i)                                   \
-            out << " ";                                                      \
-        out << "Rank " << rank << " midPipelineExecute before ConsumeBatch " \
-            << getNodeString(sink) << " " << toString(prev_op_result)        \
-            << std::endl;                                                    \
+#define DEBUG_PIPELINE_BEFORE_CONSUME(rank, sink, prev_op_result, out, batch) \
+    do {                                                                      \
+        for (unsigned i = 0; i < idx; ++i)                                    \
+            out << " ";                                                       \
+        out << "Rank " << rank << " midPipelineExecute before ConsumeBatch "  \
+            << getNodeString(sink) << " " << toString(prev_op_result)         \
+            << " NumRows=>" << getBatchRows(batch) << std::endl;              \
     } while (0)
 #else
-#define DEBUG_PIPELINE_BEFORE_CONSUME(rank, sink, prev_op_result, out) \
-    do {                                                               \
+#define DEBUG_PIPELINE_BEFORE_CONSUME(rank, sink, prev_op_result, out, batch) \
+    do {                                                                      \
     } while (0)
 #endif
 
@@ -56,15 +56,15 @@ using hrclock = std::chrono::high_resolution_clock;
 #endif
 
 #if defined(DEBUG_PIPELINE) && (DEBUG_PIPELINE >= 1)
-#define DEBUG_PIPELINE_AFTER_PRODUCE(rank, source, produce_result, out)    \
-    do {                                                                   \
-        out << "Rank " << rank << " Pipeline::Execute after ProduceBatch " \
-            << getNodeString(source) << " " << toString(produce_result)    \
-            << std::endl;                                                  \
+#define DEBUG_PIPELINE_AFTER_PRODUCE(rank, source, produce_result, out, batch) \
+    do {                                                                       \
+        out << "Rank " << rank << " Pipeline::Execute after ProduceBatch "     \
+            << getNodeString(source) << " " << toString(produce_result)        \
+            << " NumRows=>" << getBatchRows(batch) << std::endl;               \
     } while (0)
 #else
-#define DEBUG_PIPELINE_AFTER_PRODUCE(rank, source, produce_result, out) \
-    do {                                                                \
+#define DEBUG_PIPELINE_AFTER_PRODUCE(rank, source, produce_result, out, batch) \
+    do {                                                                       \
     } while (0)
 #endif
 
@@ -81,23 +81,23 @@ using hrclock = std::chrono::high_resolution_clock;
 #endif
 
 #if defined(DEBUG_PIPELINE) && (DEBUG_PIPELINE >= 1)
-#define DEBUG_PIPELINE_BEFORE_PROCESS(rank, op, prev_op_result, out)         \
+#define DEBUG_PIPELINE_BEFORE_PROCESS(rank, op, prev_op_result, out, batch)  \
     auto before_process_start = hrclock::now();                              \
     do {                                                                     \
         for (unsigned i = 0; i < idx; ++i)                                   \
             out << " ";                                                      \
         out << "Rank " << rank << " midPipelineExecute before ProcessBatch " \
             << getNodeString(op) << " " << toString(prev_op_result)          \
-            << std::endl;                                                    \
+            << " NumRows=>" << getBatchRows(batch) << std::endl;             \
     } while (0)
 #else
-#define DEBUG_PIPELINE_BEFORE_PROCESS(rank, op, prev_op_result, out) \
-    do {                                                             \
+#define DEBUG_PIPELINE_BEFORE_PROCESS(rank, op, prev_op_result, out, batch) \
+    do {                                                                    \
     } while (0)
 #endif
 
 #if defined(DEBUG_PIPELINE) && (DEBUG_PIPELINE >= 1)
-#define DEBUG_PIPELINE_AFTER_PROCESS(rank, op, prev_op_result, out)           \
+#define DEBUG_PIPELINE_AFTER_PROCESS(rank, op, prev_op_result, out, batch)    \
     do {                                                                      \
         auto after_process_start = hrclock::now();                            \
         auto diff_ms = std::chrono::duration_cast<std::chrono::microseconds>( \
@@ -107,11 +107,12 @@ using hrclock = std::chrono::high_resolution_clock;
             out << " ";                                                       \
         out << "Rank " << rank << " midPipelineExecute after ProcessBatch "   \
             << getNodeString(op) << " " << toString(prev_op_result) << " "    \
-            << diff_ms << "us" << std::endl;                                  \
+            << " NumRows=>" << getBatchRows(batch) << " " << diff_ms << "us"  \
+            << std::endl;                                                     \
     } while (0)
 #else
-#define DEBUG_PIPELINE_AFTER_PROCESS(rank, op, prev_op_result, out) \
-    do {                                                            \
+#define DEBUG_PIPELINE_AFTER_PROCESS(rank, op, prev_op_result, out, batch) \
+    do {                                                                   \
     } while (0)
 #endif
 
@@ -146,7 +147,8 @@ using hrclock = std::chrono::high_resolution_clock;
         for (unsigned i = 0; i < idx; ++i)                                   \
             out << " ";                                                      \
         out << "Rank " << rank << " midPipelineExecute in batch "            \
-            << getNodeString(op) << " " << getBatchRows(batch) << std::endl; \
+            << getNodeString(op) << " NumRows=>" << getBatchRows(batch)      \
+            << std::endl;                                                    \
         std::visit(                                                          \
             [&](auto &x) {                                                   \
                 using T = std::decay_t<decltype(x)>;                         \
@@ -158,12 +160,13 @@ using hrclock = std::chrono::high_resolution_clock;
             batch);                                                          \
     } while (0)
 #elif defined(DEBUG_PIPELINE) && (DEBUG_PIPELINE >= 1)
-#define DEBUG_PIPELINE_IN_BATCH(rank, op, batch, out)                        \
-    do {                                                                     \
-        for (unsigned i = 0; i < idx; ++i)                                   \
-            out << " ";                                                      \
-        out << "Rank " << rank << " midPipelineExecute in batch "            \
-            << getNodeString(op) << " " << getBatchRows(batch) << std::endl; \
+#define DEBUG_PIPELINE_IN_BATCH(rank, op, batch, out)                   \
+    do {                                                                \
+        for (unsigned i = 0; i < idx; ++i)                              \
+            out << " ";                                                 \
+        out << "Rank " << rank << " midPipelineExecute in batch "       \
+            << getNodeString(op) << " NumRows=>" << getBatchRows(batch) \
+            << std::endl;                                               \
     } while (0)
 #else
 #define DEBUG_PIPELINE_IN_BATCH(rank, op, batch, out) \
@@ -188,7 +191,8 @@ bool Pipeline::midPipelineExecute(
         // Iterating here as in the normal section below so that if the sink
         // says HAVE_MORE_OUTPUT that we can iterate with an empty batch.
         while (true) {
-            DEBUG_PIPELINE_BEFORE_CONSUME(rank, sink, prev_op_result, out);
+            DEBUG_PIPELINE_BEFORE_CONSUME(rank, sink, prev_op_result, out,
+                                          batch);
             OperatorResult consume_result;
             std::visit(
                 [&](auto &vop) {
@@ -234,7 +238,7 @@ bool Pipeline::midPipelineExecute(
         PhysicalCpuGpuProcessBatch &op = between_ops[idx];
         DEBUG_PIPELINE_IN_BATCH(rank, op, batch, out);
         while (true) {
-            DEBUG_PIPELINE_BEFORE_PROCESS(rank, op, prev_op_result, out);
+            DEBUG_PIPELINE_BEFORE_PROCESS(rank, op, prev_op_result, out, batch);
 
             // Process this batch with this operator.
             std::variant<std::pair<std::shared_ptr<table_info>, OperatorResult>,
@@ -253,7 +257,7 @@ bool Pipeline::midPipelineExecute(
                 },
                 op);
 
-            DEBUG_PIPELINE_AFTER_PROCESS(rank, op, prev_op_result, out);
+            DEBUG_PIPELINE_AFTER_PROCESS(rank, op, prev_op_result, out, result);
 
             // Execute subsequent operators and if any of them said that
             // no more output is needed or the current operator knows no
@@ -338,7 +342,7 @@ uint64_t Pipeline::Execute(int rank, std::ostream &out) {
         // just for compatibility with other operators' input expectations and
         // simplifying the pipeline code.
 
-        DEBUG_PIPELINE_AFTER_PRODUCE(rank, source, produce_result, out);
+        DEBUG_PIPELINE_AFTER_PRODUCE(rank, source, produce_result, out, result);
         // Run the between_ops and sink of the pipeline allowing repetition
         // in the HAVE_MORE_OUTPUT case.
         finished = midPipelineExecute(0, batch, produce_result, rank, out);

--- a/bodo/pandas/_pipeline.h
+++ b/bodo/pandas/_pipeline.h
@@ -34,6 +34,10 @@ uint64_t getBatchRows(T &t) {
             using U = std::decay_t<decltype(vt)>;
             if constexpr (std::is_same_v<U, std::shared_ptr<table_info>>) {
                 ret = vt->nrows();
+            } else if constexpr (std::is_same_v<
+                                     U, std::pair<std::shared_ptr<table_info>,
+                                                  OperatorResult>>) {
+                ret = vt.first->nrows();
 #ifdef USE_CUDF
             } else if constexpr (std::is_same_v<U, GPU_DATA>) {
                 // Non-GPU ranks return nullptr
@@ -41,6 +45,14 @@ uint64_t getBatchRows(T &t) {
                     ret = 0;
                 } else {
                     ret = vt.table->num_rows();
+                }
+            } else if constexpr (std::is_same_v<
+                                     U, std::pair<GPU_DATA, OperatorResult>>) {
+                // Non-GPU ranks return nullptr
+                if (vt.first.table == nullptr) {
+                    ret = 0;
+                } else {
+                    ret = vt.first.table->num_rows();
                 }
 #endif
             } else {

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -103,10 +103,9 @@ std::unique_ptr<cudf::scalar> make_cudf_scalar_from_value(
     using T = std::decay_t<U>;
 
     if constexpr (std::is_same_v<T, std::string>) {
-        return std::make_unique<cudf::string_scalar>(value, se->stream);
+        return cudf::make_string_scalar(value, se->stream);
     } else if constexpr (std::is_same_v<T, const char *>) {
-        return std::make_unique<cudf::string_scalar>(std::string(value),
-                                                     se->stream);
+        return cudf::make_string_scalar(std::string(value), se->stream);
     } else if constexpr (std::is_same_v<T, bool>) {
         return std::make_unique<cudf::numeric_scalar<int8_t>>(
             static_cast<int8_t>(value), true, se->stream);

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -103,9 +103,10 @@ std::unique_ptr<cudf::scalar> make_cudf_scalar_from_value(
     using T = std::decay_t<U>;
 
     if constexpr (std::is_same_v<T, std::string>) {
-        return cudf::make_string_scalar(value, se->stream);
+        return std::make_unique<cudf::string_scalar>(value, true, se->stream);
     } else if constexpr (std::is_same_v<T, const char *>) {
-        return cudf::make_string_scalar(std::string(value), se->stream);
+        return std::make_unique<cudf::string_scalar>(std::string(value), true,
+                                                     se->stream);
     } else if constexpr (std::is_same_v<T, bool>) {
         return std::make_unique<cudf::numeric_scalar<int8_t>>(
             static_cast<int8_t>(value), true, se->stream);


### PR DESCRIPTION
## Changes included in this PR

We were creating string scalars in such a way that they were not valid and thus filters were matching no rows.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.