### PR TITLE
[GPU] Support is_in() in nonequi join expr

### DIFF
--- a/bodo/pandas/physical/gpu_expression.cpp
+++ b/bodo/pandas/physical/gpu_expression.cpp
@@ -1033,9 +1033,7 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
             auto& const_expr = expr.Cast<duckdb::BoundConstantExpression>();
             const duckdb::Value& val = const_expr.value;
 
-            owner.insert_literal(val, stream);
-
-            return owner.tree.back();
+            return owner.insert_literal(val, stream);
         } break;
 
         case duckdb::ExpressionClass::BOUND_COMPARISON: {
@@ -1095,6 +1093,72 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
                 std::to_string(static_cast<int>(expr.type)));
         } break;
 
+        case duckdb::ExpressionClass::BOUND_FUNCTION: {
+            auto& bfe = expr.Cast<duckdb::BoundFunctionExpression>();
+            // Convert is_in() into a series of OR'd equality comparisons since
+            // CUDF does not have a native is_in operation.
+            if (bfe.bind_info) {
+                BodoScalarFunctionData& scalar_func_data =
+                    bfe.bind_info->Cast<BodoScalarFunctionData>();
+                if (scalar_func_data.arrow_func_name != "is_in") {
+                    throw std::runtime_error(
+                        "duckdb_expr_to_cudf_ast: only 'is_in' function is "
+                        "supported, found " +
+                        scalar_func_data.arrow_func_name);
+                }
+
+                const cudf::ast::expression& child =
+                    duckdb_expr_to_cudf_ast(*bfe.children[0], left_col_ref_map,
+                                            right_col_ref_map, owner, stream);
+
+                std::shared_ptr<arrow::Array> values_array =
+                    get_py_isin_arg_as_arrow_array(scalar_func_data.args);
+
+                if (!values_array || values_array->length() == 0) {
+                    throw std::runtime_error(
+                        "duckdb_expr_to_cudf_ast: failed to retrieve values "
+                        "array for is_in function");
+                }
+                if (values_array->null_count() > 0) {
+                    throw std::runtime_error(
+                        "duckdb_expr_to_cudf_ast: null values in is_in "
+                        "argument are not supported");
+                }
+                if (values_array->length() > 100) {
+                    throw std::runtime_error(
+                        "duckdb_expr_to_cudf_ast: is_in with more than 100 "
+                        "values is not supported");
+                }
+
+                const cudf::ast::expression* acc = nullptr;
+
+                for (int i = 0; i < values_array->length(); ++i) {
+                    std::shared_ptr<arrow::Scalar> scalar =
+                        values_array->GetScalar(i).ValueOrDie();
+                    std::unique_ptr<cudf::scalar> cudf_scalar =
+                        arrow_scalar_to_cudf(scalar, stream);
+                    const cudf::ast::expression& literal =
+                        owner.insert_literal(std::move(cudf_scalar), stream);
+
+                    const cudf::ast::expression& cmp =
+                        owner.push(cudf::ast::operation(
+                            cudf::ast::ast_operator::EQUAL, child, literal));
+
+                    if (i == 0) {
+                        acc = &cmp;
+                    } else {
+                        acc = &owner.push(cudf::ast::operation(
+                            cudf::ast::ast_operator::LOGICAL_OR, *acc, cmp));
+                    }
+                }
+                return *acc;
+
+            } else {
+                throw std::runtime_error(
+                    "duckdb_expr_to_cudf_ast: unsupported function expression");
+            }
+        } break;
+
         default:
             throw std::runtime_error(
                 "duckdb_expr_to_cudf_ast: unsupported expression class " +
@@ -1102,8 +1166,8 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
     }
 }
 
-void CudfASTOwner::insert_literal(const duckdb::Value& val,
-                                  rmm::cuda_stream_view& stream) {
+const cudf::ast::expression& CudfASTOwner::insert_literal(
+    const duckdb::Value& val, rmm::cuda_stream_view& stream) {
     // Helper to push a typed literal and then transfer ownership of the
     // scalar into the owner. Must happen in this order: literal holds a
     // ref to the scalar so it must be pushed into the tree first.
@@ -1183,6 +1247,86 @@ void CudfASTOwner::insert_literal(const duckdb::Value& val,
                 "duckdb_value_to_cudf_ast_literal: unsupported duckdb type " +
                 val.type().ToString());
     }
+    return tree.back();
+}
+
+const cudf::ast::expression& CudfASTOwner::insert_literal(
+    std::unique_ptr<cudf::scalar> val, rmm::cuda_stream_view& stream) {
+    switch (val->type().id()) {
+        case cudf::type_id::INT8: {
+            cudf::numeric_scalar<int8_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<int8_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::INT16: {
+            cudf::numeric_scalar<int16_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<int16_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::INT32: {
+            cudf::numeric_scalar<int32_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<int32_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::INT64: {
+            cudf::numeric_scalar<int64_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<int64_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::UINT8: {
+            cudf::numeric_scalar<uint8_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<uint8_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::UINT16: {
+            cudf::numeric_scalar<uint16_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<uint16_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::UINT32: {
+            cudf::numeric_scalar<uint32_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<uint32_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::UINT64: {
+            cudf::numeric_scalar<uint64_t>* typed_scalar =
+                static_cast<cudf::numeric_scalar<uint64_t>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::FLOAT32: {
+            cudf::numeric_scalar<float>* typed_scalar =
+                static_cast<cudf::numeric_scalar<float>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::FLOAT64: {
+            cudf::numeric_scalar<double>* typed_scalar =
+                static_cast<cudf::numeric_scalar<double>*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        case cudf::type_id::STRING: {
+            cudf::string_scalar* typed_scalar =
+                static_cast<cudf::string_scalar*>(val.get());
+            this->push(cudf::ast::literal(*typed_scalar));
+            break;
+        }
+        default:
+            throw std::runtime_error(
+                "insert_literal: unsupported cudf type " +
+                std::to_string(static_cast<int>(val->type().id())));
+    }
+
+    this->scalars.push_back(std::move(val));
+    return this->tree.back();
 }
 
 cudf::ast::ast_operator duckdb_etype_to_cudf_ast_op(

--- a/bodo/pandas/physical/gpu_expression.cpp
+++ b/bodo/pandas/physical/gpu_expression.cpp
@@ -14,6 +14,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
+#include "duckdb/common/types.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -1041,13 +1042,40 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
         case duckdb::ExpressionClass::BOUND_COMPARISON: {
             auto& cmp = expr.Cast<duckdb::BoundComparisonExpression>();
 
-            const cudf::ast::expression& lhs = duckdb_expr_to_cudf_ast(
+            const cudf::ast::expression& lhs_orig = duckdb_expr_to_cudf_ast(
                 *cmp.left, left_col_ref_map, right_col_ref_map, owner, stream);
-            const cudf::ast::expression& rhs = duckdb_expr_to_cudf_ast(
+            const cudf::ast::expression& rhs_orig = duckdb_expr_to_cudf_ast(
                 *cmp.right, left_col_ref_map, right_col_ref_map, owner, stream);
 
+            duckdb::LogicalType lhs_type = cmp.left->return_type;
+            duckdb::LogicalType rhs_type = cmp.right->return_type;
+
+            // Make sure operands have the same type to avoid cudf AST
+            // validation errors.
+            const cudf::ast::expression* lhs = &lhs_orig;
+            const cudf::ast::expression* rhs = &rhs_orig;
+            if (lhs_type != rhs_type) {
+                if (lhs_type == duckdb::LogicalType::DOUBLE) {
+                    rhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_FLOAT64, *rhs));
+                } else if (lhs_type == duckdb::LogicalType::BIGINT) {
+                    rhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_INT64, *rhs));
+                } else if (lhs_type == duckdb::LogicalType::INTEGER) {
+                    lhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_INT64, *lhs));
+                    rhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_INT64, *rhs));
+                } else {
+                    throw std::runtime_error(
+                        "duckdb_expr_to_cudf_ast: unsupported type coercion "
+                        "from " +
+                        rhs_type.ToString() + " to " + lhs_type.ToString());
+                }
+            }
+
             cudf::ast::ast_operator op = duckdb_etype_to_cudf_ast_op(expr.type);
-            return owner.push(cudf::ast::operation(op, lhs, rhs));
+            return owner.push(cudf::ast::operation(op, *lhs, *rhs));
         }
 
         case duckdb::ExpressionClass::BOUND_CONJUNCTION: {

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -1175,8 +1175,10 @@ class CudfASTOwner {
     const cudf::ast::expression *root{nullptr};
 
    public:
-    void insert_literal(const duckdb::Value &val,
-                        rmm::cuda_stream_view &stream);
+    const cudf::ast::expression &insert_literal(const duckdb::Value &val,
+                                                rmm::cuda_stream_view &stream);
+    const cudf::ast::expression &insert_literal(
+        std::unique_ptr<cudf::scalar> val, rmm::cuda_stream_view &stream);
     const cudf::ast::expression &get_root() const {
         if (!root) {
             throw std::runtime_error("CudfASTOwner: tree is empty");

--- a/bodo/tests/test_df_lib/test_tpch.py
+++ b/bodo/tests/test_df_lib/test_tpch.py
@@ -179,6 +179,7 @@ def test_tpch_q18():
     run_tpch_query_test(tpch.tpch_q18)
 
 
+@pytest.mark.gpu
 def test_tpch_q19():
     run_tpch_query_test(tpch.tpch_q19, plan_executions=1)
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes TPC-H Q19.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enable q19 test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
New GPU functionality.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.