### PR TITLE
[GPU][BSE-5416] Fix issues related to multiple workers per GPU and re-enabled tests

### DIFF
--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -130,7 +130,7 @@ jobs:
                  --cov-report= --cov=bodo --cov-append \
                  --store-durations --clean-durations \
                  --durations-path=buildscripts/github/test_dur_bodo_multi_gpu_more_workers.json \
-                 -m "$PYTEST_MARKER" $PYTEST_IGNORE bodo/tests
+                 -m "$PYTEST_MARKER" $PYTEST_IGNORE bodo/tests/test_df_lib/test_gpu
               python_multi_test_exit_code=$?
 
               # Merge Exit Codes

--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -126,12 +126,11 @@ jobs:
               python_test_exit_code=$?
 
               # Case 2: NUM_WORKERS > NUM GPUS
-              # TODO[BSE-5322]: Re-enable when CPU-GPU exchange doesn't change the order of data.
-              # BODO_NUM_WORKERS=9 pytest -s -v -Wignore \
-              #   --cov-report= --cov=bodo --cov-append \
-              #   --store-durations --clean-durations \
-              #   --durations-path=buildscripts/github/test_dur_bodo_multi_gpu_more_workers.json \
-              #   -m "$PYTEST_MARKER" $PYTEST_IGNORE bodo/tests
+              BODO_NUM_WORKERS=9 pytest -s -v -Wignore \
+                 --cov-report= --cov=bodo --cov-append \
+                 --store-durations --clean-durations \
+                 --durations-path=buildscripts/github/test_dur_bodo_multi_gpu_more_workers.json \
+                 -m "$PYTEST_MARKER" $PYTEST_IGNORE bodo/tests
               python_multi_test_exit_code=$?
 
               # Merge Exit Codes
@@ -228,7 +227,7 @@ jobs:
             mv .coverage outputs/.coverage_${{ inputs.batch }}_${{ inputs.test-type }}
             if [[ "${{ inputs.test-type }}" == "DF_LIB_GPU" ]]; then
               mv buildscripts/github/test_dur_bodo_multi_gpu.json outputs/test_dur_bodo_multi_gpu_${{ inputs.batch }}_${{ inputs.test-type }}.json
-              # mv buildscripts/github/test_dur_bodo_multi_gpu_more_workers.json outputs/test_dur_bodo_multi_gpu_more_workers_${{ inputs.batch }}_${{ inputs.test-type }}.json
+              mv buildscripts/github/test_dur_bodo_multi_gpu_more_workers.json outputs/test_dur_bodo_multi_gpu_more_workers_${{ inputs.batch }}_${{ inputs.test-type }}.json
             else
               mv buildscripts/github/test_dur_bodo.json outputs/test_dur_bodo_${{ inputs.batch }}_${{ inputs.test-type }}.json
               mv buildscripts/github/test_dur_bodosql.json outputs/test_dur_bodosql_${{ inputs.batch }}_${{ inputs.test-type }}.json

--- a/bodo/libs/streaming/cuda_sort.cpp
+++ b/bodo/libs/streaming/cuda_sort.cpp
@@ -306,14 +306,15 @@ void CudaSortState::FinalizeSort() {
 }
 
 std::unique_ptr<cudf::table> CudaSortState::GetOutputBatch(
-    bool& out_is_last, rmm::cuda_stream_view stream) {
+    bool& out_is_last, std::shared_ptr<StreamAndEvent> se) {
     if (state != State::MERGING) {
         out_is_last = false;
         return empty_table_from_arrow_schema(schema->ToArrowSchema());
     }
 
     if (final_result == nullptr) {
-        if (received_tables.empty() || local_slice_start == local_slice_end) {
+        if (!is_gpu_rank() || received_tables.empty() ||
+            local_slice_start == local_slice_end) {
             final_result =
                 empty_table_from_arrow_schema(schema->ToArrowSchema());
         } else {
@@ -323,7 +324,7 @@ std::unique_ptr<cudf::table> CudaSortState::GetOutputBatch(
             }
             // Multi-way Merge
             auto merged = cudf::merge(views, key_indices, column_order,
-                                      null_precedence, stream);
+                                      null_precedence, se->stream);
 
             if (local_slice_start == 0 &&
                 local_slice_end == merged->num_rows()) {

--- a/bodo/libs/streaming/cuda_sort.h
+++ b/bodo/libs/streaming/cuda_sort.h
@@ -47,11 +47,11 @@ class CudaSortState {
     /**
      * @brief Get the sorted output batch.
      * @param[out] out_is_last Whether this is the last output batch.
-     * @param stream CUDA stream for execution.
+     * @param se Stream and event for execution (nullptr on non GPU ranks).
      * @return Unique pointer to the sorted cudf table.
      */
-    std::unique_ptr<cudf::table> GetOutputBatch(bool& out_is_last,
-                                                rmm::cuda_stream_view stream);
+    std::unique_ptr<cudf::table> GetOutputBatch(
+        bool& out_is_last, std::shared_ptr<StreamAndEvent> se);
 
     /**
      * @brief Get the underlying MPI communicator.

--- a/bodo/pandas/physical/gpu_sort.h
+++ b/bodo/pandas/physical/gpu_sort.h
@@ -183,7 +183,7 @@ class PhysicalGPUSortOperator : public PhysicalGPUSource,
         time_pt start_produce = start_timer();
         bool out_is_last = false;
         std::unique_ptr<cudf::table> sorted_table =
-            cuda_sort_state->GetOutputBatch(out_is_last, se->stream);
+            cuda_sort_state->GetOutputBatch(out_is_last, se);
 
         if (sorted_table == nullptr) {
             this->metrics.produce_time += end_timer(start_produce);

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -567,7 +567,9 @@ GPUtoCPUExchange::operator()(std::shared_ptr<table_info> input_batch,
                 "GPUtoCPUExchange::operator(): Received non-empty batch after "
                 "exchange was marked finished");
         }
-        return std::make_tuple(input_batch, OperatorResult::FINISHED);
+        // Return empty batch with same schema as ctb_state
+        auto [output_batch, _] = ctb_state->builder->PopChunk(true);
+        return std::make_tuple(output_batch, OperatorResult::FINISHED);
     }
 
     if (!this->shuffle_state) {
@@ -632,8 +634,9 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
                 "CPUtoGPUExchange::operator(): Received non-empty batch after "
                 "exchange was marked finished");
         }
-        return std::make_tuple(convertTableToGPU(input_batch, se),
-                               OperatorResult::FINISHED);
+        // Return empty batch same schema as gpu_batch_generator
+        auto output_batch = gpu_batch_generator->next(se, true);
+        return std::make_tuple(output_batch, OperatorResult::FINISHED);
     }
 
     if (!this->shuffle_state) {

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -567,7 +567,6 @@ GPUtoCPUExchange::operator()(std::shared_ptr<table_info> input_batch,
                 "GPUtoCPUExchange::operator(): Received non-empty batch after "
                 "exchange was marked finished");
         }
-        // Return empty batch with same schema as ctb_state
         auto [output_batch, _] = ctb_state->builder->PopChunk(true);
         return std::make_tuple(output_batch, OperatorResult::FINISHED);
     }
@@ -634,9 +633,8 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
                 "CPUtoGPUExchange::operator(): Received non-empty batch after "
                 "exchange was marked finished");
         }
-        // Return empty batch same schema as gpu_batch_generator
-        auto output_batch = gpu_batch_generator->next(se, true);
-        return std::make_tuple(output_batch, OperatorResult::FINISHED);
+        return std::make_tuple(convertTableToGPU(input_batch, se),
+                               OperatorResult::FINISHED);
     }
 
     if (!this->shuffle_state) {

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -101,6 +101,10 @@ void GPUBatchGenerator::append_batch(GPU_DATA batch) {
 
 GPU_DATA GPUBatchGenerator::next(std::shared_ptr<StreamAndEvent> se,
                                  bool force_return) {
+    if (!is_gpu_rank()) {
+        return GPU_DATA(nullptr, dummy_gpu_data->schema, nullptr);
+    }
+
     if (collected_rows < out_batch_size && !force_return) {
         dummy_gpu_data->stream_event->event.wait(se->stream);
         return GPU_DATA(make_empty_like(dummy_gpu_data->table, se),

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1680,7 +1680,7 @@ def test_groupby_fallback():
     pandas_out = df.groupby("A", dropna=False, as_index=False, sort=True)["B"].sum(
         engine="cython"
     )
-    _test_equal(pandas_out, fallback_out)
+    _test_equal(fallback_out, pandas_out)
 
     bdf2 = bd.from_pandas(df)
 
@@ -1693,7 +1693,7 @@ def test_groupby_fallback():
     pandas_out = df.groupby("A", dropna=False, as_index=False, sort=True).sum(
         engine="cython"
     )
-    _test_equal(pandas_out, fallback_out)
+    _test_equal(fallback_out, pandas_out)
 
 
 @pytest.fixture(scope="module")
@@ -3226,7 +3226,7 @@ def test_drop_duplicates_subset(kwargs):
     )
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_uncompilable_map():
     """Test for maps that can't be compiled."""
@@ -3559,7 +3559,7 @@ def test_dataframe_reset_index_pipeline():
     )
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 def test_map_with_state():
     def init_state():
         return {1: 7}
@@ -3595,7 +3595,7 @@ def test_map_with_state():
     )
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 def test_map_partitions_with_state():
     class mystate:
         def __init__(self):
@@ -3692,7 +3692,7 @@ def test_series_quantile(quantiles):
             )
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, aggregate
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, aggregate
 @pytest.mark.parametrize("q", [0.25, 0.5, 0.75, 0.9])
 def test_series_quantile_scalar(q):
     """Tests that approximate quantiles with scalar arguments fall within expected error bounds."""

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -694,7 +694,7 @@ def test_projection_head_pushdown(datapath):
     assert len(bodo_df3) == 3
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
 def test_series_head(datapath):
     """Test for Series.head() reading from Pandas."""
     # Make sure bodo_df3 is unevaluated in the process.
@@ -708,7 +708,7 @@ def test_series_head(datapath):
     assert len(bodo_df3) == 3
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
 def test_head(datapath):
     """Test for head pushed down to read parquet."""
 
@@ -774,7 +774,7 @@ def test_apply_str(datapath, index_val):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_apply_non_jit(datapath, index_val):
     """Test unsupported UDFs fallback to Pandas execution."""
@@ -851,7 +851,7 @@ def test_series_map(datapath, index_val, na_action):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, UDF
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, UDF
 @pytest.mark.jit_dependency
 def test_series_map_non_jit(index_val):
     """Test non-jittable UDFs in ser.map still work."""
@@ -2089,7 +2089,7 @@ def test_scalar_arith_binops(datapath, index_val):
     )
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_map_partitions_df():
     """Simple tests for map_partition on lazy DataFrame."""
@@ -2125,7 +2125,7 @@ def test_map_partitions_df():
     _test_equal(bodo_df2, py_out, check_pandas_types=False)
 
 
-@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_map_partitions_series():
     """Simple tests for map_partition on lazy Series."""

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -694,7 +694,7 @@ def test_projection_head_pushdown(datapath):
     assert len(bodo_df3) == 3
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
 def test_series_head(datapath):
     """Test for Series.head() reading from Pandas."""
     # Make sure bodo_df3 is unevaluated in the process.
@@ -708,7 +708,7 @@ def test_series_head(datapath):
     assert len(bodo_df3) == 3
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, count-star
 def test_head(datapath):
     """Test for head pushed down to read parquet."""
 
@@ -774,7 +774,7 @@ def test_apply_str(datapath, index_val):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_apply_non_jit(datapath, index_val):
     """Test unsupported UDFs fallback to Pandas execution."""
@@ -851,7 +851,7 @@ def test_series_map(datapath, index_val, na_action):
     _test_equal(out_bodo, out_pd, check_pandas_types=False)
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, UDF
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, UDF
 @pytest.mark.jit_dependency
 def test_series_map_non_jit(index_val):
     """Test non-jittable UDFs in ser.map still work."""
@@ -2089,7 +2089,7 @@ def test_scalar_arith_binops(datapath, index_val):
     )
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_map_partitions_df():
     """Simple tests for map_partition on lazy DataFrame."""
@@ -2125,7 +2125,7 @@ def test_map_partitions_df():
     _test_equal(bodo_df2, py_out, check_pandas_types=False)
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_map_partitions_series():
     """Simple tests for map_partition on lazy Series."""
@@ -3226,7 +3226,7 @@ def test_drop_duplicates_subset(kwargs):
     )
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 @pytest.mark.jit_dependency
 def test_uncompilable_map():
     """Test for maps that can't be compiled."""
@@ -3559,7 +3559,7 @@ def test_dataframe_reset_index_pipeline():
     )
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 def test_map_with_state():
     def init_state():
         return {1: 7}
@@ -3595,7 +3595,7 @@ def test_map_with_state():
     )
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas
 def test_map_partitions_with_state():
     class mystate:
         def __init__(self):
@@ -3692,7 +3692,7 @@ def test_series_quantile(quantiles):
             )
 
 
-# @pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, aggregate
+@pytest.mark.gpu(allow_fallback=True)  # fallback read Pandas, aggregate
 @pytest.mark.parametrize("q", [0.25, 0.5, 0.75, 0.9])
 def test_series_quantile_scalar(q):
     """Tests that approximate quantiles with scalar arguments fall within expected error bounds."""

--- a/bodo/tests/test_df_lib/test_gpu/test_gpu_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_gpu/test_gpu_end_to_end.py
@@ -122,11 +122,10 @@ def test_cpu_to_gpu_exchange(datapath):
     assert count_gpu_plan_nodes(bdf3._plan) == 4, (
         "Expected 4 GPU nodes (ReadParquet, JoinFilter, Join, Project)"
     )
-    bdf3 = bdf3.sort_values(bdf3.columns.to_list())
 
     pdf2 = pd.read_parquet(path)
     pdf3 = pdf1.merge(pdf2, how="inner", on="A")
-    _test_equal(pdf3, bdf3)
+    _test_equal(bdf3, pdf3)
 
     # Case 2: CPU (read pandas) -> GPU sink (write parquet)
     with tempfile.TemporaryDirectory() as tmp:
@@ -137,7 +136,7 @@ def test_cpu_to_gpu_exchange(datapath):
 
         out_df = pd.read_parquet(out_path)
         # [BSE-5322] Sorting data because CPU -> GPU affects the order.
-        _test_equal(pdf, out_df, sort_output=True, reset_index=True)
+        _test_equal(out_df, pdf, sort_output=True, reset_index=True)
 
         # Check the write parquet is happening on GPU:
         write_plan = LogicalParquetWrite(
@@ -165,7 +164,7 @@ def test_gpu_to_cpu_exchange(datapath):
 
     pdf = pd.read_parquet(path)
     pdf["F"] = pdf["F"].map(lambda x: str(x))
-    _test_equal(pdf, bdf)
+    _test_equal(bdf, pdf)
 
     # Case 2: GPU (join) -> CPU sink (result collector)
     bdf = bd.read_parquet(path)
@@ -174,7 +173,7 @@ def test_gpu_to_cpu_exchange(datapath):
     bdf.execute_plan()
 
     pdf = pd.read_parquet(path)
-    _test_equal(pdf, bdf)
+    _test_equal(bdf, pdf)
 
 
 @pytest.mark.parametrize("broadcast", [True, False])

--- a/bodo/tests/test_df_lib/test_gpu/test_gpu_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_gpu/test_gpu_end_to_end.py
@@ -122,6 +122,7 @@ def test_cpu_to_gpu_exchange(datapath):
     assert count_gpu_plan_nodes(bdf3._plan) == 4, (
         "Expected 4 GPU nodes (ReadParquet, JoinFilter, Join, Project)"
     )
+    bdf3 = bdf3.sort_values(bdf3.columns.to_list())
 
     pdf2 = pd.read_parquet(path)
     pdf3 = pdf1.merge(pdf2, how="inner", on="A")

--- a/bodo/tests/test_streaming/test_cuda_sort.cpp
+++ b/bodo/tests/test_streaming/test_cuda_sort.cpp
@@ -131,8 +131,7 @@ void run_cuda_sort_test(
     sort_state.FinalizeSort();
 
     bool out_is_last = false;
-    auto output =
-        sort_state.GetOutputBatch(out_is_last, cudf::get_default_stream());
+    auto output = sort_state.GetOutputBatch(out_is_last, se);
 
     bodo::tests::check(out_is_last == true);
 

--- a/bodo/tests/utils.py
+++ b/bodo/tests/utils.py
@@ -38,7 +38,7 @@ from numba.core.ir_utils import build_definitions, find_callname, guard  # noqa 
 import bodo
 import bodo.pandas as bodo_pd
 from bodo import BodoWarning
-from bodo.spawn.spawner import SpawnDispatcher
+from bodo.spawn.spawner import SpawnDispatcher, get_num_workers
 from bodo.utils.arrow_conversion import convert_arrow_arr_to_dict
 
 test_spawn_mode_enabled = os.environ.get("BODO_CHECK_FUNC_SPAWN_MODE", "0") != "0"
@@ -1329,6 +1329,17 @@ def _test_equal(
         from scipy.sparse import csr_matrix
     except ImportError:
         csr_matrix = type(None)
+
+    if bodo.gpu_enabled:
+        import cupy as cp
+
+        num_devices = cp.cuda.runtime.getDeviceCount()
+        num_workers = get_num_workers()
+        # Automatically sort output if we have multiple workers per GPU
+        # TODO(BSE-5322): remove after CPU-GPU exchange doesn't change the order of data.
+        if num_workers > num_devices:
+            sort_output = True
+            reset_index = True
 
     # Bodo converts lists to array in array(item) array cases
     if isinstance(py_out, list) and isinstance(bodo_out, np.ndarray):


### PR DESCRIPTION
## Changes included in this PR

Fix segfaults due to non-GPU workers returning nullptr for data/streams to avoid creating contexts
Enable some GPU tests for multiple workers-per GPU case. More tests will be enabled in a followup PR

## Testing strategy

PR CI

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.