### PR TITLE
[GPU] Add GPU join stage timers and output rows count to query profiler

### DIFF
--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -57,6 +57,7 @@ inline bool gpu_capable(duckdb::LogicalComparisonJoin& logical_join) {
 class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
    private:
     bool doBroadcastJoin(duckdb::LogicalComparisonJoin& join) {
+        time_pt start_init = start_timer();
         duckdb::LogicalOperator& buildSide = *join.children[1];
         duckdb::LogicalOperator& probeSide = *join.children[0];
 
@@ -88,10 +89,12 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
 
         char* bcast_threshold = std::getenv("BODO_BCAST_JOIN_THRESHOLD");
         if (bcast_threshold) {
+            this->metrics.init_time += end_timer(start_init);
             return static_cast<int>(build_total) < std::stoi(bcast_threshold);
         }
 
         size_t total_bytes = get_smallest_gpu_mem_size();
+        this->metrics.init_time += end_timer(start_init);
         // Do broadcast join if probe table is order of magnitude smaller than
         // probe and it fits on GPU with room for the hash table.
         return (build_total < (probe_total * 0.1)) &&
@@ -108,6 +111,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
     PhysicalGPUJoin(duckdb::LogicalCrossProduct& logical_join,
                     const std::shared_ptr<bodo::Schema> build_table_schema,
                     const std::shared_ptr<bodo::Schema> probe_table_schema) {
+        time_pt start_init = start_timer();
         std::vector<int64_t> build_kept_cols;
         std::vector<int64_t> probe_kept_cols;
 
@@ -125,6 +129,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
             build_table_schema, probe_table_schema, build_kept_cols,
             probe_kept_cols, output_schema, duckdb::JoinType::INVALID, nullptr,
             true);
+        this->metrics.init_time += end_timer(start_init);
     }
 
     /**
@@ -141,6 +146,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
         duckdb::vector<duckdb::JoinCondition>& conditions,
         const std::shared_ptr<bodo::Schema> build_table_schema,
         const std::shared_ptr<bodo::Schema> probe_table_schema) {
+        time_pt start_init = start_timer();
         // Probe side
         duckdb::vector<duckdb::ColumnBinding> left_bindings =
             logical_join.children[0]->GetColumnBindings();
@@ -291,6 +297,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
                 "Output schema column count does not match logical join column "
                 "bindings count.");
         }
+        this->metrics.init_time += end_timer(start_init);
     }
 
     void initOutputSchema(
@@ -343,9 +350,28 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
 
     virtual ~PhysicalGPUJoin() = default;
 
-    void FinalizeSink() override { cuda_join->FinalizeBuild(); }
+    void FinalizeSink() override {
+        time_pt start_consume = start_timer();
+        cuda_join->FinalizeBuild();
+        this->metrics.consume_time += end_timer(start_consume);
+    }
 
-    void FinalizeProcessBatch() override {}
+    void FinalizeProcessBatch() override {
+        QueryProfileCollector::Default().SubmitOperatorName(getOpId(),
+                                                            ToString());
+        QueryProfileCollector::Default().SubmitOperatorStageTime(
+            QueryProfileCollector::MakeOperatorStageID(getOpId(), 0),
+            metrics.init_time);
+        QueryProfileCollector::Default().SubmitOperatorStageTime(
+            QueryProfileCollector::MakeOperatorStageID(getOpId(), 1),
+            metrics.consume_time);
+        QueryProfileCollector::Default().SubmitOperatorStageTime(
+            QueryProfileCollector::MakeOperatorStageID(getOpId(), 2),
+            metrics.process_batch_time);
+        QueryProfileCollector::Default().SubmitOperatorStageRowCounts(
+            QueryProfileCollector::MakeOperatorStageID(getOpId(), 2),
+            this->metrics.output_row_count);
+    }
 
     /**
      * @brief process input tables to build side of join (populate the hash
@@ -356,11 +382,13 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
     OperatorResult ConsumeBatchGPU(
         GPU_DATA input_batch, OperatorResult prev_op_result,
         std::shared_ptr<StreamAndEvent> se) override {
+        time_pt start_consume = start_timer();
         bool local_is_last = prev_op_result == OperatorResult::FINISHED;
 
         bool global_is_last = cuda_join->BuildConsumeBatch(
             input_batch.table, input_batch.stream_event, local_is_last);
 
+        this->metrics.consume_time += end_timer(start_consume);
         return global_is_last ? OperatorResult::FINISHED
                               : (cuda_join->is_build_complete()
                                      ? OperatorResult::HAVE_MORE_OUTPUT
@@ -376,6 +404,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
     std::pair<GPU_DATA, OperatorResult> ProcessBatchGPU(
         GPU_DATA input_batch, OperatorResult prev_op_result,
         std::shared_ptr<StreamAndEvent> se) override {
+        time_pt start_produce = start_timer();
         bool local_is_last = prev_op_result == OperatorResult::FINISHED;
 
         // TODO(ehsan): implement buffering output similar to CPU join
@@ -390,6 +419,9 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
             request_input = false;
         }
 
+        this->metrics.output_row_count +=
+            output_gpu_data.table ? output_gpu_data.table->num_rows() : 0;
+        this->metrics.process_batch_time += end_timer(start_produce);
         return {output_gpu_data,
                 global_is_last
                     ? OperatorResult::FINISHED


### PR DESCRIPTION
## Changes included in this PR

Adds stage timers and output row count to PhysicalGPUJoin, mirroring the CPU side

## Testing strategy

CI, manually verified profiles

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.