### PR TITLE
[GPU] fallback if Parquet dataset has partitioning

### DIFF
--- a/bodo/pandas/_bodo_scan_function.h
+++ b/bodo/pandas/_bodo_scan_function.h
@@ -84,11 +84,13 @@ class BodoParquetScanFunction : public BodoScanFunction {
 class BodoParquetScanFunctionData : public BodoScanFunctionData {
    public:
     BodoParquetScanFunctionData(PyObject *path, PyObject *pyarrow_schema,
-                                PyObject *storage_options)
+                                PyObject *storage_options,
+                                bool has_partitioning)
         : BodoScanFunctionData(BodoScanFunctionType::PARQUET_SCAN),
           path(path),
           pyarrow_schema(pyarrow_schema),
-          storage_options(storage_options) {
+          storage_options(storage_options),
+          has_partitioning(has_partitioning) {
         Py_INCREF(pyarrow_schema);
         Py_INCREF(storage_options);
         Py_INCREF(path);
@@ -109,13 +111,14 @@ class BodoParquetScanFunctionData : public BodoScanFunctionData {
         bool run_on_gpu) override;
 
     bool canRunOnGPU(bool has_filters, bool has_limit) override {
-        return !has_limit;
+        return !has_limit && !has_partitioning;
     }
 
     // Parquet dataset path
     PyObject *path;
     PyObject *pyarrow_schema;
     PyObject *storage_options;
+    bool has_partitioning;
 };
 
 /**

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1315,7 +1315,7 @@ std::pair<int64_t, PyObject *> execute_plan(
 
 duckdb::unique_ptr<duckdb::LogicalGet> make_parquet_get_node(
     PyObject *parquet_path, PyObject *pyarrow_schema, PyObject *storage_options,
-    int64_t num_rows) {
+    int64_t num_rows, bool has_partitioning) {
     duckdb::shared_ptr<duckdb::Binder> binder = get_duckdb_binder();
     std::shared_ptr<arrow::Schema> arrow_schema = unwrap_schema(pyarrow_schema);
 
@@ -1323,7 +1323,7 @@ duckdb::unique_ptr<duckdb::LogicalGet> make_parquet_get_node(
         BodoParquetScanFunction(arrow_schema);
     duckdb::unique_ptr<duckdb::FunctionData> bind_data1 =
         duckdb::make_uniq<BodoParquetScanFunctionData>(
-            parquet_path, pyarrow_schema, storage_options);
+            parquet_path, pyarrow_schema, storage_options, has_partitioning);
 
     // Convert Arrow schema to DuckDB
     auto [return_names, return_types] = arrow_schema_to_duckdb(arrow_schema);

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -500,7 +500,7 @@ duckdb::unique_ptr<duckdb::LogicalSample> make_sample(
  */
 duckdb::unique_ptr<duckdb::LogicalGet> make_parquet_get_node(
     PyObject *parquet_path, PyObject *pyarrow_schema, PyObject *storage_options,
-    int64_t num_rows);
+    int64_t num_rows, bool has_partitioning);
 
 /**
  * @brief Create a LogicalCopyToFile node for writing a Parquet dataset.

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -192,9 +192,7 @@ def read_parquet(
     empty_df = arrow_to_empty_df(arrow_schema)
 
     plan = LogicalGetParquetRead(
-        empty_df,
-        path,
-        storage_options,
+        empty_df, path, storage_options, pq_dataset.partitioning is not None
     )
     return wrap_plan(plan=plan)
 

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -314,7 +314,7 @@ cdef extern from "_plan.h" nogil:
         pass
 
     cdef idx_t getTableIndex() except +
-    cdef unique_ptr[CLogicalGet] make_parquet_get_node(object parquet_path, object arrow_schema, object storage_options, int64_t num_rows) except +
+    cdef unique_ptr[CLogicalGet] make_parquet_get_node(object parquet_path, object arrow_schema, object storage_options, int64_t num_rows, bool has_partitioning) except +
     cdef unique_ptr[CLogicalGet] make_dataframe_get_seq_node(object df, object arrow_schema, int64_t num_rows) except +
     cdef unique_ptr[CLogicalGet] make_dataframe_get_parallel_node(c_string res_id, object arrow_schema, int64_t num_rows) except +
     cdef unique_ptr[CLogicalGet] make_iceberg_get_node(object arrow_schema, c_string table_identifier, object pyiceberg_catalog, object iceberg_filter, object iceberg_schema, int64_t snapshot_id, uint64_t table_len_estimate) except +
@@ -911,7 +911,7 @@ cdef class LogicalGetParquetRead(LogicalOperator):
     cdef readonly object storage_options
     cdef readonly int64_t nrows
 
-    def __cinit__(self, object out_schema, object parquet_path, object storage_options):
+    def __cinit__(self, object out_schema, object parquet_path, object storage_options, bool has_partitioning):
         from bodo.ext import hdist
 
         self.out_schema = out_schema
@@ -919,7 +919,7 @@ cdef class LogicalGetParquetRead(LogicalOperator):
         self.storage_options = storage_options
         self.nrows = -1
         cdef int64_t nrows_estimate = hdist.bcast_int64_py_wrapper(self._get_nrows(exact=False) if bodo.get_rank() == 0 else 0)
-        cdef unique_ptr[CLogicalGet] c_logical_get = make_parquet_get_node(parquet_path, out_schema, storage_options, nrows_estimate)
+        cdef unique_ptr[CLogicalGet] c_logical_get = make_parquet_get_node(parquet_path, out_schema, storage_options, nrows_estimate, has_partitioning)
         self.c_logical_operator = unique_ptr[CLogicalOperator](<CLogicalGet*> c_logical_get.release())
 
     def __str__(self):

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -314,7 +314,7 @@ cdef extern from "_plan.h" nogil:
         pass
 
     cdef idx_t getTableIndex() except +
-    cdef unique_ptr[CLogicalGet] make_parquet_get_node(object parquet_path, object arrow_schema, object storage_options, int64_t num_rows, bool has_partitioning) except +
+    cdef unique_ptr[CLogicalGet] make_parquet_get_node(object parquet_path, object arrow_schema, object storage_options, int64_t num_rows, c_bool has_partitioning) except +
     cdef unique_ptr[CLogicalGet] make_dataframe_get_seq_node(object df, object arrow_schema, int64_t num_rows) except +
     cdef unique_ptr[CLogicalGet] make_dataframe_get_parallel_node(c_string res_id, object arrow_schema, int64_t num_rows) except +
     cdef unique_ptr[CLogicalGet] make_iceberg_get_node(object arrow_schema, c_string table_identifier, object pyiceberg_catalog, object iceberg_filter, object iceberg_schema, int64_t snapshot_id, uint64_t table_len_estimate) except +

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1155,6 +1155,7 @@ def test_set_df_column_extra_proj(datapath, index_val):
     _test_equal(bdf2, pdf2, check_pandas_types=False)
 
 
+@pytest.mark.gpu(allow_fallback=True)  # fallback partitioning
 def test_parquet_read_partitioned(datapath):
     """Test reading a partitioned parquet dataset."""
     path = datapath("dataframe_library/example_partitioned.parquet")
@@ -1184,6 +1185,7 @@ def test_parquet_read_partitioned(datapath):
     )
 
 
+@pytest.mark.gpu(allow_fallback=True)  # fallback partitioning
 def test_parquet_read_partitioned_filter(datapath):
     """Test filter pushdown on partitioned parquet dataset."""
     path = datapath("dataframe_library/example_partitioned.parquet")

--- a/bodo/tests/test_df_lib/test_plan.py
+++ b/bodo/tests/test_df_lib/test_plan.py
@@ -16,11 +16,13 @@ def test_join_node(datapath):
         pa.schema([("A", pa.int64()), ("B", pa.string())]),
         datapath("example.parquet"),
         {},
+        False,
     )
     P2 = plan_optimizer.LogicalGetParquetRead(
         pa.schema([("A", pa.int64()), ("B", pa.string())]),
         datapath("example2.parquet"),
         {},
+        False,
     )
     A = plan_optimizer.LogicalComparisonJoin(
         pa.schema([("A", pa.int64()), ("B", pa.string())]),
@@ -39,6 +41,7 @@ def test_projection_node(datapath):
         pa.schema([("A", pa.int64()), ("B", pa.string())]),
         datapath("example.parquet"),
         {},
+        False,
     )
     exprs = [
         plan_optimizer.ColRefExpression(pa.schema([("A", pa.int64())]), P1, 0),
@@ -59,6 +62,7 @@ def test_filter_node(datapath):
         pa.schema([("A", pa.int64()), ("B", pa.string())]),
         datapath("example.parquet"),
         {},
+        False,
     )
     A = plan_optimizer.ColRefExpression(pa.schema([("A", pa.int64())]), P1, 0)
     B = plan_optimizer.ComparisonOpExpression(
@@ -75,6 +79,7 @@ def test_parquet_node(datapath):
         pa.schema([("A", pa.int64()), ("B", pa.string())]),
         datapath("example.parquet"),
         {},
+        False,
     )
     assert str(A).startswith("LogicalGetParquetRead(") and str(A).endswith(
         "example.parquet)"
@@ -89,6 +94,7 @@ def test_optimize_call(datapath):
         pa.schema([("A", pa.int64()), ("B", pa.string())]),
         datapath("example.parquet"),
         {},
+        False,
     )
     B = plan_optimizer.py_optimize_plan(A)
     assert str(B) == "LogicalOperator()"
@@ -108,6 +114,7 @@ def test_parquet_projection_pushdown(datapath):
         ),
         datapath("example.parquet"),
         {},
+        False,
     )
     exprs = [
         plan_optimizer.ColRefExpression(pa.schema([("A", pa.int64())]), A, 0),


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes test errors.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Parquet datasets with partitioning now fallback on CPU instead of error.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.