### PR TITLE
[GPU] Fix broadcast join segfault from OpenMPI/UCX

### DIFF
--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -166,19 +166,15 @@ std::unique_ptr<cudf::table> CudaJoin::produce_unmatched_build_rows(
     const MPI_Comm comm = this->probe_shuffle_manager->get_mpi_comm();
     if (this->is_broadcast_join && !this->build_matches_synced) {
         if (this->sync_build_matches_req == MPI_REQUEST_NULL) {
-            this->n_build_rows = this->unmatched_build_rows->size();
-            this->unmatched_build_rows_contents =
-                std::make_unique<cudf::column::contents>(
-                    this->unmatched_build_rows->release());
-            auto* d_buf = static_cast<uint8_t*>(
-                unmatched_build_rows_contents->data->data());
-            cudaHostAlloc(&this->unmatched_build_rows_host, n_build_rows,
+            int n = this->unmatched_build_rows->size();
+            auto d_buf = unmatched_build_rows->view().data<uint8_t>();
+            cudaHostAlloc(&this->unmatched_build_rows_host, n,
                           cudaHostAllocDefault);
-            cudaMemcpy(unmatched_build_rows_host, d_buf, n_build_rows,
+            cudaMemcpy(unmatched_build_rows_host, d_buf, n,
                        cudaMemcpyDeviceToHost);
             CHECK_MPI(
-                MPI_Iallreduce(MPI_IN_PLACE, unmatched_build_rows_host,
-                               n_build_rows, MPI_UINT8_T, MPI_BAND, comm,
+                MPI_Iallreduce(MPI_IN_PLACE, unmatched_build_rows_host, n,
+                               MPI_UINT8_T, MPI_BAND, comm,
                                &this->sync_build_matches_req),
                 "produce_unmatched_build_rows: MPI error on MPI_Iallreduce ");
             return table;
@@ -189,14 +185,11 @@ std::unique_ptr<cudf::table> CudaJoin::produce_unmatched_build_rows(
                       "produce_unmatched_build_rows: MPI error on MPI_Test ");
             if (flag) {
                 this->build_matches_synced = true;
-                auto* d_buf = static_cast<uint8_t*>(
-                    unmatched_build_rows_contents->data->data());
-                cudaMemcpy(d_buf, unmatched_build_rows_host, n_build_rows,
+                auto* d_buf =
+                    unmatched_build_rows->mutable_view().data<uint8_t>();
+                cudaMemcpy(d_buf, unmatched_build_rows_host,
+                           unmatched_build_rows->size(),
                            cudaMemcpyHostToDevice);
-                this->unmatched_build_rows = std::make_unique<cudf::column>(
-                    cudf::data_type{cudf::type_id::BOOL8}, n_build_rows,
-                    std::move(*unmatched_build_rows_contents->data),
-                    std::move(*unmatched_build_rows_contents->null_mask), 0);
             } else {
                 return table;
             }

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -849,8 +849,6 @@ CudaNonEquiJoin::ProbeProcessBatch(
     // Update which build table indices we've matched if it's relevant
     if (duckdb::PropagatesBuildSide(this->join_type) &&
         this->unmatched_build_rows && build_idx_view.size()) {
-        std::cout << " setting idxs at " << __FILE__ << ":" << __LINE__
-                  << std::endl;
         cudf_set_bools_from_indices<false>(
             this->unmatched_build_rows->mutable_view(), build_idx_view, stream);
     }

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -2,6 +2,7 @@
 #include <arrow/array/util.h>
 #include <arrow/compute/api_aggregate.h>
 #include <mpi.h>
+#include <cudf/aggregation.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/concatenate.hpp>
@@ -12,6 +13,7 @@
 #include <cudf/join/join.hpp>
 #include <cudf/join/mixed_join.hpp>
 #include <cudf/reduction.hpp>
+#include <cudf/sorting.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/types.hpp>
 #include <memory>
@@ -19,6 +21,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <stdexcept>
+#include <string>
 #include "../../pandas/physical/gpu_expression.h"
 #include "../../pandas/physical/operator.h"
 #include "../_utils.h"
@@ -174,7 +177,7 @@ std::unique_ptr<cudf::table> CudaJoin::produce_unmatched_build_rows(
                        cudaMemcpyDeviceToHost);
             CHECK_MPI(
                 MPI_Iallreduce(MPI_IN_PLACE, unmatched_build_rows_host, n,
-                               MPI_UINT8_T, MPI_BAND, comm,
+                               MPI_UINT8_T, MPI_LAND, comm,
                                &this->sync_build_matches_req),
                 "produce_unmatched_build_rows: MPI error on MPI_Iallreduce ");
             return table;
@@ -190,6 +193,7 @@ std::unique_ptr<cudf::table> CudaJoin::produce_unmatched_build_rows(
                 cudaMemcpy(d_buf, unmatched_build_rows_host,
                            unmatched_build_rows->size(),
                            cudaMemcpyHostToDevice);
+                cudaFreeHost(this->unmatched_build_rows_host);
             } else {
                 return table;
             }
@@ -304,6 +308,24 @@ std::pair<std::unique_ptr<cudf::table>, bool> CudaJoin::materialize_and_output(
             global_is_last && this->build_matches_synced};
 }
 
+void CudaJoin::sort_build_table() {
+    if (!this->_build_table) {
+        throw std::runtime_error(
+            "CudaJoin::sort_build_table called before build table is "
+            "initialized");
+    }
+
+    auto unsorted_build = std::move(this->_build_table);
+    auto order = cudf::sorted_order(
+        unsorted_build->view(),
+        std::vector<cudf::order>(unsorted_build->num_columns(),
+                                 cudf::order::ASCENDING),
+        std::vector<cudf::null_order>(unsorted_build->num_columns(),
+                                      cudf::null_order::AFTER));
+    auto sorted = cudf::gather(unsorted_build->view(), order->view());
+    this->_build_table = std::move(sorted);
+}
+
 void CudaHashJoin::build_hash_table(
     const std::vector<std::shared_ptr<cudf::table>>& build_chunks) {
     std::vector<cudf::table_view> build_views;
@@ -314,6 +336,11 @@ void CudaHashJoin::build_hash_table(
     }
     if (build_views.size() > 0) {
         this->_build_table = cudf::concatenate(build_views);
+
+        if (this->is_broadcast_join &&
+            duckdb::PropagatesBuildSide(this->join_type)) {
+            sort_build_table();
+        }
     } else {
         std::shared_ptr<arrow::Schema> build_table_arrow_schema =
             this->build_table_schema->ToArrowSchema();
@@ -700,6 +727,10 @@ void CudaNonEquiJoin::FinalizeBuild() {
         this->unmatched_build_rows = cudf::make_column_from_scalar(
             cudf::numeric_scalar(true), this->_build_table->num_rows(),
             cudf::get_default_stream());
+
+        if (this->is_broadcast_join) {
+            sort_build_table();
+        }
     }
 }
 
@@ -818,6 +849,8 @@ CudaNonEquiJoin::ProbeProcessBatch(
     // Update which build table indices we've matched if it's relevant
     if (duckdb::PropagatesBuildSide(this->join_type) &&
         this->unmatched_build_rows && build_idx_view.size()) {
+        std::cout << " setting idxs at " << __FILE__ << ":" << __LINE__
+                  << std::endl;
         cudf_set_bools_from_indices<false>(
             this->unmatched_build_rows->mutable_view(), build_idx_view, stream);
     }

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -16,12 +16,14 @@
 #include <cudf/types.hpp>
 #include <memory>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <stdexcept>
 #include "../../pandas/physical/gpu_expression.h"
 #include "../../pandas/physical/operator.h"
 #include "../_utils.h"
 #include "_util.h"
+#include "cuda_runtime_api.h"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/enums/join_type.hpp"
 
@@ -157,19 +159,29 @@ bool CudaJoin::BuildConsumeBatch(
 std::unique_ptr<cudf::table> CudaJoin::produce_unmatched_build_rows(
     std::unique_ptr<cudf::table> table, bool global_is_last,
     rmm::cuda_stream_view stream) {
-    if (!global_is_last || !duckdb::PropagatesBuildSide(this->join_type) ||
-        unmatched_build_rows == nullptr) {
+    if (!global_is_last || !duckdb::PropagatesBuildSide(this->join_type)) {
         return table;
     }
 
     const MPI_Comm comm = this->probe_shuffle_manager->get_mpi_comm();
     if (this->is_broadcast_join && !this->build_matches_synced) {
         if (this->sync_build_matches_req == MPI_REQUEST_NULL) {
+            this->n_build_rows = this->unmatched_build_rows->size();
+            this->unmatched_build_rows_contents =
+                std::make_unique<cudf::column::contents>(
+                    this->unmatched_build_rows->release());
+            auto* d_buf = static_cast<uint8_t*>(
+                unmatched_build_rows_contents->data->data());
+            cudaHostAlloc(&this->unmatched_build_rows_host, n_build_rows,
+                          cudaHostAllocDefault);
+            cudaMemcpy(unmatched_build_rows_host, d_buf, n_build_rows,
+                       cudaMemcpyDeviceToHost);
             CHECK_MPI(
-                MPI_Iallreduce(MPI_IN_PLACE, this->unmatched_build_rows.get(),
-                               this->unmatched_build_rows->size(), MPI_UINT8_T,
-                               MPI_BAND, comm, &this->sync_build_matches_req),
+                MPI_Iallreduce(MPI_IN_PLACE, unmatched_build_rows_host,
+                               n_build_rows, MPI_UINT8_T, MPI_BAND, comm,
+                               &this->sync_build_matches_req),
                 "produce_unmatched_build_rows: MPI error on MPI_Iallreduce ");
+            return table;
         } else {
             int flag = 0;
             CHECK_MPI(MPI_Test(&this->sync_build_matches_req, &flag,
@@ -177,6 +189,14 @@ std::unique_ptr<cudf::table> CudaJoin::produce_unmatched_build_rows(
                       "produce_unmatched_build_rows: MPI error on MPI_Test ");
             if (flag) {
                 this->build_matches_synced = true;
+                auto* d_buf = static_cast<uint8_t*>(
+                    unmatched_build_rows_contents->data->data());
+                cudaMemcpy(d_buf, unmatched_build_rows_host, n_build_rows,
+                           cudaMemcpyHostToDevice);
+                this->unmatched_build_rows = std::make_unique<cudf::column>(
+                    cudf::data_type{cudf::type_id::BOOL8}, n_build_rows,
+                    std::move(*unmatched_build_rows_contents->data),
+                    std::move(*unmatched_build_rows_contents->null_mask), 0);
             } else {
                 return table;
             }
@@ -188,7 +208,7 @@ std::unique_ptr<cudf::table> CudaJoin::produce_unmatched_build_rows(
     // If it's a broadcast join we only want to
     // produce the unmatched rows on one rank since
     // all ranks share a build table
-    if (this->is_broadcast_join && rank > 0) {
+    if ((this->is_broadcast_join && rank > 0) || !this->unmatched_build_rows) {
         return table;
     }
 

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -2,7 +2,6 @@
 #include <arrow/array/util.h>
 #include <arrow/compute/api_aggregate.h>
 #include <mpi.h>
-#include <cudf/aggregation.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/concatenate.hpp>
@@ -18,10 +17,8 @@
 #include <cudf/types.hpp>
 #include <memory>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <stdexcept>
-#include <string>
 #include "../../pandas/physical/gpu_expression.h"
 #include "../../pandas/physical/operator.h"
 #include "../_utils.h"

--- a/bodo/libs/streaming/cuda_join.h
+++ b/bodo/libs/streaming/cuda_join.h
@@ -45,6 +45,12 @@ struct CudaJoin {
     std::unique_ptr<cudf::column> unmatched_build_rows =
         nullptr;  // Used for right/outer joins to track which
                   // build rows have been matched
+    size_t n_build_rows = 0;
+    uint8_t* unmatched_build_rows_host;  // Host buffer for
+                                         // unmatched_build_rows reduction
+    std::unique_ptr<cudf::column::contents>
+        unmatched_build_rows_contents;  // Device buffer for
+                                        // unmatched_build_rows reduction result
     // For broadcast joins on RIGHT/OUTER joins we need to sync the build table
     // matches globally to only produce unmatched build rows once.
     MPI_Request sync_build_matches_req = MPI_REQUEST_NULL;

--- a/bodo/libs/streaming/cuda_join.h
+++ b/bodo/libs/streaming/cuda_join.h
@@ -199,6 +199,14 @@ struct CudaJoin {
         cudf::table_view const& build_kept_view,
         cudf::column_view const& build_idx_view, bool global_is_last,
         rmm::cuda_stream_view stream);
+
+    /**
+     * @brief Sort build table in lexicographical order to make broadcast join
+     * build_indices consistent across all ranks.
+     * TODO(scott): Sort build chunks as they are received to avoid sorting at
+     * the end.
+     */
+    void sort_build_table();
 };
 
 struct CudaHashJoin : public CudaJoin {

--- a/bodo/libs/streaming/cuda_join.h
+++ b/bodo/libs/streaming/cuda_join.h
@@ -45,12 +45,8 @@ struct CudaJoin {
     std::unique_ptr<cudf::column> unmatched_build_rows =
         nullptr;  // Used for right/outer joins to track which
                   // build rows have been matched
-    size_t n_build_rows = 0;
-    uint8_t* unmatched_build_rows_host;  // Host buffer for
+    uint8_t* unmatched_build_rows_host;  // Pinned host buffer for
                                          // unmatched_build_rows reduction
-    std::unique_ptr<cudf::column::contents>
-        unmatched_build_rows_contents;  // Device buffer for
-                                        // unmatched_build_rows reduction result
     // For broadcast joins on RIGHT/OUTER joins we need to sync the build table
     // matches globally to only produce unmatched build rows once.
     MPI_Request sync_build_matches_req = MPI_REQUEST_NULL;


### PR DESCRIPTION
## Changes included in this PR

* Replace CUDA-aware MPI_Iallreduce with copy to host.
* Sort build table in the broadcast join case to make sure build_indices are consistent across all ranks

## Testing strategy

TPCH Q22 runs and SF10 results are correct on a 4 GPU Instance.

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.