### PR TITLE
[GPU] Avoid UDFs in TPC-H Q12 to work on GPUs

### DIFF
--- a/benchmarks/tpch/bodo/dataframe_queries.py
+++ b/benchmarks/tpch/bodo/dataframe_queries.py
@@ -438,7 +438,7 @@ def tpch_q11(partsupp, supplier, nation, scale_factor=1.0, pd=bodo.pandas):
 
 
 def tpch_q12(lineitem, orders, pd=bodo.pandas):
-    """Adapted from:
+    """Adapted from (removed UDFs to work on GPUs):
     https://github.com/xorbitsai/benchmarks/blob/main/tpch/pandas_queries/queries.py
     """
     var1 = datetime.date(1994, 1, 1)
@@ -453,14 +453,12 @@ def tpch_q12(lineitem, orders, pd=bodo.pandas):
         & (jn1["L_RECEIPTDATE"] < var2)
     ]
 
-    def g1(x):
-        return ((x == "1-URGENT") | (x == "2-HIGH")).sum()
+    jn1["HIGH_LINE"] = jn1["O_ORDERPRIORITY"].isin(["1-URGENT", "2-HIGH"])
+    jn1["LOW_LINE"] = ~jn1["HIGH_LINE"]
 
-    def g2(x):
-        return ((x != "1-URGENT") & (x != "2-HIGH")).sum()
-
-    gb = jn1.groupby("L_SHIPMODE", as_index=False)["O_ORDERPRIORITY"].agg(
-        HIGH_LINE_COUNT=g1, LOW_LINE_COUNT=g2
+    gb = jn1.groupby("L_SHIPMODE", as_index=False).agg(
+        HIGH_LINE_COUNT=pd.NamedAgg(column="HIGH_LINE", aggfunc="sum"),
+        LOW_LINE_COUNT=pd.NamedAgg(column="LOW_LINE", aggfunc="sum"),
     )
     result_df = gb.sort_values("L_SHIPMODE")
 

--- a/bodo/tests/test_df_lib/test_tpch.py
+++ b/bodo/tests/test_df_lib/test_tpch.py
@@ -146,6 +146,7 @@ def test_tpch_q11():
     run_tpch_query_test(tpch.tpch_q11, ctes_created=1)
 
 
+@pytest.mark.gpu
 def test_tpch_q12():
     run_tpch_query_test(tpch.tpch_q12)
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.