### PR TITLE
[GPU] Fix Series.str.match() on CPU and support on GPU

### DIFF
--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1254,6 +1254,8 @@ class PhysicalArrowExpression : public PhysicalExpression {
             result = do_arrow_compute_cast(res, duckdb::LogicalType::DATE);
         } else if (scalar_func_data.arrow_func_name ==
                        "match_substring_regex" ||
+                   scalar_func_data.arrow_func_name ==
+                       "match_substring_regex_first" ||
                    scalar_func_data.arrow_func_name == "starts_with" ||
                    scalar_func_data.arrow_func_name == "ends_with") {
             if (!PyTuple_Check(scalar_func_data.args) ||
@@ -1280,9 +1282,19 @@ class PhysicalArrowExpression : public PhysicalExpression {
                                 scalar_func_data.arrow_func_name));
             }
 
-            arrow::compute::MatchSubstringOptions opts(c_str);
-            result = do_arrow_compute_unary(
-                res, scalar_func_data.arrow_func_name, &opts);
+            std::string func_name = scalar_func_data.arrow_func_name;
+            std::string pattern(c_str);
+            if (func_name == "match_substring_regex_first") {
+                // match_substring_regex in Arrow matches anywhere in the string
+                // but Series.str.match() matches from the start. Add ^ to the
+                // pattern to match from the start same as Pandas:
+                // https://github.com/pandas-dev/pandas/blob/366ccdfcd8ed1e5543bfb6d4ee0c9bc519898670/pandas/core/arrays/_arrow_string_mixins.py#L378
+                func_name = "match_substring_regex";
+                pattern = "^(" + pattern + ")";
+            }
+
+            arrow::compute::MatchSubstringOptions opts(pattern);
+            result = do_arrow_compute_unary(res, func_name, &opts);
         } else if (scalar_func_data.arrow_func_name == "round") {
             int64_t digits = 0;
             if (PyTuple_Check(scalar_func_data.args) &&

--- a/bodo/pandas/physical/gpu_expression.cpp
+++ b/bodo/pandas/physical/gpu_expression.cpp
@@ -500,6 +500,8 @@ bool gpu_capable(duckdb::Expression& expr) {
                            scalar_func_data.arrow_func_name == "starts_with" ||
                            scalar_func_data.arrow_func_name ==
                                "match_substring_regex" ||
+                           scalar_func_data.arrow_func_name ==
+                               "match_substring_regex_first" ||
                            scalar_func_data.arrow_func_name == "year" ||
                            scalar_func_data.arrow_func_name == "round" ||
                            scalar_func_data.arrow_func_name == "is_null";

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -899,17 +899,20 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
         if (scalar_func_data.arrow_func_name != "ends_with" &&
             scalar_func_data.arrow_func_name != "starts_with" &&
             scalar_func_data.arrow_func_name != "match_substring_regex" &&
+            scalar_func_data.arrow_func_name != "match_substring_regex_first" &&
             scalar_func_data.arrow_func_name != "year" &&
             scalar_func_data.arrow_func_name != "round" &&
             scalar_func_data.arrow_func_name != "is_null") {
             throw std::runtime_error(
                 "PhysicalGPUArrowExpression only supports ends_with, "
-                "starts_with, match_substring_regex, year, round and is_null "
-                "for now.");
+                "starts_with, match_substring_regex, "
+                "match_substring_regex_first, "
+                "year, round and is_null for now.");
         }
         if (scalar_func_data.arrow_func_name == "ends_with" ||
             scalar_func_data.arrow_func_name == "starts_with" ||
-            scalar_func_data.arrow_func_name == "match_substring_regex") {
+            scalar_func_data.arrow_func_name == "match_substring_regex" ||
+            scalar_func_data.arrow_func_name == "match_substring_regex_first") {
             extract_string_arg_from_python();
         } else if (scalar_func_data.arrow_func_name == "round") {
             extract_round_arg_from_python();
@@ -939,6 +942,10 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
                    "match_substring_regex") {
             result = cudf::strings::contains_re(in_as_array->result->view(),
                                                 *regex_prog, se->stream);
+        } else if (scalar_func_data.arrow_func_name ==
+                   "match_substring_regex_first") {
+            result = cudf::strings::matches_re(in_as_array->result->view(),
+                                               *regex_prog, se->stream);
         } else if (scalar_func_data.arrow_func_name == "year") {
             result = cudf::datetime::extract_datetime_component(
                 in_as_array->result->view(),
@@ -1016,7 +1023,8 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
                             scalar_func_data.arrow_func_name));
         }
 
-        if (scalar_func_data.arrow_func_name == "match_substring_regex") {
+        if (scalar_func_data.arrow_func_name == "match_substring_regex" ||
+            scalar_func_data.arrow_func_name == "match_substring_regex_first") {
             regex_prog =
                 cudf::strings::regex_program::create(std::string(c_str));
         } else {

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -3013,7 +3013,10 @@ def _get_series_func_plan(
             body = name.split(".")[1]
             return "utf8_" + body[:2] + "_" + body[2:]
         if name == "str.match":
-            return "match_substring_regex"
+            # match_substring_regex in Arrow matches anywhere in the string but
+            # Series.str.match() matches from the start. match_substring_regex_first is
+            # a placeholder for CPU and GPU backends to implement the correct behavior.
+            return "match_substring_regex_first"
         if name == "str.startswith":
             return "starts_with"
         if name == "str.endswith":

--- a/bodo/tests/test_df_lib/series_test_generator.py
+++ b/bodo/tests/test_df_lib/series_test_generator.py
@@ -54,7 +54,7 @@ def generate_series_test(name, df, arg_sets, accessor=None):
     Generates a parameterized test case for Series methods.
     """
     marked_arg_sets = arg_sets.copy()
-    if name == "contains" and accessor == "str":
+    if name in ["contains", "match"] and accessor == "str":
         # Only the first argument set is supported on GPU
         marked_arg_sets[0] = pytest.param(*arg_sets[0], marks=pytest.mark.gpu)
 

--- a/bodo/tests/test_df_lib/test_series_str_methods.py
+++ b/bodo/tests/test_df_lib/test_series_str_methods.py
@@ -237,6 +237,8 @@ df = pd.DataFrame(
             "B-anan-a",
             " E-xc i-ted ",
             "Do-g",
+            # Pattern "A" is not first to distinguish between contains() and match()
+            "lastA",
         ],
     }
 )

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -1429,7 +1429,7 @@ def _test_equal(
 
             # Pandas boolean output may have False instead of NA
             if pa.types.is_boolean(pa_type) and py_out.dtype == np.bool_:
-                bodo_out = _pd_fillna_value(py_out, False)
+                bodo_out = _pd_fillna_value(bodo_out, False)
 
             # Handle NA/nan mismatch
             if pa.types.is_boolean(pa_type) and py_out.dtype == np.object_:


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Needed for TPC-H queries.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Series.str.match() now works on GPU.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.