### PR TITLE
[GPU] Support Series.isin() on GPU

### DIFF
--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1340,8 +1340,8 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
                                                                       false);
 
             case arrow::Type::BOOL:
-                return std::make_unique<cudf::numeric_scalar<int8_t>>(
-                    static_cast<int8_t>(false), false);
+                return std::make_unique<cudf::numeric_scalar<bool>>(false,
+                                                                    false);
 
             case arrow::Type::LARGE_STRING:
             case arrow::Type::STRING:
@@ -1438,10 +1438,8 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
                 std::static_pointer_cast<arrow::DoubleScalar>(s)->value, true);
 
         case arrow::Type::BOOL:
-            return std::make_unique<cudf::numeric_scalar<int8_t>>(
-                static_cast<int8_t>(
-                    std::static_pointer_cast<arrow::BooleanScalar>(s)->value),
-                true);
+            return std::make_unique<cudf::numeric_scalar<bool>>(
+                std::static_pointer_cast<arrow::BooleanScalar>(s)->value, true);
 
         // ---------------- STRINGS / BINARY ----------------
         case arrow::Type::STRING: {

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1125,6 +1125,29 @@ std::tuple<int64_t, int64_t, int64_t> get_py_slice_args(PyObject *args) {
 template std::tuple<int64_t, int64_t, int64_t> get_py_slice_args<int64_t>(
     PyObject *args);
 
+std::shared_ptr<arrow::Array> get_py_isin_arg_as_arrow_array(PyObject *args) {
+    if (!PyTuple_Check(args) || PyTuple_Size(args) != 1) {
+        throw std::runtime_error("isin args not a 1-element tuple.");
+    }
+
+    // Get the first element (borrowed reference)
+    PyObject *py_arg = PyTuple_GetItem(args, 0);
+
+    // Convert the Python object to an Arrow array
+    // https://arrow.apache.org/docs/python/integration/extending.html
+    if (arrow::py::import_pyarrow() != 0) {
+        throw std::runtime_error("Failed to import pyarrow module.");
+    }
+    arrow::Result<std::shared_ptr<arrow::Array>> result =
+        arrow::py::unwrap_array(py_arg);
+    if (!result.ok()) {
+        throw std::runtime_error(
+            "Failed to convert isin argument to Arrow array: " +
+            result.status().ToString());
+    }
+    return result.ValueOrDie();
+}
+
 #ifdef USE_CUDF
 
 template std::tuple<int64_t, int64_t, int64_t>

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -422,6 +422,15 @@ int64_t get_py_round_arg(PyObject *args);
 template <typename StopMaxT = int64_t>
 std::tuple<int64_t, int64_t, int64_t> get_py_slice_args(PyObject *args);
 
+/**
+ * @brief Convert isin argument from Python to an Arrow array. The argument is
+ * expected to be a PyArrow array.
+ *
+ * @param args Python tuple containing the function arguments
+ * @return std::shared_ptr<arrow::Array> The converted Arrow array
+ */
+std::shared_ptr<arrow::Array> get_py_isin_arg_as_arrow_array(PyObject *args);
+
 #ifdef USE_CUDF
 
 #include <cstdint>

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1291,6 +1291,11 @@ class PhysicalArrowExpression : public PhysicalExpression {
 
             arrow::compute::SliceOptions opts(start, stop, step);
             result = do_arrow_compute_unary(res, "utf8_slice_codeunits", &opts);
+        } else if (scalar_func_data.arrow_func_name == "is_in") {
+            std::shared_ptr<arrow::Array> values_array =
+                get_py_isin_arg_as_arrow_array(scalar_func_data.args);
+            arrow::compute::SetLookupOptions opts(values_array);
+            result = do_arrow_compute_unary(res, "is_in", &opts);
         } else {
             result =
                 do_arrow_compute_unary(res, scalar_func_data.arrow_func_name);

--- a/bodo/pandas/physical/gpu_expression.cpp
+++ b/bodo/pandas/physical/gpu_expression.cpp
@@ -506,6 +506,7 @@ bool gpu_capable(duckdb::Expression& expr) {
                                "utf8_slice_codeunits" ||
                            scalar_func_data.arrow_func_name == "year" ||
                            scalar_func_data.arrow_func_name == "round" ||
+                           scalar_func_data.arrow_func_name == "is_in" ||
                            scalar_func_data.arrow_func_name == "is_null";
                 } else if (scalar_func_data.args) {
                     return false;

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -974,9 +974,8 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
         } else if (scalar_func_data.arrow_func_name == "is_null") {
             result = cudf::is_null(in_as_array->result->view(), se->stream);
         } else if (scalar_func_data.arrow_func_name == "is_in") {
-            result =
-                cudf::contains(in_as_array->result->view(),
-                               isin_data->get_column(0).view(), se->stream);
+            result = cudf::contains(isin_data->get_column(0).view(),
+                                    in_as_array->result->view(), se->stream);
         } else {
             throw std::runtime_error(
                 fmt::format("Unsupported Arrow function: {}",

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -6,6 +6,7 @@
 #include <arrow/compute/kernel.h>
 #include <arrow/result.h>
 #include <arrow/status.h>
+#include <arrow/table.h>
 #include <arrow/type_traits.h>
 #include <future>
 #include <rmm/cuda_stream_view.hpp>
@@ -29,6 +30,7 @@
 #include <cudf/round.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/search.hpp>
 #include <cudf/strings/contains.hpp>
 #include <cudf/strings/find.hpp>
 #include <cudf/strings/regex/regex_program.hpp>
@@ -900,12 +902,13 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
             scalar_func_data.arrow_func_name != "utf8_slice_codeunits" &&
             scalar_func_data.arrow_func_name != "year" &&
             scalar_func_data.arrow_func_name != "round" &&
-            scalar_func_data.arrow_func_name != "is_null") {
+            scalar_func_data.arrow_func_name != "is_null" &&
+            scalar_func_data.arrow_func_name != "is_in") {
             throw std::runtime_error(
                 "PhysicalGPUArrowExpression only supports ends_with, "
                 "starts_with, match_substring_regex, "
                 "match_substring_regex_first, "
-                "year, round and is_null for now.");
+                "year, round, is_null and is_in for now.");
         }
         if (scalar_func_data.arrow_func_name == "ends_with" ||
             scalar_func_data.arrow_func_name == "starts_with" ||
@@ -916,6 +919,8 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
             round_ndigits = get_py_round_arg(scalar_func_data.args);
         } else if (scalar_func_data.arrow_func_name == "utf8_slice_codeunits") {
             extract_slice_arg_from_python();
+        } else if (scalar_func_data.arrow_func_name == "is_in") {
+            extract_isin_arg_from_python();
         }
     }
 
@@ -968,6 +973,10 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
 #pragma GCC diagnostic pop
         } else if (scalar_func_data.arrow_func_name == "is_null") {
             result = cudf::is_null(in_as_array->result->view(), se->stream);
+        } else if (scalar_func_data.arrow_func_name == "is_in") {
+            result =
+                cudf::contains(in_as_array->result->view(),
+                               isin_data->get_column(0).view(), se->stream);
         } else {
             throw std::runtime_error(
                 fmt::format("Unsupported Arrow function: {}",
@@ -1018,6 +1027,19 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
             get_py_slice_args<cudf::size_type>(scalar_func_data.args);
     }
 
+    void extract_isin_arg_from_python() {
+        std::shared_ptr<arrow::Array> values_array =
+            get_py_isin_arg_as_arrow_array(scalar_func_data.args);
+
+        // Convert isin input to cudf table
+        std::shared_ptr<arrow::Table> values_table = arrow::Table::Make(
+            arrow::schema({arrow::field("values", values_array->type())}),
+            {values_array});
+        GPU_DATA gpu_data = convertArrowTableToGPU(values_table, nullptr);
+
+        isin_data = gpu_data.table;
+    }
+
     // Keeping reference to the cudf string scalar created from the Python
     // string argument to ensure it stays alive during processing.
     std::shared_ptr<cudf::string_scalar> str_scalar_in;
@@ -1031,6 +1053,9 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
     int64_t start = 0;
     int64_t stop = 0;
     int64_t step = 0;
+
+    // isin argument
+    std::shared_ptr<cudf::table> isin_data;
 };
 
 struct PhysicalGPUUDFExpressionMetrics {

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -27,6 +27,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/datetime.hpp>
+#include <cudf/replace.hpp>
 #include <cudf/round.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
@@ -976,6 +977,18 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
         } else if (scalar_func_data.arrow_func_name == "is_in") {
             result = cudf::contains(isin_data->get_column(0).view(),
                                     in_as_array->result->view(), se->stream);
+            // handle nulls in input to match Pandas similar to cudf:
+            // https://github.com/rapidsai/cudf/blob/1fd16fda34a6e78777330f4e02bdd122a6977a22/python/cudf/cudf/core/column/column.py#L2164
+            if (in_as_array->result->has_nulls()) {
+                std::unique_ptr<cudf::scalar> fill_scalar =
+                    arrow_scalar_to_cudf(
+                        arrow::MakeScalar(arrow::boolean(),
+                                          isin_data->get_column(0).has_nulls())
+                            .ValueOrDie(),
+                        se->stream);
+                result = cudf::replace_nulls(result->view(), *fill_scalar,
+                                             se->stream);
+            }
         } else {
             throw std::runtime_error(
                 fmt::format("Unsupported Arrow function: {}",

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -1,7 +1,6 @@
 #include "operator.h"
 #include <arrow/array/builder_base.h>
 #include <arrow/util/endian.h>
-#include <cudf/utilities/default_stream.hpp>
 #include <memory>
 #include <string>
 
@@ -10,6 +9,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 #include "../../libs/gpu_utils.h"

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -1,6 +1,7 @@
 #include "operator.h"
 #include <arrow/array/builder_base.h>
 #include <arrow/util/endian.h>
+#include <cudf/utilities/default_stream.hpp>
 #include <memory>
 #include <string>
 
@@ -296,7 +297,8 @@ GPU_DATA convertArrowTableToGPU(std::shared_ptr<arrow::Table> arrow_table,
     // from_arrow_host parses the structs, allocates GPU memory, and performs
     // the copy.
     std::unique_ptr<cudf::table> result =
-        cudf::from_arrow_host(&arrow_schema, &device_array, se->stream);
+        cudf::from_arrow_host(&arrow_schema, &device_array,
+                              se ? se->stream : cudf::get_default_stream());
 
     // Clean up the C structs (Arrow requires manual release if not imported,
     // but Export gives us ownership, so we must release the release callbacks)

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -1202,17 +1202,6 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         from bodo.ext import plan_optimizer
         from bodo.pandas.base import _empty_like
 
-        # If the number of possible values is small then it will be faster to run them as
-        # a conjunction of equality checks rather than with an expensive UDF.
-        if not isinstance(values, BodoSeries) and len(values) <= 4:
-            ret = None
-            for val in values:
-                if ret is None:
-                    ret = self == val
-                else:
-                    ret = ret | (self == val)
-            return ret
-
         new_metadata = pd.Series(
             dtype=pd.ArrowDtype(pa.bool_()),
             name=self.name,
@@ -1284,6 +1273,8 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
             return wrap_plan(proj_plan)
 
         # It's just a map function if 'values' is not a BodoSeries
+        # prepare input for Arrow backend
+        values = pa.array(values, type=self.head(0).dtype.pyarrow_dtype)
         return _get_series_func_plan(self._plan, new_metadata, "isin", (values,), {})
 
     @check_args_fallback(supported=["drop", "name", "level"])
@@ -3046,6 +3037,7 @@ def _get_series_func_plan(
         "round",
         "isna",
         "isnull",
+        "isin",
     )
 
     def get_arrow_func(name):
@@ -3074,6 +3066,8 @@ def _get_series_func_plan(
             return "round"
         if name in ("isna", "isnull"):
             return "is_null"
+        if name == "isin":
+            return "is_in"
         return name.split(".")[-1]
 
     if func in arrow_compute_list and len(kwargs) == 0:

--- a/bodo/tests/test_df_lib/test_direct_series_methods.py
+++ b/bodo/tests/test_df_lib/test_direct_series_methods.py
@@ -80,7 +80,7 @@ def _install_series_direct_tests():
     """Installs tests for direct Series.<method> methods."""
     for method_name, arg_sets in test_map_arg_direct.items():
         test = generate_series_test(method_name, df, arg_sets)
-        if method_name == "isnull":
+        if method_name in ("isnull", "isin"):
             test = pytest.mark.gpu(test)
         globals()[f"test_dir_{method_name}"] = test
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Supports `Series.isin()` (that is not called on another Series) on GPU. Needed for TPC-H.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Series.isin() now works on GPU.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.