### PR TITLE
[GPU] Fix join expression column reference handling and reduction output

### DIFF
--- a/bodo/pandas/physical/gpu_expression.cpp
+++ b/bodo/pandas/physical/gpu_expression.cpp
@@ -971,7 +971,10 @@ void tableFilterSetToCudfAST(
 
 CudfASTOwner build_mixed_join_predicate(
     const std::vector<duckdb::unique_ptr<duckdb::Expression>>& exprs,
-    const std::unordered_set<duckdb::idx_t>& left_table_indices,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>&
+        left_col_ref_map,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>&
+        right_col_ref_map,
     rmm::cuda_stream_view& stream) {
     if (exprs.empty()) {
         throw std::runtime_error(
@@ -981,15 +984,15 @@ CudfASTOwner build_mixed_join_predicate(
     CudfASTOwner owner;
 
     // Convert the first expression — its root becomes the accumulator.
-    const cudf::ast::expression* acc =
-        &duckdb_expr_to_cudf_ast(*exprs[0], left_table_indices, owner, stream);
+    const cudf::ast::expression* acc = &duckdb_expr_to_cudf_ast(
+        *exprs[0], left_col_ref_map, right_col_ref_map, owner, stream);
 
     // Each subsequent expression is converted into the same owner and
     // AND-ed with the accumulated root. Because all nodes live in the
     // same tree, the references remain valid.
     for (size_t i = 1; i < exprs.size(); ++i) {
         const cudf::ast::expression& rhs = duckdb_expr_to_cudf_ast(
-            *exprs[i], left_table_indices, owner, stream);
+            *exprs[i], left_col_ref_map, right_col_ref_map, owner, stream);
         acc = &owner.push(cudf::ast::operation(
             cudf::ast::ast_operator::LOGICAL_AND, *acc, rhs));
     }
@@ -999,19 +1002,30 @@ CudfASTOwner build_mixed_join_predicate(
 
 const cudf::ast::expression& duckdb_expr_to_cudf_ast(
     const duckdb::Expression& expr,
-    const std::unordered_set<duckdb::idx_t>& left_table_indices,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>&
+        left_col_ref_map,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>&
+        right_col_ref_map,
     CudfASTOwner& owner, rmm::cuda_stream_view& stream) {
     switch (expr.expression_class) {
         case duckdb::ExpressionClass::BOUND_COLUMN_REF: {
             auto& col_ref = expr.Cast<duckdb::BoundColumnRefExpression>();
+            size_t col_idx;
+            cudf::ast::table_reference table_ref;
+            auto key = std::make_pair(col_ref.binding.table_index,
+                                      col_ref.binding.column_index);
+            if (left_col_ref_map.count(key)) {
+                col_idx = left_col_ref_map.at(key);
+                table_ref = cudf::ast::table_reference::LEFT;
+            } else if (right_col_ref_map.count(key)) {
+                col_idx = right_col_ref_map.at(key);
+                table_ref = cudf::ast::table_reference::RIGHT;
+            } else {
+                throw std::runtime_error(
+                    "duckdb_expr_to_cudf_ast: column reference not found in "
+                    "either left or right map");
+            }
 
-            duckdb::idx_t table_idx = col_ref.binding.table_index;
-            duckdb::idx_t col_idx = col_ref.binding.column_index;
-
-            cudf::ast::table_reference table_ref =
-                left_table_indices.count(table_idx)
-                    ? cudf::ast::table_reference::LEFT
-                    : cudf::ast::table_reference::RIGHT;
             return owner.push(cudf::ast::column_reference(col_idx, table_ref));
         } break;
 
@@ -1028,9 +1042,9 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
             auto& cmp = expr.Cast<duckdb::BoundComparisonExpression>();
 
             const cudf::ast::expression& lhs = duckdb_expr_to_cudf_ast(
-                *cmp.left, left_table_indices, owner, stream);
+                *cmp.left, left_col_ref_map, right_col_ref_map, owner, stream);
             const cudf::ast::expression& rhs = duckdb_expr_to_cudf_ast(
-                *cmp.right, left_table_indices, owner, stream);
+                *cmp.right, left_col_ref_map, right_col_ref_map, owner, stream);
 
             cudf::ast::ast_operator op = duckdb_etype_to_cudf_ast_op(expr.type);
             return owner.push(cudf::ast::operation(op, lhs, rhs));
@@ -1047,12 +1061,14 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
 
             cudf::ast::ast_operator op = duckdb_etype_to_cudf_ast_op(expr.type);
 
-            const cudf::ast::expression* acc = &duckdb_expr_to_cudf_ast(
-                *conj.children[0], left_table_indices, owner, stream);
+            const cudf::ast::expression* acc =
+                &duckdb_expr_to_cudf_ast(*conj.children[0], left_col_ref_map,
+                                         right_col_ref_map, owner, stream);
 
             for (size_t i = 1; i < conj.children.size(); ++i) {
-                const cudf::ast::expression& rhs = duckdb_expr_to_cudf_ast(
-                    *conj.children[i], left_table_indices, owner, stream);
+                const cudf::ast::expression& rhs =
+                    duckdb_expr_to_cudf_ast(*conj.children[i], left_col_ref_map,
+                                            right_col_ref_map, owner, stream);
                 acc = &owner.push(cudf::ast::operation(op, *acc, rhs));
             }
             return *acc;
@@ -1068,7 +1084,8 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
                         "child");
                 }
                 const cudf::ast::expression& child = duckdb_expr_to_cudf_ast(
-                    *op_expr.children[0], left_table_indices, owner, stream);
+                    *op_expr.children[0], left_col_ref_map, right_col_ref_map,
+                    owner, stream);
                 return owner.push(
                     cudf::ast::operation(cudf::ast::ast_operator::NOT, child));
             }

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -1191,7 +1191,9 @@ class CudfASTOwner {
     }
 
     friend const cudf::ast::expression &duckdb_expr_to_cudf_ast(
-        const duckdb::Expression &, const std::unordered_set<duckdb::idx_t> &,
+        const duckdb::Expression &,
+        const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> &,
+        const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> &,
         CudfASTOwner &, rmm::cuda_stream_view &);
 };
 
@@ -1212,14 +1214,13 @@ cudf::ast::ast_operator duckdb_etype_to_cudf_ast_op(
  * (table_index, column_index) duckdb pairs to a flat column index into the
  * *_conditional table_view passed to mixed_join.  The table_reference
  * (LEFT vs RIGHT) is determined by whether the duckdb table_index is
- * found in @p left_table_indices.
+ * found in @p left_col_ref_map.
  *
  * @param expr              Root of the duckdb expression subtree to convert.
- * @param left_table_indices
- *                          Set of duckdb table indices that belong to the left
- *                          side of the join.  Any table index NOT in this set
- *                          is treated as belonging to the right side.
- * @param owner             Keeps all allocated AST nodes and scalars alive.
+ * @param left_col_ref_map Duckdb column references on the left side of the
+ * join.
+ * @param right_col_ref_map Duckdb column references on the right side of the
+ * join.
  *
  * @param stream cuda stream to create scalars on
  *
@@ -1230,7 +1231,10 @@ cudf::ast::ast_operator duckdb_etype_to_cudf_ast_op(
  */
 const cudf::ast::expression &duckdb_expr_to_cudf_ast(
     const duckdb::Expression &expr,
-    const std::unordered_set<duckdb::idx_t> &left_table_indices,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>
+        &left_col_ref_map,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>
+        &right_col_ref_map,
     CudfASTOwner &owner, rmm::cuda_stream_view &stream);
 /**
  * @brief Convert multiple duckdb expressions into a single CudfASTOwner,
@@ -1238,12 +1242,17 @@ const cudf::ast::expression &duckdb_expr_to_cudf_ast(
  *
  * @param exprs             The duckdb expressions to combine.
  * index.
- * @param left_table_indices Set of duckdb table indices on the left side of the
+ * @param left_col_ref_map Duckdb column references on the left side of the
+ * join.
+ * @param right_col_ref_map Duckdb column references on the right side of the
  * join.
  * @param stream to create scalars on
  * @return CudfASTOwner whose tree root is the AND of all expressions.
  */
 CudfASTOwner build_mixed_join_predicate(
     const std::vector<duckdb::unique_ptr<duckdb::Expression>> &exprs,
-    const std::unordered_set<duckdb::idx_t> &left_table_indices,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>
+        &left_col_ref_map,
+    const std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t>
+        &right_col_ref_map,
     rmm::cuda_stream_view &stream);

--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -225,10 +225,6 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
             probe_kept_cols.push_back(idx);
         }
 
-        std::unordered_set<duckdb::idx_t> probe_table_inds;
-        for (auto [k, _] : left_col_ref_map) {
-            probe_table_inds.emplace(k.first);
-        }
         std::vector<duckdb::unique_ptr<duckdb::Expression>> duckdb_exprs;
         for (duckdb::JoinCondition& cond : conditions) {
             if (cond.IsComparison() &&
@@ -245,8 +241,9 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
         rmm::cuda_stream_view stream = cudf::get_default_stream();
         std::unique_ptr<CudfASTOwner> physExprTree =
             duckdb_exprs.size()
-                ? std::make_unique<CudfASTOwner>(build_mixed_join_predicate(
-                      duckdb_exprs, probe_table_inds, stream))
+                ? std::make_unique<CudfASTOwner>(
+                      build_mixed_join_predicate(duckdb_exprs, left_col_ref_map,
+                                                 right_col_ref_map, stream))
                 : nullptr;
 
         bool build_table_outer =

--- a/bodo/pandas/physical/gpu_reduce.h
+++ b/bodo/pandas/physical/gpu_reduce.h
@@ -226,6 +226,8 @@ class PhysicalGPUReduce : public PhysicalGPUSource, public PhysicalGPUSink {
     std::pair<GPU_DATA, OperatorResult> ProduceBatchGPU(
         std::shared_ptr<StreamAndEvent> se) override {
         time_pt start_produce_time = start_timer();
+        int rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
         if (!is_gpu_rank()) {
             return {GPU_DATA(nullptr, out_schema->ToArrowSchema(), se),
@@ -244,8 +246,10 @@ class PhysicalGPUReduce : public PhysicalGPUSource, public PhysicalGPUSink {
                     out_schema->column_types[i]->ToArrowDataType()));
             }
 
-            std::unique_ptr<cudf::column> col1 =
-                cudf::make_column_from_scalar(*output_scalar, 1, se->stream);
+            // Only rank 0 returns a single row with the result, other ranks
+            // return an empty array
+            std::unique_ptr<cudf::column> col1 = cudf::make_column_from_scalar(
+                *output_scalar, rank == 0 ? 1 : 0, se->stream);
             cols.push_back(std::move(col1));
         }
 

--- a/bodo/tests/test_df_lib/test_tpch.py
+++ b/bodo/tests/test_df_lib/test_tpch.py
@@ -137,6 +137,7 @@ def test_tpch_q10():
     run_tpch_query_test(tpch.tpch_q10)
 
 
+@pytest.mark.gpu
 def test_tpch_q11():
     run_tpch_query_test(tpch.tpch_q11, ctes_created=1)
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes TPC-H Q11 issues.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.