### PR TITLE
[GPU] BSE-5362: GPU Sort limit and offset

### DIFF
--- a/bodo/libs/streaming/cuda_sort.cpp
+++ b/bodo/libs/streaming/cuda_sort.cpp
@@ -16,11 +16,14 @@ CudaSortState::CudaSortState(
     std::shared_ptr<bodo::Schema> schema,
     std::vector<cudf::size_type> const& key_indices,
     std::vector<cudf::order> const& column_order,
-    std::vector<cudf::null_order> const& null_precedence)
+    std::vector<cudf::null_order> const& null_precedence, int64_t limit,
+    int64_t offset)
     : schema(std::move(schema)),
       key_indices(key_indices),
       column_order(column_order),
-      null_precedence(null_precedence) {}
+      null_precedence(null_precedence),
+      limit(limit),
+      offset(offset) {}
 
 void CudaSortState::ConsumeBatch(std::shared_ptr<cudf::table> table,
                                  std::shared_ptr<StreamAndEvent> input_se) {
@@ -227,6 +230,53 @@ void CudaSortState::ExecutePsrsStep2(rmm::cuda_stream_view stream) {
                                  std::move(split_indices), se);
 }
 
+void CudaSortState::FinalizeSort() {
+    if (!is_gpu_rank()) {
+        return;
+    }
+    if (state != State::MERGING) {
+        throw std::runtime_error(
+            "FinalizeSort called before FinalizeAccumulation finished");
+    }
+
+    int64_t local_nrows = 0;
+    for (const auto& table : received_tables) {
+        local_nrows += table->num_rows();
+    }
+
+    MPI_Comm comm = shuffle_manager.get_mpi_comm();
+    int n_pes, myrank;
+    MPI_Comm_size(comm, &n_pes);
+    MPI_Comm_rank(comm, &myrank);
+
+    std::vector<int64_t> nrows_collect(n_pes);
+    CHECK_MPI(MPI_Allgather(&local_nrows, 1, MPI_INT64_T, nrows_collect.data(),
+                            1, MPI_INT64_T, comm),
+              "CudaSortState::FinalizeSort: MPI error on MPI_Allgather");
+
+    int64_t total_rows_before = 0;
+    for (int i = 0; i < myrank; i++) {
+        total_rows_before += nrows_collect[i];
+    }
+
+    bool is_beyond_limit = (limit != -1 && total_rows_before >= limit + offset);
+    bool is_before_offset = (total_rows_before + local_nrows <= offset);
+
+    if (is_beyond_limit || is_before_offset || limit == 0) {
+        local_slice_start = 0;
+        local_slice_end = 0;
+    } else {
+        local_slice_start = std::max(0L, offset - total_rows_before);
+        int64_t local_limit = local_nrows - local_slice_start;
+        if (limit != -1) {
+            local_limit =
+                std::min(local_limit, limit + offset - total_rows_before -
+                                          local_slice_start);
+        }
+        local_slice_end = local_slice_start + local_limit;
+    }
+}
+
 std::unique_ptr<cudf::table> CudaSortState::GetOutputBatch(
     bool& out_is_last, rmm::cuda_stream_view stream) {
     if (state != State::MERGING) {
@@ -235,7 +285,7 @@ std::unique_ptr<cudf::table> CudaSortState::GetOutputBatch(
     }
 
     if (final_result == nullptr) {
-        if (received_tables.empty()) {
+        if (received_tables.empty() || local_slice_start == local_slice_end) {
             final_result =
                 empty_table_from_arrow_schema(schema->ToArrowSchema());
         } else {
@@ -244,8 +294,19 @@ std::unique_ptr<cudf::table> CudaSortState::GetOutputBatch(
                 views.push_back(table->view());
             }
             // Multi-way Merge
-            final_result = cudf::merge(views, key_indices, column_order,
-                                       null_precedence, stream);
+            auto merged = cudf::merge(views, key_indices, column_order,
+                                      null_precedence, stream);
+
+            if (local_slice_start == 0 &&
+                local_slice_end == merged->num_rows()) {
+                final_result = std::move(merged);
+            } else {
+                std::vector<cudf::size_type> indices = {
+                    static_cast<cudf::size_type>(local_slice_start),
+                    static_cast<cudf::size_type>(local_slice_end)};
+                auto sliced = cudf::slice(merged->view(), indices);
+                final_result = std::make_unique<cudf::table>(sliced[0]);
+            }
         }
         received_tables.clear();
     }

--- a/bodo/libs/streaming/cuda_sort.cpp
+++ b/bodo/libs/streaming/cuda_sort.cpp
@@ -329,6 +329,10 @@ std::unique_ptr<cudf::table> CudaSortState::GetOutputBatch(
                 local_slice_end == merged->num_rows()) {
                 final_result = std::move(merged);
             } else {
+                // Ideally we'd not have to merge all the data just to slice out
+                // a portion of it, but cudf doesn't support top-k style
+                // multi-way merge that would allow us to only merge up to the
+                // offset + limit.
                 std::vector<cudf::size_type> indices = {
                     static_cast<cudf::size_type>(local_slice_start),
                     static_cast<cudf::size_type>(local_slice_end)};

--- a/bodo/libs/streaming/cuda_sort.cpp
+++ b/bodo/libs/streaming/cuda_sort.cpp
@@ -9,6 +9,7 @@
 #include "../_utils.h"
 #include "../gpu_utils.h"
 #include "_util.h"
+#include "physical/operator.h"
 
 #ifdef USE_CUDF
 
@@ -27,13 +28,38 @@ CudaSortState::CudaSortState(
 
 void CudaSortState::ConsumeBatch(std::shared_ptr<cudf::table> table,
                                  std::shared_ptr<StreamAndEvent> input_se) {
+    static int batch_size = get_streaming_batch_size();
     if (table->num_rows() == 0) {
         return;
     }
     std::unique_ptr<cudf::table> sorted_table =
         cudf::sort_by_key(table->view(), table->select(key_indices),
                           column_order, null_precedence, input_se->stream);
+    total_rows_in_buffer += sorted_table->num_rows();
     accumulation_buffer.push_back(std::move(sorted_table));
+
+    // Top-K optimization: if we have a limit + offset, we only need to keep
+    // the top K elements locally on each rank.
+    if (limit != -1 && total_rows_in_buffer > limit + offset &&
+        accumulation_buffer.size() >= static_cast<size_t>(batch_size)) {
+        std::vector<cudf::table_view> views;
+        for (const auto& t : accumulation_buffer) {
+            views.push_back(t->view());
+        }
+        auto merged = cudf::merge(views, key_indices, column_order,
+                                  null_precedence, input_se->stream);
+
+        int64_t target_rows = limit + offset;
+        if (merged->num_rows() > target_rows) {
+            std::vector<cudf::size_type> split_indices = {
+                0, static_cast<cudf::size_type>(target_rows)};
+            auto sliced = cudf::slice(merged->view(), split_indices);
+            merged = std::make_unique<cudf::table>(sliced[0]);
+        }
+        total_rows_in_buffer = merged->num_rows();
+        accumulation_buffer.clear();
+        accumulation_buffer.push_back(std::move(merged));
+    }
 }
 
 bool CudaSortState::FinalizeAccumulation(
@@ -92,8 +118,10 @@ void CudaSortState::ExecutePsrsStep1(rmm::cuda_stream_view stream) {
         local_table = cudf::merge(views, key_indices, column_order,
                                   null_precedence, stream);
         accumulation_buffer.clear();
+        total_rows_in_buffer = 0;
     } else {
         local_table = empty_table_from_arrow_schema(schema->ToArrowSchema());
+        total_rows_in_buffer = 0;
     }
 
     MPI_Comm comm = sample_gatherer.get_mpi_comm();

--- a/bodo/libs/streaming/cuda_sort.h
+++ b/bodo/libs/streaming/cuda_sort.h
@@ -16,7 +16,8 @@ class CudaSortState {
     CudaSortState(std::shared_ptr<bodo::Schema> schema,
                   std::vector<cudf::size_type> const& key_indices,
                   std::vector<cudf::order> const& column_order,
-                  std::vector<cudf::null_order> const& null_precedence);
+                  std::vector<cudf::null_order> const& null_precedence,
+                  int64_t limit = -1, int64_t offset = 0);
 
     /**
      * @brief Consume a batch of data to be sorted.
@@ -34,6 +35,14 @@ class CudaSortState {
      */
     bool FinalizeAccumulation(bool local_is_last,
                               std::shared_ptr<StreamAndEvent> input_se);
+
+    /**
+     * @brief Finalize the sort phase and compute limits/offsets across ranks.
+     * This MUST be called exactly once by all ranks after
+     * FinalizeAccumulation returns true and before any calls to
+     * GetOutputBatch.
+     */
+    void FinalizeSort();
 
     /**
      * @brief Get the sorted output batch.
@@ -55,6 +64,8 @@ class CudaSortState {
     std::vector<cudf::size_type> key_indices;
     std::vector<cudf::order> column_order;
     std::vector<cudf::null_order> null_precedence;
+    const int64_t limit;
+    const int64_t offset;
 
     // Accumulation buffer for local batches
     std::vector<std::shared_ptr<cudf::table>> accumulation_buffer;
@@ -64,6 +75,10 @@ class CudaSortState {
 
     // Final merged result
     std::unique_ptr<cudf::table> final_result = nullptr;
+
+    // Local slice indices (pre-calculated in FinalizeSort)
+    int64_t local_slice_start = 0;
+    int64_t local_slice_end = 0;
 
     GpuRangeShuffleManager shuffle_manager;
     GpuTableAllGatherManager sample_gatherer;

--- a/bodo/libs/streaming/cuda_sort.h
+++ b/bodo/libs/streaming/cuda_sort.h
@@ -69,6 +69,7 @@ class CudaSortState {
 
     // Accumulation buffer for local batches
     std::vector<std::shared_ptr<cudf::table>> accumulation_buffer;
+    int64_t total_rows_in_buffer = 0;
 
     // Received tables from shuffle
     std::vector<std::shared_ptr<cudf::table>> received_tables;

--- a/bodo/pandas/physical/gpu_sort.h
+++ b/bodo/pandas/physical/gpu_sort.h
@@ -13,7 +13,7 @@
 
 inline bool gpu_capable(duckdb::LogicalOrder& op) { return true; }
 
-inline bool gpu_capable(duckdb::LogicalTopN& op) { return false; }
+inline bool gpu_capable(duckdb::LogicalTopN& op) { return true; }
 
 struct PhysicalGPUSortMetrics {
     using stat_t = MetricBase::StatValue;
@@ -40,12 +40,6 @@ class PhysicalGPUSortOperator : public PhysicalGPUSource,
         int64_t offset, unsigned node_cols,
         const std::vector<duckdb::idx_t>& projection_map = {}) {
         time_pt start_init = start_timer();
-
-        if (limit != -1 || offset != -1) {
-            throw std::runtime_error(
-                "PhysicalGPUSortOperator: limit and offset are not yet "
-                "supported.");
-        }
 
         // Calculate the output schema and kept columns.
         this->output_schema = std::make_shared<bodo::Schema>();
@@ -131,7 +125,8 @@ class PhysicalGPUSortOperator : public PhysicalGPUSource,
         }
 
         this->cuda_sort_state = std::make_unique<CudaSortState>(
-            input_schema, key_indices, column_order, null_precedence);
+            input_schema, key_indices, column_order, null_precedence, limit,
+            offset);
 
         this->metrics.init_time = end_timer(start_init);
     }
@@ -158,7 +153,7 @@ class PhysicalGPUSortOperator : public PhysicalGPUSource,
 
     virtual ~PhysicalGPUSortOperator() = default;
 
-    void FinalizeSink() override {}
+    void FinalizeSink() override { cuda_sort_state->FinalizeSort(); }
 
     void FinalizeSource() override {
         QueryProfileCollector::Default().SubmitOperatorName(getOpId(),

--- a/bodo/tests/test_streaming/test_cuda_sort.cpp
+++ b/bodo/tests/test_streaming/test_cuda_sort.cpp
@@ -94,19 +94,21 @@ void run_cuda_sort_test(
     std::vector<cudf::null_order> const& null_precedence,
     std::function<std::unique_ptr<cudf::table>(int, int, size_t&)>
         create_input_fn,
+    int64_t limit = -1, int64_t offset = -1,
     std::function<void(cudf::table_view, int, int, MPI_Comm)> extra_verify_fn =
         nullptr) {
     rmm::cuda_device_id device_id = get_gpu_id();
     if (device_id.value() >= 0) {
         cudaSetDevice(device_id.value());
     }
-    CudaSortState sort_state(schema, key_indices, column_order,
-                             null_precedence);
+    CudaSortState sort_state(schema, key_indices, column_order, null_precedence,
+                             limit, offset);
     if (!is_gpu_rank()) {
         bool global_is_last = false;
         while (!global_is_last) {
             global_is_last = sort_state.FinalizeAccumulation(true, nullptr);
         }
+        sort_state.FinalizeSort();
         return;
     }
     MPI_Comm gpu_comm = sort_state.get_mpi_comm();
@@ -126,6 +128,7 @@ void run_cuda_sort_test(
     while (!global_is_last) {
         global_is_last = sort_state.FinalizeAccumulation(true, se);
     }
+    sort_state.FinalizeSort();
 
     bool out_is_last = false;
     auto output =
@@ -146,7 +149,15 @@ void run_cuda_sort_test(
                             MPI_SUM, gpu_comm),
               "MPI_Allreduce failed");
 
-    bodo::tests::check(total_rows == expected_total);
+    int64_t expected_after_limit = expected_total;
+    if (offset > 0) {
+        expected_after_limit = std::max(0L, expected_after_limit - offset);
+    }
+    if (limit != -1) {
+        expected_after_limit = std::min((int64_t)expected_after_limit, limit);
+    }
+
+    bodo::tests::check((int64_t)total_rows == expected_after_limit);
 
     // Verify global order across ranks (on the first key column)
     auto const& col = output->get_column(key_indices[0]);
@@ -336,6 +347,7 @@ static bodo::tests::suite cuda_sort_tests([] {
                     cols.push_back(std::move(key_col));
                     return std::make_unique<cudf::table>(std::move(cols));
                 },
+                -1, -1,
                 [](cudf::table_view output, int rank, int n_ranks,
                    MPI_Comm comm) {
                     int num_rows = output.num_rows();
@@ -391,4 +403,24 @@ static bodo::tests::suite cuda_sort_tests([] {
                 });
         },
         {"gpu_cpp"});
+
+    bodo::tests::test("test_cuda_sort_limit_offset",
+                      [] {
+                          run_cuda_sort_test(
+                              make_simple_int64_schema(1), {0},
+                              {cudf::order::ASCENDING},
+                              {cudf::null_order::BEFORE},
+                              [](int rank, int n_ranks, size_t& rows_count) {
+                                  std::vector<int64_t> vals;
+                                  if (rank == 0) {
+                                      vals = {50, 10, 80, 30};
+                                  } else if (rank == 1) {
+                                      vals = {20, 70, 40, 60};
+                                  }
+                                  rows_count = vals.size();
+                                  return create_int_table_to_sort(vals);
+                              },
+                              3, 2);  // limit=3, offset=2
+                      },
+                      {"gpu_cpp"});
 });

--- a/docs/docs/api_docs/dataframe_lib/series/sort_values.md
+++ b/docs/docs/api_docs/dataframe_lib/series/sort_values.md
@@ -12,6 +12,8 @@ BodoSeries.sort_values(
         key: ValueKeyFunc | None = None,
     ) -> BodoSeries
 ```
+
+**GPU:** ✔ Supported
 Sorts the elements of the BodoSeries and returns a new sorted BodoSeries.
 
 <p class="api-header">Parameters</p>

--- a/docs/docs/api_docs/pandas/dataframe/drop_duplicates.md
+++ b/docs/docs/api_docs/pandas/dataframe/drop_duplicates.md
@@ -2,6 +2,7 @@
 
 
 `pandas.DataFrame.drop_duplicates(subset=None, keep='first', inplace=False, ignore_index=False)`
+**GPU:** ✔ Supported
 
 
 ### Supported Arguments

--- a/docs/docs/api_docs/pandas/dataframe/merge.md
+++ b/docs/docs/api_docs/pandas/dataframe/merge.md
@@ -2,6 +2,7 @@
 
 
 `pandas.DataFrame.merge(right, how='inner', on=None, left_on=None, right_on=None, left_index=False, right_index=False, sort=False, suffixes=('_x', '_y'), copy=True, indicator=False, validate=None)`
+**GPU:** ✔ Supported
 
 
 !!! note

--- a/docs/docs/api_docs/pandas/dataframe/sort_values.md
+++ b/docs/docs/api_docs/pandas/dataframe/sort_values.md
@@ -1,6 +1,7 @@
 # `pd.DataFrame.sort_values`
 
 `pandas.DataFrame.sort_values(by, axis=0, ascending=True, inplace=False, kind='quicksort', na_position='last', ignore_index=False, key=None)`
+**GPU:** ✔ Supported
 
 ### Supported Arguments
 

--- a/docs/docs/api_docs/pandas/dataframe/to_parquet.md
+++ b/docs/docs/api_docs/pandas/dataframe/to_parquet.md
@@ -1,6 +1,7 @@
 # `pd.DataFrame.to_parquet`
 
 `pandas.DataFrame.to_parquet(path, engine='auto', compression='snappy', index=None, partition_cols=None, storage_options=None)`
+**GPU:** ✔ Supported
 
 ### Supported Arguments
 * `path` is a required argument and must be a string. When writing distributed dataframes, the path refers to a directory of parquet files.

--- a/docs/docs/guides/dataframes/gpu_acceleration.md
+++ b/docs/docs/guides/dataframes/gpu_acceleration.md
@@ -144,6 +144,10 @@ The listed aggregations (sum, count, mean, min, max, var, std, size, skew, nuniq
 
 Inner equi-joins are supported on GPU. Joins with non-equality predicates (range joins, inequality joins, or arbitrary expressions) are not supported on GPU and will run on CPU.
 
+### Sorting
+
+Sorting is supported on the GPU, including top-k sorts and offsets into the sorted output.
+
 ## Troubleshooting
 
 If execution is slower than expected, confirm the operators in your plan are supported on GPU (see supported list).

--- a/docs/docs/guides/dataframes/gpu_acceleration.md
+++ b/docs/docs/guides/dataframes/gpu_acceleration.md
@@ -112,15 +112,13 @@ Below is a concise summary of broad capabilities that can run on GPU today, foll
 
 * GroupBy aggregations: sum, count, mean, min, max, var, std, size, skew, nunique
 
-* Inner joins with equality conditions.
-
 * drop_duplicates
 
 ## Unsupported Capabilities
 
 No other input types (Pandas dataframe, CSV, remote Iceberg reads, etc.) are currently supported on GPU. Those reads run on CPU.
 
-Limit, sampling, CTEs, sorting, quantiles, and union are not currently supported.
+Sampling, quantiles, and union distinct are not currently supported.
 
 ## Important Per-Feature Caveats
 
@@ -142,7 +140,7 @@ The listed aggregations (sum, count, mean, min, max, var, std, size, skew, nuniq
 
 ### Joins
 
-Inner equi-joins are supported on GPU. Joins with non-equality predicates (range joins, inequality joins, or arbitrary expressions) are not supported on GPU and will run on CPU.
+Joins are supported on GPU.
 
 ### Sorting
 


### PR DESCRIPTION
## Changes included in this PR
Adds limit and offset to cuda sort, enabling TopN.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
New unit test and tpch on pr ci
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Full GPU sort support
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.