### PR TITLE
[GPU] Fix TPC-H Q20 AST type mismatch error

### DIFF
--- a/bodo/pandas/physical/gpu_expression.cpp
+++ b/bodo/pandas/physical/gpu_expression.cpp
@@ -14,6 +14,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
+#include "duckdb/common/types.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -1041,13 +1042,40 @@ const cudf::ast::expression& duckdb_expr_to_cudf_ast(
         case duckdb::ExpressionClass::BOUND_COMPARISON: {
             auto& cmp = expr.Cast<duckdb::BoundComparisonExpression>();
 
-            const cudf::ast::expression& lhs = duckdb_expr_to_cudf_ast(
+            const cudf::ast::expression& lhs_orig = duckdb_expr_to_cudf_ast(
                 *cmp.left, left_col_ref_map, right_col_ref_map, owner, stream);
-            const cudf::ast::expression& rhs = duckdb_expr_to_cudf_ast(
+            const cudf::ast::expression& rhs_orig = duckdb_expr_to_cudf_ast(
                 *cmp.right, left_col_ref_map, right_col_ref_map, owner, stream);
 
+            duckdb::LogicalType lhs_type = cmp.left->return_type;
+            duckdb::LogicalType rhs_type = cmp.right->return_type;
+
+            // Make sure operands have the same type to avoid cudf AST
+            // validation errors.
+            const cudf::ast::expression* lhs = &lhs_orig;
+            const cudf::ast::expression* rhs = &rhs_orig;
+            if (lhs_type != rhs_type) {
+                if (lhs_type == duckdb::LogicalType::DOUBLE) {
+                    rhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_FLOAT64, *rhs));
+                } else if (lhs_type == duckdb::LogicalType::BIGINT) {
+                    rhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_INT64, *rhs));
+                } else if (lhs_type == duckdb::LogicalType::INTEGER) {
+                    lhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_INT64, *lhs));
+                    rhs = &owner.push(cudf::ast::operation(
+                        cudf::ast::ast_operator::CAST_TO_INT64, *rhs));
+                } else {
+                    throw std::runtime_error(
+                        "duckdb_expr_to_cudf_ast: unsupported type coercion "
+                        "from " +
+                        rhs_type.ToString() + " to " + lhs_type.ToString());
+                }
+            }
+
             cudf::ast::ast_operator op = duckdb_etype_to_cudf_ast_op(expr.type);
-            return owner.push(cudf::ast::operation(op, lhs, rhs));
+            return owner.push(cudf::ast::operation(op, *lhs, *rhs));
         }
 
         case duckdb::ExpressionClass::BOUND_CONJUNCTION: {


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes error on CI revealed by merging of previous two PRs.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.