### PR TITLE
Fix groupby output schema error

### DIFF
--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -553,13 +553,18 @@ def _groupby_agg_plan(
 ) -> BodoSeries | BodoDataFrame:
     """Compute groupby.func() on the Series or DataFrame GroupBy object."""
     from bodo.pandas.base import _empty_like
+    from bodo.pandas_compat import pandas_version
 
     grouped_selection = grouped.selection_for_plan
 
     zero_size_df = _empty_like(grouped._obj)
 
-    # Convert to Pandas types to avoid gaps in Arrow conversion
-    zero_size_df_pandas = convert_to_pandas_types(zero_size_df)
+    # Convert to Pandas types to avoid gaps in Arrow types of Pandas <3
+    zero_size_df_pandas = (
+        convert_to_pandas_types(zero_size_df)
+        if pandas_version < (3, 0)
+        else zero_size_df
+    )
     empty_data_pandas = zero_size_df_pandas.groupby(
         grouped._keys, as_index=grouped._as_index
     )[
@@ -579,7 +584,7 @@ def _groupby_agg_plan(
 
     n_key_cols = 0 if grouped._as_index else len(grouped._keys)
     empty_data = _cast_groupby_agg_columns(
-        normalized_func, zero_size_df, empty_data_pandas, n_key_cols
+        normalized_func, zero_size_df, empty_data_pandas, n_key_cols, grouped._keys
     )
 
     out_types = empty_data
@@ -982,6 +987,7 @@ def _cast_groupby_agg_columns(
     in_data: pd.DataFrame,
     out_data: pd.Series | pd.DataFrame,
     n_key_cols: int,
+    keys: list[str],
 ) -> pd.Series | pd.DataFrame:
     """
     Casts dtypes in the output of GroupBy.agg() to the correct type for aggregation.
@@ -994,6 +1000,7 @@ def _cast_groupby_agg_columns(
         in_data : An empty DataFrame with the same shape as the input to the
             aggregation.
         n_key_cols : Number of grouping keys in the output.
+        keys: column names of key columns
 
     Returns:
         pd.Series | pd.DataFrame: A DataFrame or Series with the dtypes casted depending
@@ -1030,5 +1037,11 @@ def _cast_groupby_agg_columns(
 
         out_col_name = out_data.columns[i + n_key_cols]
         out_data[out_col_name] = pd.Series([], dtype=pd.ArrowDtype(new_type))
+
+    # Set key dtypes as Arrow dtypes to avoid object dtype issues downstream
+    # TODO(ehsan): handle as_index=True case which generates MultiIndex
+    for i in range(n_key_cols):
+        key_col_name = keys[i]
+        out_data[key_col_name] = pd.Series([], dtype=in_data[key_col_name].dtype)
 
     return out_data

--- a/bodo/tests/test_df_lib/test_plan.py
+++ b/bodo/tests/test_df_lib/test_plan.py
@@ -4,8 +4,10 @@ Tests dataframe library plan nodes.
 
 import operator
 
+import pandas as pd
 import pyarrow as pa
 
+import bodo.pandas as bd
 from bodo.ext import plan_optimizer
 
 
@@ -127,3 +129,20 @@ def test_parquet_projection_pushdown(datapath):
     assert plan_optimizer.get_pushed_down_columns(C) == [0, 2], (
         "Invalid projection pushdown"
     )
+
+
+def test_groupby_output_schema():
+    """Make sure groupby output schema has proper Arrow data types and not object dtype.
+    Tests BSE-5410.
+    """
+
+    df = pd.DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": pd.date_range("2023-01-01", periods=3).date,
+            "C": [0.1, 0.2, 0.3],
+        }
+    )
+    bdf = bd.from_pandas(df)
+    out = bdf.groupby("B", as_index=False).sum()
+    assert pa.types.is_date32(out._plan.empty_data.dtypes["B"].pyarrow_dtype)


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Pandas produces object dtype for date columns, which resulted in an error somewhere downstream. This fixes it.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.