### PR TITLE
[GPU] Todd/bodosql groupby

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -195,6 +195,95 @@ def java_call_to_python_call(java_call, input_plan):
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return UnaryOpExpression(bool_empty_data, input, "notnull")
 
+    # Add this block inside java_call_to_python_call, after SqlCastFunction handling
+    if operator_class_name == "SqlBasicFunction":
+        # Map Calcite basic functions to Bodo expressions
+        operands = java_call.getOperands()
+        op_exprs = [java_expr_to_python_expr(o, input_plan) for o in operands]
+        # function name as string (e.g., "POWER", "SQRT")
+        func_name = op.getName().toUpperCase()
+
+        # Binary power: POWER(x, y) -> use __pow__ via ArithOpExpression
+        if func_name == "POWER" and len(op_exprs) == 2:
+            left = op_exprs[0]
+            right = op_exprs[1]
+            out_empty = left.empty_data.iloc[:, 0] ** right.empty_data.iloc[:, 0]
+            return ArithOpExpression(out_empty, left, right, "__pow__")
+
+        # SQRT(x) -> unary sqrt
+        if func_name == "SQRT" and len(op_exprs) == 1:
+            inp = op_exprs[0]
+            out_empty = inp.empty_data.iloc[:, 0] ** 0.5
+            return UnaryOpExpression(out_empty, inp, "sqrt")
+
+        # ABS(x)
+        if func_name == "ABS" and len(op_exprs) == 1:
+            inp = op_exprs[0]
+            out_empty = inp.empty_data.iloc[:, 0].abs()
+            return UnaryOpExpression(out_empty, inp, "abs")
+
+        # CEIL(x) / CEILING(x)
+        if func_name in ("CEIL", "CEILING") and len(op_exprs) == 1:
+            inp = op_exprs[0]
+            out_empty = inp.empty_data.iloc[:, 0].apply(
+                lambda v: int(pd.NA)
+                if pd.isna(v)
+                else int(
+                    pd.Series([v]).apply(
+                        lambda x: int(x) if x == int(x) else int(x) + 1
+                    )[0]
+                )
+            )
+            # simpler: use numpy ceil if numeric; here we use pandas Series method
+            return UnaryOpExpression(out_empty, inp, "ceil")
+
+        # FLOOR(x)
+        if func_name == "FLOOR" and len(op_exprs) == 1:
+            inp = op_exprs[0]
+            out_empty = inp.empty_data.iloc[:, 0].apply(
+                lambda v: v if pd.isna(v) else int(v) // 1
+            )
+            return UnaryOpExpression(out_empty, inp, "floor")
+
+        # EXP(x)
+        if func_name == "EXP" and len(op_exprs) == 1:
+            inp = op_exprs[0]
+            out_empty = inp.empty_data.iloc[:, 0].apply(
+                lambda v: float("nan") if pd.isna(v) else float(pa.scalar(v).as_py())
+            )  # placeholder numeric mapping
+            out_empty = out_empty.astype("float64")
+            return UnaryOpExpression(out_empty, inp, "exp")
+
+        # LN(x) or LOG(x) -> natural log
+        if func_name in ("LN", "LOG") and len(op_exprs) == 1:
+            inp = op_exprs[0]
+            out_empty = inp.empty_data.iloc[:, 0].apply(
+                lambda v: float("nan") if pd.isna(v) else float(pa.scalar(v).as_py())
+            )
+            out_empty = out_empty.astype("float64")
+            return UnaryOpExpression(out_empty, inp, "log")
+
+        # ROUND(x, d) or ROUND(x) -> map to a unary/binary op if supported
+        if func_name == "ROUND" and len(op_exprs) in (1, 2):
+            inp = op_exprs[0]
+            if len(op_exprs) == 1:
+                out_empty = inp.empty_data.iloc[:, 0].round()
+            else:
+                # second operand is digits; try to apply if it's a constant
+                digits_expr = op_exprs[1]
+                try:
+                    # attempt to extract integer from empty_data if available
+                    digits_val = int(digits_expr.empty_data.iloc[0, 0])
+                    out_empty = inp.empty_data.iloc[:, 0].round(digits_val)
+                except Exception:
+                    out_empty = inp.empty_data.iloc[:, 0].round()
+            return UnaryOpExpression(out_empty, inp, "round")
+
+        # If we didn't match a supported basic function, fall through to NotImplemented
+        raise NotImplementedError(
+            f"SqlBasicFunction {func_name} not supported yet: " + java_call.toString()
+        )
+
     raise NotImplementedError(
         f"Call operator {operator_class_name} not supported yet: "
         + java_call.toString()
@@ -229,6 +318,11 @@ def java_binop_to_python_expr(kind, op_exprs):
     if kind.equals(SqlKind.TIMES):
         out_empty = left.empty_data.iloc[:, 0] * right.empty_data.iloc[:, 0]
         expr = ArithOpExpression(out_empty, left, right, "__mul__")
+        return expr
+
+    if kind.equals(SqlKind.DIVIDE):
+        out_empty = left.empty_data.iloc[:, 0] / right.empty_data.iloc[:, 0]
+        expr = ArithOpExpression(out_empty, left, right, "__truediv__")
         return expr
 
     # Comparison operators
@@ -440,12 +534,14 @@ def java_agg_to_python_agg(ctx, java_plan):
                 "Only zero or single-argument size aggregations are supported"
             )
             out_type = pa.int64()
-        else:
+        elif func_name in ["sum", "max", "min", "std", "mean"]:
             assert len(arg_cols) == 1, "Only single-argument aggregations are supported"
             in_type = input_plan.pa_schema.field(arg_cols[0]).type
             out_type = _get_agg_output_type(
                 GroupbyAggFunc("dummy", func_name), in_type, "dummy"
             )
+        else:
+            raise NotImplementedError(f"Aggregation {func_name} not supported yet")
         out_types.append(out_type)
         exprs.append(
             AggregateExpression(
@@ -482,6 +578,18 @@ def _agg_to_func_name(func):
 
     if kind.equals(SqlKind.COUNT) and len(func.getArgList()) <= 1:
         return "size"
+
+    if kind.equals(SqlKind.MAX) and len(func.getArgList()) == 1:
+        return "max"
+
+    if kind.equals(SqlKind.MIN) and len(func.getArgList()) == 1:
+        return "min"
+
+    if kind.equals(SqlKind.AVG) and len(func.getArgList()) == 1:
+        return "mean"
+
+    if kind.equals(SqlKind.STDDEV_SAMP) and len(func.getArgList()) == 1:
+        return "std"
 
     raise NotImplementedError(f"Aggregation {kind.toString()} not supported yet")
 
@@ -699,7 +807,7 @@ def java_call_to_pyiceberg_call(java_call, field_names):
             return pie.NotNull(input)
 
     raise NotImplementedError(
-        f"Call operator {operator_class_name} not supported yet: "
+        f"Call operator {operator_class_name} for pyiceberg not supported yet: "
         + java_call.toString()
     )
 

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -436,6 +436,9 @@ def java_agg_to_python_agg(ctx, java_plan):
         func_name = _agg_to_func_name(func)
         arg_cols = list(func.getArgList())
         if func_name == "size":
+            assert len(arg_cols) in [0, 1], (
+                "Only zero or single-argument size aggregations are supported"
+            )
             out_type = pa.int64()
         else:
             assert len(arg_cols) == 1, "Only single-argument aggregations are supported"
@@ -477,7 +480,7 @@ def _agg_to_func_name(func):
     if kind.equals(SqlKind.SUM) or kind.equals(SqlKind.SUM0):
         return "sum"
 
-    if kind.equals(SqlKind.COUNT) and len(func.getArgList()) == 0:
+    if kind.equals(SqlKind.COUNT) and len(func.getArgList()) <= 1:
         return "size"
 
     raise NotImplementedError(f"Aggregation {kind.toString()} not supported yet")

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -195,7 +195,6 @@ def java_call_to_python_call(java_call, input_plan):
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return UnaryOpExpression(bool_empty_data, input, "notnull")
 
-    # Add this block inside java_call_to_python_call, after SqlCastFunction handling
     if operator_class_name == "SqlBasicFunction":
         # Map Calcite basic functions to Bodo expressions
         operands = java_call.getOperands()

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -224,58 +224,33 @@ def java_call_to_python_call(java_call, input_plan):
         # CEIL(x) / CEILING(x)
         if func_name in ("CEIL", "CEILING") and len(op_exprs) == 1:
             inp = op_exprs[0]
-            out_empty = inp.empty_data.iloc[:, 0].apply(
-                lambda v: int(pd.NA)
-                if pd.isna(v)
-                else int(
-                    pd.Series([v]).apply(
-                        lambda x: int(x) if x == int(x) else int(x) + 1
-                    )[0]
-                )
-            )
-            # simpler: use numpy ceil if numeric; here we use pandas Series method
+            out_empty = inp.empty_data
             return UnaryOpExpression(out_empty, inp, "ceil")
 
         # FLOOR(x)
         if func_name == "FLOOR" and len(op_exprs) == 1:
             inp = op_exprs[0]
-            out_empty = inp.empty_data.iloc[:, 0].apply(
-                lambda v: v if pd.isna(v) else int(v) // 1
-            )
+            out_empty = inp.empty_data
             return UnaryOpExpression(out_empty, inp, "floor")
 
         # EXP(x)
         if func_name == "EXP" and len(op_exprs) == 1:
             inp = op_exprs[0]
-            out_empty = inp.empty_data.iloc[:, 0].apply(
-                lambda v: float("nan") if pd.isna(v) else float(pa.scalar(v).as_py())
-            )  # placeholder numeric mapping
+            out_empty = inp.empty_data
             out_empty = out_empty.astype("float64")
             return UnaryOpExpression(out_empty, inp, "exp")
 
         # LN(x) or LOG(x) -> natural log
         if func_name in ("LN", "LOG") and len(op_exprs) == 1:
             inp = op_exprs[0]
-            out_empty = inp.empty_data.iloc[:, 0].apply(
-                lambda v: float("nan") if pd.isna(v) else float(pa.scalar(v).as_py())
-            )
+            out_empty = inp.empty_data
             out_empty = out_empty.astype("float64")
             return UnaryOpExpression(out_empty, inp, "log")
 
         # ROUND(x, d) or ROUND(x) -> map to a unary/binary op if supported
         if func_name == "ROUND" and len(op_exprs) in (1, 2):
             inp = op_exprs[0]
-            if len(op_exprs) == 1:
-                out_empty = inp.empty_data.iloc[:, 0].round()
-            else:
-                # second operand is digits; try to apply if it's a constant
-                digits_expr = op_exprs[1]
-                try:
-                    # attempt to extract integer from empty_data if available
-                    digits_val = int(digits_expr.empty_data.iloc[0, 0])
-                    out_empty = inp.empty_data.iloc[:, 0].round(digits_val)
-                except Exception:
-                    out_empty = inp.empty_data.iloc[:, 0].round()
+            out_empty = inp.empty_data
             return UnaryOpExpression(out_empty, inp, "round")
 
         # If we didn't match a supported basic function, fall through to NotImplemented

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -191,7 +191,7 @@ def test_count_datetime(bodosql_datetime_types, spark_info, memory_leak_check):
     )
 
 
-@pytest.mark.bodosql_cpp
+# @pytest.mark.bodosql_cpp   # dataframe shape mismatch
 def test_count_interval(bodosql_interval_types, memory_leak_check):
     """test various count queries on Timedelta data."""
     check_query(

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -2012,6 +2012,7 @@ def test_mixed_nested_agg_keys(memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_groupby_agg_on_key_col(spark_info, memory_leak_check):
     """
     Test Groupby cases where the key columns are also the data columns.

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -50,7 +50,7 @@ def test_agg_numeric(
         "MIN",
         "AVG",
     ]:
-        pytest.skip("Only SUM is supported in C++ backend for now")
+        pytest.skip(f"{numeric_agg_builtin_funcs} not supported in C++ backend for now")
 
     # bitwise aggregate function only valid on integers
     if numeric_agg_builtin_funcs in {"BIT_XOR", "BIT_OR", "BIT_AND"}:
@@ -68,11 +68,20 @@ def test_agg_numeric(
     )
 
 
-# @pytest.mark.bodosql_cpp   # failing for variance, stddev w/ unimplemented CASE
+@pytest.mark.bodosql_cpp  # failing for variance, stddev w/ unimplemented CASE
 def test_agg_numeric_larger_group(
     grouped_dfs, numeric_agg_builtin_funcs, spark_info, memory_leak_check
 ):
     """test aggregation calls in queries on DataFrames with a larger data in each group."""
+
+    if bodosql.use_cpp_backend and numeric_agg_builtin_funcs not in [
+        "SUM",
+        "COUNT",
+        "MAX",
+        "MIN",
+        "AVG",
+    ]:
+        pytest.skip(f"{numeric_agg_builtin_funcs} not supported in C++ backend for now")
 
     # bitwise aggregate function only valid on integers
     if numeric_agg_builtin_funcs in {"BIT_XOR", "BIT_OR", "BIT_AND"}:
@@ -92,10 +101,20 @@ def test_agg_numeric_larger_group(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp  # failing for variance, stddev w/ unimplemented CASE
 def test_aliasing_agg_numeric(
     bodosql_numeric_types, numeric_agg_builtin_funcs, spark_info, memory_leak_check
 ):
     """test aliasing of aggregations in queries"""
+
+    if bodosql.use_cpp_backend and numeric_agg_builtin_funcs not in [
+        "SUM",
+        "COUNT",
+        "MAX",
+        "MIN",
+        "AVG",
+    ]:
+        pytest.skip(f"{numeric_agg_builtin_funcs} not supported in C++ backend for now")
 
     # bitwise aggregate function only valid on integers
     if numeric_agg_builtin_funcs in {"BIT_XOR", "BIT_OR", "BIT_AND"}:

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -37,13 +37,19 @@ def grouped_dfs():
 
 
 @pytest.mark.slow
-@pytest.mark.bodosql_cpp
+@pytest.mark.bodosql_cpp  # failing for variance, stddev w/ unimplemented CASE
 def test_agg_numeric(
     bodosql_numeric_types, numeric_agg_builtin_funcs, memory_leak_check
 ):
     """test aggregation calls in queries"""
 
-    if bodosql.use_cpp_backend and numeric_agg_builtin_funcs != "SUM":
+    if bodosql.use_cpp_backend and numeric_agg_builtin_funcs not in [
+        "SUM",
+        "COUNT",
+        "MAX",
+        "MIN",
+        "AVG",
+    ]:
         pytest.skip("Only SUM is supported in C++ backend for now")
 
     # bitwise aggregate function only valid on integers
@@ -62,6 +68,7 @@ def test_agg_numeric(
     )
 
 
+# @pytest.mark.bodosql_cpp   # failing for variance, stddev w/ unimplemented CASE
 def test_agg_numeric_larger_group(
     grouped_dfs, numeric_agg_builtin_funcs, spark_info, memory_leak_check
 ):
@@ -106,6 +113,7 @@ def test_aliasing_agg_numeric(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_count_numeric(bodosql_numeric_types, spark_info, memory_leak_check):
     """test various count queries on numeric data."""
     check_query(
@@ -124,6 +132,7 @@ def test_count_numeric(bodosql_numeric_types, spark_info, memory_leak_check):
     )
 
 
+# @pytest.mark.bodosql_cpp   # nulls not handled correctly
 def test_count_nullable_numeric(
     bodosql_nullable_numeric_types, spark_info, memory_leak_check
 ):
@@ -144,6 +153,7 @@ def test_count_nullable_numeric(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_count_datetime(bodosql_datetime_types, spark_info, memory_leak_check):
     """test various count queries on Timestamp data."""
     check_query(
@@ -162,6 +172,7 @@ def test_count_datetime(bodosql_datetime_types, spark_info, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_count_interval(bodosql_interval_types, memory_leak_check):
     """test various count queries on Timedelta data."""
     check_query(
@@ -190,6 +201,7 @@ def test_count_interval(bodosql_interval_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_count_string(bodosql_string_types, spark_info, memory_leak_check):
     """test various count queries on string data."""
     check_query(
@@ -208,6 +220,7 @@ def test_count_string(bodosql_string_types, spark_info, memory_leak_check):
     )
 
 
+# @pytest.mark.bodosql_cpp   # dataframe are different
 def test_count_binary(bodosql_binary_types, spark_info, memory_leak_check):
     """test various count queries on binary data."""
     check_query(
@@ -226,6 +239,7 @@ def test_count_binary(bodosql_binary_types, spark_info, memory_leak_check):
     )
 
 
+# @pytest.mark.bodosql_cpp   # dataframe are different
 def test_count_boolean(bodosql_boolean_types, spark_info, memory_leak_check):
     """test various count queries on boolean data."""
     check_query(
@@ -245,6 +259,7 @@ def test_count_boolean(bodosql_boolean_types, spark_info, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_count_numeric_alias(bodosql_numeric_types, spark_info, memory_leak_check):
     """test various count queries on numeric data with aliases."""
     check_query(
@@ -264,6 +279,7 @@ def test_count_numeric_alias(bodosql_numeric_types, spark_info, memory_leak_chec
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_having_repeat_numeric(bodosql_numeric_types, spark_info, memory_leak_check):
     """test having clause in numeric queries"""
     check_query(
@@ -275,6 +291,7 @@ def test_having_repeat_numeric(bodosql_numeric_types, spark_info, memory_leak_ch
     )
 
 
+# @pytest.mark.bodosql_cpp   # dataframe are different
 def test_having_repeat_datetime(bodosql_datetime_types, spark_info, memory_leak_check):
     """test having clause in datetime queries"""
     check_query(
@@ -287,6 +304,7 @@ def test_having_repeat_datetime(bodosql_datetime_types, spark_info, memory_leak_
 
 
 @pytest.mark.slow
+# @pytest.mark.bodosql_cpp   # dataframe are different
 def test_having_repeat_interval(bodosql_interval_types, memory_leak_check):
     """test having clause in datetime queries"""
     expected_output = bodosql_interval_types["TABLE1"].groupby("A")["B"].count()
@@ -304,6 +322,7 @@ def test_having_repeat_interval(bodosql_interval_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_agg_repeat_col(bodosql_numeric_types, spark_info, memory_leak_check):
     """test aggregations repeating the same column"""
     check_query(
@@ -316,6 +335,7 @@ def test_agg_repeat_col(bodosql_numeric_types, spark_info, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_groupby_bool(bodosql_boolean_types, spark_info, memory_leak_check):
     """
     Simple test to ensure that groupby and max are working on boolean types
@@ -333,6 +353,7 @@ def test_groupby_bool(bodosql_boolean_types, spark_info, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_groupby_string(bodosql_string_types, spark_info, memory_leak_check):
     """
     Simple test to ensure that groupby and max are working on string types
@@ -354,6 +375,7 @@ def test_groupby_string(bodosql_string_types, spark_info, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_groupby_numeric_scalars(basic_df, spark_info, memory_leak_check):
     """
     tests to ensure that groupby and max are working with numeric scalars
@@ -370,6 +392,7 @@ def test_groupby_numeric_scalars(basic_df, spark_info, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_groupby_datetime_types(bodosql_datetime_types, spark_info, memory_leak_check):
     """
     Simple test to ensure that groupby and max are working on datetime types
@@ -391,6 +414,7 @@ def test_groupby_datetime_types(bodosql_datetime_types, spark_info, memory_leak_
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_groupby_interval_types(bodosql_interval_types, memory_leak_check):
     """
     Simple test to ensure that groupby and max are working on interval types
@@ -444,6 +468,7 @@ def test_groupby_interval_types(bodosql_interval_types, memory_leak_check):
         ),
     ],
 )
+# @pytest.mark.bodosql_cpp   # agg OTHER_FUNCTION not supported, SqlPostfixOperator not supported IS NULL
 def test_count_if(query, spark_info, memory_leak_check):
     ctx = {
         "TABLE1": pd.DataFrame(
@@ -467,6 +492,7 @@ def test_count_if(query, spark_info, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_having_numeric(
     bodosql_numeric_types,
     comparison_ops,
@@ -495,6 +521,7 @@ def test_having_numeric(
     )
 
 
+# @pytest.mark.bodosql_cpp   # SqlPrefixOperator not supported NOT
 def test_having_boolean_agg_cond(bodosql_boolean_types, spark_info, memory_leak_check):
     """
     Tests groupby + having with aggregation in the condition
@@ -518,6 +545,7 @@ def test_having_boolean_agg_cond(bodosql_boolean_types, spark_info, memory_leak_
     )
 
 
+# @pytest.mark.bodosql_cpp   # SqlPrefixOperator not supported NOT
 def test_having_boolean_groupby_cond(
     bodosql_boolean_types, spark_info, memory_leak_check
 ):
@@ -544,6 +572,7 @@ def test_having_boolean_groupby_cond(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_repeat_columns(basic_df, spark_info, memory_leak_check):
     """
     Tests that a column that won't produce a conflicting name
@@ -582,6 +611,7 @@ def groupby_extension_table():
     }
 
 
+# @pytest.mark.bodosql_cpp   # uses grouping sets not implemented
 def test_cube(groupby_extension_table, spark_info, memory_leak_check):
     """
     Tests that bodosql can use snowflake's cube syntax in groupby.
@@ -604,6 +634,7 @@ def test_cube(groupby_extension_table, spark_info, memory_leak_check):
 
 
 @pytest.mark.slow
+# @pytest.mark.bodosql_cpp   # uses grouping sets not implemented
 def test_rollup(groupby_extension_table, spark_info, memory_leak_check):
     """
     Tests that bodosql can use snowflake's rollup syntax in groupby.
@@ -626,6 +657,7 @@ def test_rollup(groupby_extension_table, spark_info, memory_leak_check):
 
 
 @pytest.mark.slow
+# @pytest.mark.bodosql_cpp   # uses grouping sets not implemented
 def test_grouping_sets(groupby_extension_table, spark_info, memory_leak_check):
     """
     Tests that bodosql can use snowflake's grouping sets syntax in groupby.
@@ -646,6 +678,7 @@ def test_grouping_sets(groupby_extension_table, spark_info, memory_leak_check):
 
 
 @pytest.mark.slow
+# @pytest.mark.bodosql_cpp   # uses grouping sets not implemented
 def test_no_group_or_agg(groupby_extension_table, spark_info, memory_leak_check):
     """Tests the case in which we have at least one empty group with no aggregation"""
 
@@ -708,6 +741,7 @@ def test_nested_grouping_clauses(
         pytest.param("H", id="string_array"),
     ],
 )
+# @pytest.mark.bodosql_cpp   # aggregation ANY_VALUE not supported
 def test_any_value(agg_col, memory_leak_check):
     """Tests ANY_VALUE, which is normally nondeterministic but has been
     implemented in a way that is reproducible (by always returning the first
@@ -914,6 +948,7 @@ def test_any_value(agg_col, memory_leak_check):
         ),
     ],
 )
+# @pytest.mark.bodosql_cpp   # aggregation OTHER not supported yet
 def test_boolor_booland_boolxor_agg(query, res, memory_leak_check):
     """Tests boolor_agg, booland_agg and boolxor_agg. These is done separately
     from existing aggregation tests, as we need specific inputs to stress this function
@@ -1058,6 +1093,7 @@ def test_boolor_booland_boolxor_agg(query, res, memory_leak_check):
 
 
 @pytest.mark.slow
+# @pytest.mark.bodosql_cpp   # aggregation OTHER not supported yet
 def test_booland_agg_having(memory_leak_check):
     """Test having with booland_agg aggregation in the condition"""
     query = (
@@ -1122,6 +1158,7 @@ def test_booland_agg_having(memory_leak_check):
 
 
 @pytest.mark.slow
+# @pytest.mark.bodosql_cpp   # aggregations without group by not supported yet
 def test_boolor_agg_output_type(memory_leak_check):
     """Test boolor_agg to verify the output type is boolean"""
     query = """WITH TEMP AS(SELECT boolor_agg(A) as agg_A, B FROM table1 GROUP BY B)
@@ -1175,6 +1212,7 @@ def test_boolor_agg_output_type(memory_leak_check):
 
 
 @pytest.mark.tz_aware
+@pytest.mark.bodosql_cpp
 def test_max_min_tz_aware(memory_leak_check):
     """
     Test max and min on a tz-aware timestamp column
@@ -1202,6 +1240,7 @@ def test_max_min_tz_aware(memory_leak_check):
 
 
 @pytest.mark.tz_aware
+# @pytest.mark.bodosql_cpp   # dataframes are different
 def test_count_tz_aware(memory_leak_check):
     """
     Test count and count(*) on a tz-aware timestamp column
@@ -1230,6 +1269,7 @@ def test_count_tz_aware(memory_leak_check):
 
 @pytest.mark.tz_aware
 @pytest.mark.slow
+# @pytest.mark.bodosql_cpp   # aggregation ANY_VALUE not supported yet
 def test_any_value_tz_aware(memory_leak_check):
     """
     Test any_value on a tz-aware timestamp column
@@ -1260,6 +1300,7 @@ def test_any_value_tz_aware(memory_leak_check):
 
 
 @pytest.mark.tz_aware
+@pytest.mark.bodosql_cpp
 def test_tz_aware_key(memory_leak_check):
     """
     Test tz_aware values as a key to groupby.
@@ -1290,6 +1331,7 @@ def test_tz_aware_key(memory_leak_check):
 
 @pytest.mark.tz_aware
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tz_aware_having(memory_leak_check):
     """
     Test having with tz-aware values.
@@ -1339,6 +1381,7 @@ def test_tz_aware_having(memory_leak_check):
     )
 
 
+# @pytest.mark.bodosql_cpp   # aggregation OTHER not supported yet
 def test_all_nulls_1(memory_leak_check):
     """
     Test the case where all values in a group are null.
@@ -1380,6 +1423,7 @@ def test_all_nulls_1(memory_leak_check):
     check_query(query, ctx, None, check_dtype=False, expected_output=py_output)
 
 
+# @pytest.mark.bodosql_cpp   # Call operator SqlCastFunction not supported yet
 def test_all_nulls_2(memory_leak_check):
     """
     Tests that groupby aggregations work correctly when the
@@ -1465,6 +1509,7 @@ def test_all_nulls_2(memory_leak_check):
         pytest.param("HIJ", id="slow_tests_b", marks=pytest.mark.slow),
     ],
 )
+# @pytest.mark.bodosql_cpp   # Aggregation OTHER_FUNCTIOn not supported yet
 def test_kurtosis_skew(agg_cols, spark_info, memory_leak_check):
     """Tests the Kurtosis and Skew functions"""
     query = (
@@ -1552,6 +1597,7 @@ def test_kurtosis_skew(agg_cols, spark_info, memory_leak_check):
         ),
     ],
 )
+# @pytest.mark.bodosql_cpp   # Aggregation MODE not supported yet
 def test_mode(values, dtype, memory_leak_check):
     """Tests MODE as a groupby aggregation on a subset of datatypes. The
     full type tests are done in the Python tests.
@@ -1596,6 +1642,7 @@ def test_mode(values, dtype, memory_leak_check):
     )
 
 
+# @pytest.mark.bodosql_cpp   # GroupBy.<bodo.pandas.groupby.GroupbyAggFunc object at 0x7ca675130d70>() on input column 'dummy' with type: decimal128(38, 37) not supported yet.
 def test_decimal_sum():
     """Tests groupby sum for decimals, which shoud throw error in case of overflow"""
     query = "SELECT A, sum(B) FROM table1 GROUP BY A"
@@ -1655,6 +1702,7 @@ def test_decimal_sum():
         ),
     ],
 )
+# @pytest.mark.bodosql_cpp   # Aggregation ARRAY_AGG not supported yet
 def test_array_agg(call, answer, memory_leak_check):
     """Tests ARRAY_AGG on integer data with and without a WITHIN GROUP clause containing
     a single ordering term, no DISTINCT, and accompanied by a GROUP BY.
@@ -1731,6 +1779,7 @@ def test_array_agg(call, answer, memory_leak_check):
         ),
     ],
 )
+# @pytest.mark.bodosql_cpp   # Aggregation ARRAY_AGG not supported yet
 def test_array_agg_distinct(call, answer, memory_leak_check):
     """Tests ARRAY_AGG on integer data with and without a WITHIN GROUP clause containing
     a single ordering term, with DISTINCT, and accompanied by a GROUP BY.
@@ -1828,6 +1877,7 @@ def test_array_agg_distinct(call, answer, memory_leak_check):
         ),
     ],
 )
+# @pytest.mark.bodosql_cpp   # from_pandas(): Could not convert DataFrame to Bodo: Unsupported datatype encountered in one or more columns: Could not convert Time(hour=0, minute=0, second=10, millisecond=648, microsecond=0, nanosecond=0, precision=9) with type Time: did not recognize Python value type when inferring an Arrow data type.  Aggregation OTHER_FUNCTION not supported yet
 def test_object_agg(value_pool, dtype, val_arrow_type, nullable, memory_leak_check):
     """Tests OBJECT_AGG with GROUP BY"""
     query = "SELECT G AS G, OBJECT_AGG(K, V) AS J FROM table1 GROUP BY G"
@@ -1894,6 +1944,7 @@ def test_object_agg(value_pool, dtype, val_arrow_type, nullable, memory_leak_che
         ),
     ],
 )
+# @pytest.mark.bodosql_cpp   # Aggregation OTHER_FUNCTION not supported yet
 def test_array_unique_agg(call, expected, memory_leak_check):
     """Tests ARRAY_AGG on integer data with and without a WITHIN GROUP clause containing
     a single ordering term, with DISTINCT, and accompanied by a GROUP BY.
@@ -1934,6 +1985,7 @@ def test_array_unique_agg(call, expected, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_mixed_nested_agg(memory_leak_check):
     """
     Test the case where we have a mix of semi-structured and regular keys.
@@ -1974,6 +2026,7 @@ def test_mixed_nested_agg(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_mixed_nested_agg_keys(memory_leak_check):
     query = "SELECT A, B, SUM(C) as C from table1 GROUP BY A, B"
     ctx = {


### PR DESCRIPTION
## Changes included in this PR

Enabling more aggregates for bodosql with dataframe cpp backend.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.