### PR TITLE
[GPU] Fall back for timestamp with timezone

### DIFF
--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -103,6 +103,14 @@ std::map<duckdb::LogicalOperatorType, uint64_t> GPU_MIN_SIZE{
 
 #ifdef USE_CUDF
 
+bool is_supported_cudf_type(const duckdb::LogicalType &type) {
+    if (type.id() == duckdb::LogicalTypeId::TIMESTAMP_TZ) {
+        return false;
+    }
+    // TODO(ehsan): add other unsupported types.
+    return true;
+}
+
 class DevicePlanNode {
    private:
     duckdb::LogicalOperator &op;
@@ -126,6 +134,13 @@ class DevicePlanNode {
      * in the physical GPU node file so things stay colocated.
      */
     bool determineGPUCapable(duckdb::LogicalOperator &op) {
+        // Make sure the data types are supported in libcudf.
+        op.ResolveOperatorTypes();
+        for (duckdb::LogicalType &type : op.types) {
+            if (!is_supported_cudf_type(type)) {
+                return false;
+            }
+        }
         switch (op.type) {
             case duckdb::LogicalOperatorType::LOGICAL_GET: {
                 duckdb::LogicalGet &lget = op.Cast<duckdb::LogicalGet>();

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1205,8 +1205,12 @@ cudf::data_type duckdb_logicaltype_to_cudf(const duckdb::LogicalType &dtype) {
             return cudf::data_type{type_id::TIMESTAMP_MICROSECONDS};
 
         case LogicalTypeId::TIMESTAMP_NS:
-        case LogicalTypeId::TIMESTAMP_TZ:
             return cudf::data_type{type_id::TIMESTAMP_NANOSECONDS};
+
+        case LogicalTypeId::TIMESTAMP_TZ:
+            throw std::runtime_error(
+                "duckdb_logicaltype_to_cudf: cudf does not support "
+                "TIMESTAMP_TZ type");
 
         // Date / Time / Interval
         case LogicalTypeId::DATE:
@@ -1522,8 +1526,14 @@ cudf::data_type arrow_to_cudf_type(const std::shared_ptr<arrow::DataType> &t) {
             return cudf::data_type{type_id::STRING};
 
         case Type::TIMESTAMP: {
-            auto unit =
-                std::static_pointer_cast<arrow::TimestampType>(t)->unit();
+            auto timestamp = std::static_pointer_cast<arrow::TimestampType>(t);
+            if (!timestamp->timezone().empty()) {
+                throw std::runtime_error(
+                    "Arrow timestamp has timezone '" + timestamp->timezone() +
+                    "' but cuDF does not support timezones.");
+            }
+
+            auto unit = timestamp->unit();
             switch (unit) {
                 case arrow::TimeUnit::SECOND:
                     return cudf::data_type{type_id::TIMESTAMP_SECONDS};

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1928,6 +1928,7 @@ def test_series_mod(datapath):
     )
 
 
+@pytest.mark.gpu
 def test_series_compound_expression(datapath):
     """Very simple test for projection expressions."""
     with assert_executed_plan_count(0):
@@ -1949,6 +1950,7 @@ def test_series_compound_expression(datapath):
     )
 
 
+@pytest.mark.gpu
 def test_series_arith_binops(datapath, index_val):
     """Test various cases of Series binary operations."""
     df = pd.DataFrame({"A": [1, 2, 3], "B": ["aa", "bb", "c"], "C": [4, 5, 6]})
@@ -1990,6 +1992,7 @@ def test_series_arith_binops(datapath, index_val):
     )
 
 
+@pytest.mark.gpu
 def test_series_cmp_binops(datapath, index_val):
     """Test various cases of Series binary operations."""
     df = pd.DataFrame({"A": [1, 20, 300], "B": ["aa", "bb", "c"], "C": [4, 5, 6]})
@@ -2031,6 +2034,7 @@ def test_series_cmp_binops(datapath, index_val):
     )
 
 
+@pytest.mark.gpu
 def test_scalar_arith_binops(datapath, index_val):
     """Test various cases of BodoScalar binary operations."""
 
@@ -4124,7 +4128,7 @@ def test_timezone_scalar_func(engine, index_val, timezone_timestamp_df):
     _test_equal(bodo_out, expected, check_pandas_types=False)
 
 
-@pytest.mark.gpu
+@pytest.mark.gpu(allow_fallback=True)  # fallback timezone
 def test_timezone_filter(index_val, timezone_timestamp_df):
     """Test filter works with timezones"""
     df = timezone_timestamp_df
@@ -4154,6 +4158,7 @@ def test_timezone_groupby(timezone_timestamp_df):
     _test_equal(bodo_out, pandas_out, check_pandas_types=False)
 
 
+@pytest.mark.gpu(allow_fallback=True)  # fallback timezone
 def test_timezone_merge(timezone_timestamp_df):
     """Test merge works with timezone keys"""
     df = timezone_timestamp_df

--- a/bodo/tests/test_parquet_read.py
+++ b/bodo/tests/test_parquet_read.py
@@ -78,9 +78,7 @@ def test_pq_nullable(fname, datapath, memory_leak_check):
         ),
         pytest.param("nullable_float.pq", id="nullable_float", marks=pytest.mark.gpu),
         pytest.param("datetime64ns_1.pq", id="datetime64ns", marks=pytest.mark.gpu),
-        pytest.param(
-            "datetime64ns_tz_1.pq", id="datetime64ns_tz", marks=pytest.mark.gpu
-        ),
+        pytest.param("datetime64ns_tz_1.pq", id="datetime64ns_tz"),
         pytest.param("struct_1.pq", id="struct"),
         pytest.param("map_1.pq", id="map"),
         pytest.param("dictionary_string_1.pq", id="dictionary_string"),


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Fall back for timezones.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.