### PR TITLE
[GPU] Assert sort runs on GPU in tests

### DIFF
--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -998,7 +998,7 @@ bool cpu_fallback_disabled() {
  *
  */
 bool ignore_cpu_fallback(duckdb::LogicalOperator const &op) {
-    // Only explicitly allow fallback for DataFrame source and sort.
+    // Only explicitly allow fallback for DataFrame source.
     if (op.type == duckdb::LogicalOperatorType::LOGICAL_GET) {
         duckdb::LogicalGet const &get_op = op.Cast<duckdb::LogicalGet>();
         return get_op.bind_data->Cast<BodoScanFunctionData>()

--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -1005,7 +1005,7 @@ bool ignore_cpu_fallback(duckdb::LogicalOperator const &op) {
                    .getScanFunctionType() ==
                BodoScanFunctionType::DATAFRAME_SCAN;
     }
-    return op.type == duckdb::LogicalOperatorType::LOGICAL_ORDER_BY;
+    return false;
 }
 
 #endif  // USE_CUDF


### PR DESCRIPTION
## Changes included in this PR

Assert sort runs on GPU in tests.

## Testing strategy

GPU PR CI ran+passed

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.