### PR TITLE
Fix test_count_interval for c++ backend.

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -520,10 +520,10 @@ def java_agg_to_python_agg(ctx, java_plan):
             raise NotImplementedError("Filtered aggregations are not supported yet")
         func_name = _agg_to_func_name(func)
         arg_cols = list(func.getArgList())
-        if func_name in ["size"]:
+        if func_name == "size":
             assert len(arg_cols) == 0, "Only zero size aggregations are supported"
             out_type = pa.int64()
-        elif func_name in ["nunique"]:
+        elif func_name == "nunique":
             assert len(arg_cols) == 1, (
                 "Only single-argument nunique aggregations are supported"
             )

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -521,7 +521,14 @@ def java_agg_to_python_agg(ctx, java_plan):
         func_name = _agg_to_func_name(func)
         arg_cols = list(func.getArgList())
         if func_name == "size":
-            assert len(arg_cols) == 0, "Only zero size aggregations are supported"
+            assert len(arg_cols) in [0, 1], (
+                "Size aggregations arg len not in [0,1] are not supported"
+            )
+            out_type = pa.int64()
+        elif func_name == "count":
+            assert len(arg_cols) == 1, (
+                "Only single-argument count aggregations are supported"
+            )
             out_type = pa.int64()
         elif func_name == "nunique":
             assert len(arg_cols) == 1, (
@@ -567,26 +574,28 @@ def _agg_to_func_name(func):
     SqlKind = gateway.jvm.org.apache.calcite.sql.SqlKind
     kind = agg.getKind()
 
+    argList = func.getArgList()
+
     # TODO[BSE-5163]: support SUM0 initialization properly
     if kind.equals(SqlKind.SUM) or kind.equals(SqlKind.SUM0):
         return "sum"
 
-    if kind.equals(SqlKind.COUNT) and len(func.getArgList()) == 0:
+    if kind.equals(SqlKind.COUNT) and len(argList) == 0:
         return "size"
 
-    if kind.equals(SqlKind.COUNT) and len(func.getArgList()) == 1:
-        return "nunique"
+    if kind.equals(SqlKind.COUNT) and len(argList) == 1:
+        return "count"
 
-    if kind.equals(SqlKind.MAX) and len(func.getArgList()) == 1:
+    if kind.equals(SqlKind.MAX) and len(argList) == 1:
         return "max"
 
-    if kind.equals(SqlKind.MIN) and len(func.getArgList()) == 1:
+    if kind.equals(SqlKind.MIN) and len(argList) == 1:
         return "min"
 
-    if kind.equals(SqlKind.AVG) and len(func.getArgList()) == 1:
+    if kind.equals(SqlKind.AVG) and len(argList) == 1:
         return "mean"
 
-    if kind.equals(SqlKind.STDDEV_SAMP) and len(func.getArgList()) == 1:
+    if kind.equals(SqlKind.STDDEV_SAMP) and len(argList) == 1:
         return "std"
 
     raise NotImplementedError(f"Aggregation {kind.toString()} not supported yet")

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -17,6 +17,7 @@ from bodo.pandas.plan import (
     ConstantExpression,
     LogicalAggregate,
     LogicalComparisonJoin,
+    LogicalDistinct,
     LogicalFilter,
     LogicalJoinFilter,
     LogicalOrder,
@@ -498,14 +499,33 @@ def java_agg_to_python_agg(ctx, java_plan):
 
     exprs = []
     out_types = [input_plan.pa_schema.field(k).type for k in keys]
-    for func in java_plan.getAggCallList():
+    aggCallList = java_plan.getAggCallList()
+    if len(aggCallList) == 0:
+        # If no aggregation expressions then use distinct instead.
+
+        names = list(java_plan.getRowType().getFieldNames())
+        new_schema = pa.schema([pa.field(name, t) for name, t in zip(names, out_types)])
+        empty_out_data = arrow_to_empty_df(new_schema)
+
+        exprs = make_col_ref_exprs(keys, input_plan)
+        plan = LogicalDistinct(
+            empty_out_data,
+            input_plan,
+            exprs,
+        )
+        return plan
+
+    for func in aggCallList:
         if func.hasFilter():
             raise NotImplementedError("Filtered aggregations are not supported yet")
         func_name = _agg_to_func_name(func)
         arg_cols = list(func.getArgList())
-        if func_name == "size":
-            assert len(arg_cols) in [0, 1], (
-                "Only zero or single-argument size aggregations are supported"
+        if func_name in ["size"]:
+            assert len(arg_cols) == 0, "Only zero size aggregations are supported"
+            out_type = pa.int64()
+        elif func_name in ["nunique"]:
+            assert len(arg_cols) == 1, (
+                "Only single-argument nunique aggregations are supported"
             )
             out_type = pa.int64()
         elif func_name in ["sum", "max", "min", "std", "mean"]:
@@ -524,13 +544,14 @@ def java_agg_to_python_agg(ctx, java_plan):
                 func_name,
                 None,
                 arg_cols,
-                False,
+                True,
             )
         )
 
     names = list(java_plan.getRowType().getFieldNames())
     new_schema = pa.schema([pa.field(name, t) for name, t in zip(names, out_types)])
     empty_out_data = arrow_to_empty_df(new_schema)
+
     plan = LogicalAggregate(
         empty_out_data,
         input_plan,
@@ -550,8 +571,11 @@ def _agg_to_func_name(func):
     if kind.equals(SqlKind.SUM) or kind.equals(SqlKind.SUM0):
         return "sum"
 
-    if kind.equals(SqlKind.COUNT) and len(func.getArgList()) <= 1:
+    if kind.equals(SqlKind.COUNT) and len(func.getArgList()) == 0:
         return "size"
+
+    if kind.equals(SqlKind.COUNT) and len(func.getArgList()) == 1:
+        return "nunique"
 
     if kind.equals(SqlKind.MAX) and len(func.getArgList()) == 1:
         return "max"

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -551,7 +551,7 @@ def java_agg_to_python_agg(ctx, java_plan):
                 func_name,
                 None,
                 arg_cols,
-                True,
+                False,
             )
         )
 

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -310,7 +310,7 @@ def test_having_repeat_numeric(bodosql_numeric_types, spark_info, memory_leak_ch
     )
 
 
-# @pytest.mark.bodosql_cpp   # dataframe are different
+@pytest.mark.bodosql_cpp
 def test_having_repeat_datetime(bodosql_datetime_types, spark_info, memory_leak_check):
     """test having clause in datetime queries"""
     check_query(
@@ -323,7 +323,7 @@ def test_having_repeat_datetime(bodosql_datetime_types, spark_info, memory_leak_
 
 
 @pytest.mark.slow
-# @pytest.mark.bodosql_cpp   # dataframe are different
+@pytest.mark.bodosql_cpp
 def test_having_repeat_interval(bodosql_interval_types, memory_leak_check):
     """test having clause in datetime queries"""
     expected_output = bodosql_interval_types["TABLE1"].groupby("A")["B"].count()

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -151,7 +151,7 @@ def test_count_numeric(bodosql_numeric_types, spark_info, memory_leak_check):
     )
 
 
-# @pytest.mark.bodosql_cpp   # nulls not handled correctly
+@pytest.mark.bodosql_cpp
 def test_count_nullable_numeric(
     bodosql_nullable_numeric_types, spark_info, memory_leak_check
 ):
@@ -1259,7 +1259,7 @@ def test_max_min_tz_aware(memory_leak_check):
 
 
 @pytest.mark.tz_aware
-# @pytest.mark.bodosql_cpp   # dataframes are different
+@pytest.mark.bodosql_cpp
 def test_count_tz_aware(memory_leak_check):
     """
     Test count and count(*) on a tz-aware timestamp column

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -191,7 +191,7 @@ def test_count_datetime(bodosql_datetime_types, spark_info, memory_leak_check):
     )
 
 
-# @pytest.mark.bodosql_cpp   # dataframe shape mismatch
+@pytest.mark.bodosql_cpp
 def test_count_interval(bodosql_interval_types, memory_leak_check):
     """test various count queries on Timedelta data."""
     check_query(

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -540,7 +540,7 @@ def test_having_numeric(
     )
 
 
-# @pytest.mark.bodosql_cpp   # SqlPrefixOperator not supported NOT
+@pytest.mark.bodosql_cpp
 def test_having_boolean_agg_cond(bodosql_boolean_types, spark_info, memory_leak_check):
     """
     Tests groupby + having with aggregation in the condition
@@ -564,7 +564,7 @@ def test_having_boolean_agg_cond(bodosql_boolean_types, spark_info, memory_leak_
     )
 
 
-# @pytest.mark.bodosql_cpp   # SqlPrefixOperator not supported NOT
+@pytest.mark.bodosql_cpp
 def test_having_boolean_groupby_cond(
     bodosql_boolean_types, spark_info, memory_leak_check
 ):


### PR DESCRIPTION
## Changes included in this PR

1) Convert aggregation with no column expressions into a distinct.
2) Support nunique.
3) Make calcite count with 0 args become bodo size and calcite count with non-zero args
   become bodo count.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.