### PR TITLE
[GPU] Support dropna and avoid string sum in groupby

### DIFF
--- a/bodo/libs/streaming/cuda_groupby.cpp
+++ b/bodo/libs/streaming/cuda_groupby.cpp
@@ -38,7 +38,7 @@
 
 std::unique_ptr<cudf::table> CudaGroupbyState::do_groupby(
     cudf::table_view const& _input, std::vector<uint64_t>& key_indices,
-    std::vector<uint64_t>& column_indices,
+    bool drop_na_keys, std::vector<uint64_t>& column_indices,
     std::vector<cudf::groupby::aggregation_request>& aggregation_requests,
     col_to_col_fn_vec& aggregation_fns, col_to_col_fn_vec& post_agg_fns,
     tbl_to_tbl_fn_vec& pre_agg_table_fns, rmm::cuda_stream_view& stream) {
@@ -65,7 +65,9 @@ std::unique_ptr<cudf::table> CudaGroupbyState::do_groupby(
     // Create a view with just the key columns.
     cudf::table_view keys{key_columns};
     // Build the groupby object
-    cudf::groupby::groupby gb_obj(keys, cudf::null_policy::EXCLUDE);
+    cudf::groupby::groupby gb_obj(keys, drop_na_keys
+                                            ? cudf::null_policy::EXCLUDE
+                                            : cudf::null_policy::INCLUDE);
 
     std::vector<std::unique_ptr<cudf::column>> fn_cols;
     // Put the column view for the aggregations into aggregation_requests.
@@ -131,10 +133,10 @@ bool CudaGroupbyState::build_consume_batch(
         std::shared_ptr<StreamAndEvent> local_groupby_se =
             make_stream_and_event(g_use_async);
         input_se->event.wait(local_groupby_se->stream);
-        std::shared_ptr<cudf::table> new_data =
-            do_groupby(input_table->view(), key_indices, column_indices,
-                       aggregation_requests, aggregation_fns, post_agg_fns,
-                       pre_agg_table_fns, local_groupby_se->stream);
+        std::shared_ptr<cudf::table> new_data = do_groupby(
+            input_table->view(), key_indices, drop_na_keys, column_indices,
+            aggregation_requests, aggregation_fns, post_agg_fns,
+            pre_agg_table_fns, local_groupby_se->stream);
         local_groupby_se->event.record(local_groupby_se->stream);
         merge_shuffler.append_batch(new_data, shuffle_key_indices,
                                     local_groupby_se);
@@ -175,10 +177,10 @@ bool CudaGroupbyState::build_consume_batch(
     // Make one table out of all the views.
     auto combined = cudf::concatenate(views, output_stream);
     // Do the groupby on the combined table.
-    accumulation =
-        do_groupby(combined->view(), merge_key_indices, merge_column_indices,
-                   merge_aggregation_requests, merge_aggregation_fns,
-                   post_merge_agg_fns, pre_merge_agg_table_fns, output_stream);
+    accumulation = do_groupby(combined->view(), merge_key_indices, drop_na_keys,
+                              merge_column_indices, merge_aggregation_requests,
+                              merge_aggregation_fns, post_merge_agg_fns,
+                              pre_merge_agg_table_fns, output_stream);
     return global_is_last;
 }
 

--- a/bodo/libs/streaming/cuda_groupby.h
+++ b/bodo/libs/streaming/cuda_groupby.h
@@ -94,9 +94,11 @@ class CudaGroupbyState {
     std::unique_ptr<cudf::table> accumulation;
     std::vector<FinalMerge> final_merges;
 
+    bool drop_na_keys = true;
+
     static std::unique_ptr<cudf::table> do_groupby(
         cudf::table_view const &input, std::vector<uint64_t> &key_indices,
-        std::vector<uint64_t> &column_indices,
+        bool drop_na_keys, std::vector<uint64_t> &column_indices,
         std::vector<cudf::groupby::aggregation_request> &aggregation_requests,
         col_to_col_fn_vec &aggregation_fns, col_to_col_fn_vec &post_agg_fns,
         tbl_to_tbl_fn_vec &pre_agg_table_fns, rmm::cuda_stream_view &stream);
@@ -365,8 +367,10 @@ class CudaGroupbyState {
     CudaGroupbyState(
         const std::vector<uint64_t> &_key_indices,
         const std::vector<std::pair<uint64_t, int32_t>> &column_agg_funcs,
-        std::shared_ptr<arrow::Schema> _output_schema)
-        : output_schema(_output_schema), key_indices(_key_indices) {
+        std::shared_ptr<arrow::Schema> _output_schema, bool drop_na_keys = true)
+        : output_schema(_output_schema),
+          key_indices(_key_indices),
+          drop_na_keys(drop_na_keys) {
         unsigned num_keys = key_indices.size();
 
         if (column_agg_funcs.size() == 0) {

--- a/bodo/pandas/physical/gpu_aggregate.h
+++ b/bodo/pandas/physical/gpu_aggregate.h
@@ -36,6 +36,10 @@ inline bool gpu_capable(duckdb::LogicalAggregate& logical_aggregate) {
         return gpu_capable_reduce(logical_aggregate);
     }
 
+    std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> col_ref_map =
+        getColRefMap(logical_aggregate.children[0]->GetColumnBindings());
+    logical_aggregate.children[0]->ResolveOperatorTypes();
+
     for (size_t i = 0; i < logical_aggregate.expressions.size(); i++) {
         const auto& expr = logical_aggregate.expressions[i];
 
@@ -49,6 +53,26 @@ inline bool gpu_capable(duckdb::LogicalAggregate& logical_aggregate) {
         // Check if the aggregate function is supported
         bool is_udf = agg_expr.function.name.starts_with("udf");
         if (is_udf) {
+            return false;
+        }
+
+        // Check input types of the aggregate function
+        auto& child_expr = agg_expr.children[0];
+        if (child_expr->type != duckdb::ExpressionType::BOUND_COLUMN_REF) {
+            throw std::runtime_error(
+                "Aggregate expression must have only col ref "
+                "expression children" +
+                expr->ToString());
+        }
+        auto& colref = child_expr->Cast<duckdb::BoundColumnRefExpression>();
+
+        uint64_t col_idx = col_ref_map.at(
+            {colref.binding.table_index, colref.binding.column_index});
+
+        // cudf doesn't support sum aggregation on string columns
+        if (agg_expr.function.name == "sum" &&
+            logical_aggregate.children[0]->types[col_idx].id() ==
+                duckdb::LogicalTypeId::VARCHAR) {
             return false;
         }
     }
@@ -153,7 +177,7 @@ class PhysicalGPUAggregate : public PhysicalGPUSource, public PhysicalGPUSink {
         PhysicalGPUSource::EnsureNoNumpyColumns(this->output_schema);
         arrow_output_schema = this->output_schema->ToArrowSchema();
         this->groupby_state = std::make_unique<CudaGroupbyState>(
-            keys, column_agg_funcs, arrow_output_schema);
+            keys, column_agg_funcs, arrow_output_schema, dropna.value());
 
         this->metrics.init_time += end_timer(start_init);
     }

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1599,6 +1599,7 @@ def as_index(request):
     return request.param
 
 
+@pytest.mark.gpu
 def test_series_groupby(dropna, as_index):
     """
     Test a simple groupby operation.
@@ -1607,7 +1608,7 @@ def test_series_groupby(dropna, as_index):
         df1 = pd.DataFrame(
             {
                 "B": ["a1", "b11", "c111"] * 2,
-                "E": pd.array([1.1, pd.NA, 13.3, pd.NA, pd.NA, 13.3], "Float64"),
+                "E": pd.array([1.1, 4.1, 13.3, 1.9, 3.5, 13.3], "Float64"),
                 "A": pd.array([pd.NA, 2, 3] * 2, "Int64"),
             },
             index=[0, 41, 2] * 2,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1619,6 +1619,7 @@ def test_series_groupby(dropna, as_index):
     _test_equal(bdf2, df2, sort_output=True, reset_index=True, check_pandas_types=False)
 
 
+@pytest.mark.gpu(allow_fallback=True)  # fallback groupby with string aggregation
 @pytest.mark.parametrize(
     "selection",
     [pytest.param(None, id="select_all"), pytest.param(["C", "A"], id="select_subset")],
@@ -1630,7 +1631,7 @@ def test_dataframe_groupby(dropna, as_index, selection):
     with assert_executed_plan_count(0):
         df1 = pd.DataFrame(
             {
-                "A": pd.array([1, 2, pd.NA, 2147483647] * 3, "Int32"),
+                "A": pd.array([1, 2, 4, 2147483647] * 3, "Int32"),
                 "B": ["A", "B"] * 6,
                 "E": [False, True] * 6,
                 "D": pd.array(


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes some test issues.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Fixes groupby issues on GPU.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.