### PR TITLE
[GPU] Different GPU batch size adaptation.

### DIFF
--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #ifdef USE_CUDF
+#include <cuda_runtime.h>
 #include <cudf/concatenate.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/table/table.hpp>
@@ -24,10 +25,42 @@ int get_streaming_batch_size() {
     return (env_str != nullptr) ? std::stoi(env_str) : 32768;
 }
 
+#ifdef USE_CUDF
+
 int get_gpu_streaming_batch_size() {
+    static std::once_flag once_flag_;
+    static int default_result;
+
+    std::call_once(once_flag_, [&]() {
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        // Get total bytes available on the GPU.
+        cudaMemGetInfo(&free_bytes, &total_bytes);
+        // Use this environment variable to override the default divisor
+        // of 2000.
+        char *env_str = std::getenv("BODO_GPU_STREAMING_BATCH_SIZE_DIVISOR");
+        // We have some data on a limited number of GPU types that allowing for
+        // 1000 bytes per row with all attendant overheads and temporary tables
+        // yields a good performance with low-risk of crashing or hanging due
+        // to memory related problems.  Allocating 500 bytes per row + overheads
+        // pretty consistently has problems particularly if there are CTEs
+        // involved.  Allocating 2000 per row + overheads is about 10% slower
+        // but with even less likelihood of memory problems.
+        int divisor = (env_str != nullptr) ? std::stoi(env_str) : 2000;
+        default_result = total_bytes / divisor;
+    });
+
     char *env_str = std::getenv("BODO_GPU_STREAMING_BATCH_SIZE");
-    return (env_str != nullptr) ? std::stoi(env_str) : 24.e6;
+    return (env_str != nullptr) ? std::stoi(env_str) : default_result;
 }
+
+#else  // USE_CUDF
+
+int get_gpu_streaming_batch_size() {
+    throw std::runtime_error("Code asked for GPU batch size in non-CUDF mode.");
+}
+
+#endif  // USE_CUDF
 
 // Maximum Parquet file size for streaming Parquet write
 int64_t get_parquet_chunk_size() {


### PR DESCRIPTION
## Changes included in this PR

Divide GPU memory size by a constant to get batch size.  Simple adaptation for different GPUs.

## Testing strategy

run_ci

## User facing changes

Added BODO_GPU_STREAMING_BATCH_SIZE_DIVISOR to control how many GPU bytes get allocated per batch row.  So, can control GPU batch size this way or by setting the absolute size with the existing env var.  This way allows you more control when your GPUs have differing memory amounts.

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.