### PR TITLE
Increase timeout for optimized_numeric_window_functions

### DIFF
--- a/BodoSQL/bodosql/tests/test_window/test_generic_window_fns.py
+++ b/BodoSQL/bodosql/tests/test_window/test_generic_window_fns.py
@@ -321,6 +321,7 @@ def test_blended_fusion(memory_leak_check):
         pytest.param("VAR_POP"),
     ],
 )
+@pytest.mark.timeout(1300)
 def test_optimized_numeric_window_functions(func, all_numeric_window_df, spark_info):
     """Tests numeric window functions that can use groupby.window"""
     selects = []


### PR DESCRIPTION
## Changes included in this PR
As title, these tests timeout after numba upgrade, give them a little more time
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.