### PR TITLE
[GPU] Fix groupby nunique null corner case [run ci]

### DIFF
--- a/bodo/libs/streaming/cuda_groupby.h
+++ b/bodo/libs/streaming/cuda_groupby.h
@@ -210,8 +210,12 @@ class CudaGroupbyState {
                 break;
             case Bodo_FTypes::nunique:
                 add_agg_entry(
+                    // Nulls have to be included to avoid droping non-null
+                    // values from other data columns during cudf::explode().
+                    // The cudf::lists::count_elements() call at the end skips
+                    // nulls.
                     cudf::make_collect_set_aggregation<
-                        cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE,
+                        cudf::groupby_aggregation>(cudf::null_policy::INCLUDE,
                                                    cudf::null_equality::UNEQUAL,
                                                    cudf::nan_equality::UNEQUAL),
                     aggregation_requests, aggregation_fns, post_agg_fns,

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1816,6 +1816,7 @@ def test_size_no_val(groupby_agg_df, as_index):
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize(
     "func",
     [


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.