### PR TITLE
[GPU] Fix groupby test hang

### DIFF
--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1292,6 +1292,20 @@ std::unique_ptr<cudf::scalar> make_invalid_like(
             return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_ns>>(
                 static_cast<int64_t>(0), false, stream, mr);
 
+        // **durations**
+        case cudf::type_id::DURATION_SECONDS:
+            return std::make_unique<cudf::duration_scalar<cudf::duration_s>>(
+                static_cast<int64_t>(0), false, stream, mr);
+        case cudf::type_id::DURATION_MILLISECONDS:
+            return std::make_unique<cudf::duration_scalar<cudf::duration_ms>>(
+                static_cast<int64_t>(0), false, stream, mr);
+        case cudf::type_id::DURATION_MICROSECONDS:
+            return std::make_unique<cudf::duration_scalar<cudf::duration_us>>(
+                static_cast<int64_t>(0), false, stream, mr);
+        case cudf::type_id::DURATION_NANOSECONDS:
+            return std::make_unique<cudf::duration_scalar<cudf::duration_ns>>(
+                static_cast<int64_t>(0), false, stream, mr);
+
         default:
             throw std::runtime_error(
                 "Unsupported cudf::type_id in make_invalid_like");
@@ -1552,9 +1566,26 @@ cudf::data_type arrow_to_cudf_type(const std::shared_ptr<arrow::DataType> &t) {
             return cudf::data_type{type_id::TIMESTAMP_DAYS};
         }
 
-        default:
+        case Type::DURATION: {
+            auto duration = std::static_pointer_cast<arrow::DurationType>(t);
+            switch (duration->unit()) {
+                case arrow::TimeUnit::SECOND:
+                    return cudf::data_type{type_id::DURATION_SECONDS};
+                case arrow::TimeUnit::MILLI:
+                    return cudf::data_type{type_id::DURATION_MILLISECONDS};
+                case arrow::TimeUnit::MICRO:
+                    return cudf::data_type{type_id::DURATION_MICROSECONDS};
+                case arrow::TimeUnit::NANO:
+                    return cudf::data_type{type_id::DURATION_NANOSECONDS};
+                default:
+                    throw std::runtime_error("Unsupported Arrow duration unit");
+            }
+        }
+
+        default: {
             throw std::runtime_error("Unsupported Arrow type: " +
                                      t->ToString());
+        }
     }
 }
 
@@ -1642,6 +1673,14 @@ std::shared_ptr<arrow::DataType> cudf_to_arrow_type(cudf::data_type &t) {
             return arrow::timestamp(arrow::TimeUnit::NANO);
         case type_id::TIMESTAMP_DAYS:
             return arrow::date32();
+        case type_id::DURATION_SECONDS:
+            return arrow::duration(arrow::TimeUnit::SECOND);
+        case type_id::DURATION_MILLISECONDS:
+            return arrow::duration(arrow::TimeUnit::MILLI);
+        case type_id::DURATION_MICROSECONDS:
+            return arrow::duration(arrow::TimeUnit::MICRO);
+        case type_id::DURATION_NANOSECONDS:
+            return arrow::duration(arrow::TimeUnit::NANO);
         default:
             throw std::runtime_error(
                 "Unsupported cudf data_type for Arrow conversion: " +

--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -900,7 +900,7 @@ def _get_agg_output_type(
         elif pa.types.is_decimal(pa_type):
             # TODO: Decimal sum
             fallback = True
-    elif func_name in ("mean", "std", "var", "skew"):
+    elif func_name in ("mean", "std", "var", "skew", "median"):
         if pa.types.is_integer(pa_type) or pa.types.is_floating(pa_type):
             new_type = pa.float64()
         elif pa.types.is_boolean(pa_type) or pa.types.is_decimal(pa_type):

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1700,9 +1700,9 @@ def test_groupby_fallback():
 def groupby_agg_df(request):
     return pd.DataFrame(
         {
-            "A": pd.array([1, 2, pd.NA, 2147483647] * 3, "Int32"),
+            "A": pd.array([1, 2, 0, 2147483647] * 3, "Int32"),
             "D": pd.array(
-                [i * 2 if (i**2) % 3 == 0 else pd.NA for i in range(12)], "Int32"
+                [i * 2 if (i**2) % 3 == 0 else 0 for i in range(12)], "Int32"
             ),
             "B": pd.array(["A", "B", pd.NA] * 4),
             "C": pd.array([0.2, 0.2, 0.3] * 4, "Float32"),
@@ -1711,6 +1711,7 @@ def groupby_agg_df(request):
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize(
     "func, kwargs",
     [

--- a/docs/docs/guides/dataframes/gpu_acceleration.md
+++ b/docs/docs/guides/dataframes/gpu_acceleration.md
@@ -139,6 +139,7 @@ Column selection and built-in arithmetic/boolean expressions are supported on GP
 ### GroupBy
 
 The listed aggregations (sum, count, mean, min, max, var, std, size, skew, nunique) are supported on GPU. Custom aggregations implemented as UDFs or Python callbacks will run on CPU.
+`sum` of an all-NA group produces NA output (libcudf behavior) instead of zero (Pandas behavior).
 
 ### Joins
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixing the hang needed duration data type support.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix. More timedelta support.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.