### PR TITLE
[GPU] Write Pandas metadata in write Parquet

### DIFF
--- a/bodo/pandas/physical/gpu_write_parquet.h
+++ b/bodo/pandas/physical/gpu_write_parquet.h
@@ -120,6 +120,18 @@ class PhysicalGPUWriteParquet : public PhysicalGPUSink {
         return names;
     }
 
+    // Extract pandas metadata from the arrow schema to include in the output
+    // parquet metadata. See
+    // https://github.com/rapidsai/cudf/blob/cb6fe6d8727f789e74951423964f0e92daffb8cb/python/cudf/cudf/io/parquet.py#L189
+    std::vector<std::map<std::string, std::string>> get_pq_pandas_metadata() {
+        std::vector<std::map<std::string, std::string>> metadata_vector;
+        metadata_vector.emplace_back(std::map<std::string, std::string>{
+            {"pandas", arrow_schema->metadata()
+                           ? arrow_schema->metadata()->Get("pandas").ValueOr("")
+                           : ""}});
+        return metadata_vector;
+    }
+
     std::shared_ptr<StreamAndEvent> prev_batch_se;
 
    public:
@@ -315,7 +327,8 @@ class PhysicalGPUWriteParquet : public PhysicalGPUSink {
             // build writer options (row_group_size, compression, etc.)
             auto sink = cudf::io::sink_info(&bodo_data_sink);
             auto builder = cudf::io::parquet_writer_options::builder(sink, bttv)
-                               .metadata(meta);
+                               .metadata(meta)
+                               .key_value_metadata(get_pq_pandas_metadata());
             if (row_group_size > 0) {
                 builder = builder.row_group_size_rows(row_group_size);
             }

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -231,6 +231,7 @@ def test_read_parquet_filter_projection(datapath):
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.jit_dependency
 def test_write_parquet(index_val):
     """Test writing a DataFrame to parquet."""


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Makes sure Pandas Index is set properly when reading Bodo's Parquet output.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Pandas Index is read properly from Bodo written output.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.