### PR TITLE
Refactor function expression creation in plans

### DIFF
--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1115,9 +1115,9 @@ static void RunFunction(duckdb::DataChunk &args, duckdb::ExpressionState &state,
 }
 
 duckdb::unique_ptr<duckdb::Expression> make_scalar_func_expr(
-    std::unique_ptr<duckdb::LogicalOperator> &source, PyObject *out_schema_py,
-    PyObject *args, const std::vector<int> &selected_columns, bool is_cfunc,
-    bool has_state, const std::string arrow_compute_func) {
+    PyObject *out_schema_py,
+    std::vector<std::unique_ptr<duckdb::Expression>> &in_exprs, PyObject *args,
+    bool is_cfunc, bool has_state, const std::string arrow_compute_func) {
     // Get output data type (UDF output is a single column)
     std::shared_ptr<arrow::Schema> out_schema = unwrap_schema(out_schema_py);
     auto [_, out_types] = arrow_schema_to_duckdb(out_schema);
@@ -1125,15 +1125,17 @@ duckdb::unique_ptr<duckdb::Expression> make_scalar_func_expr(
     assert(out_types.size() > 0);
     duckdb::LogicalType out_type = out_types[0];
 
-    // Necessary before accessing source->types attribute
-    source->ResolveOperatorTypes();
-
     auto scalar_name =
         (arrow_compute_func == "") ? "bodo_udf" : arrow_compute_func;
 
+    duckdb::vector<duckdb::LogicalType> input_types;
+    for (auto &expr : in_exprs) {
+        input_types.push_back(expr->return_type);
+    }
+
     // Create ScalarFunction for Python UDF or Arrow Compute Function
     duckdb::ScalarFunction scalar_function = duckdb::ScalarFunction(
-        scalar_name, source->types, out_type, RunFunction, nullptr, nullptr,
+        scalar_name, input_types, out_type, RunFunction, nullptr, nullptr,
         nullptr, nullptr, duckdb::LogicalTypeId::INVALID,
         duckdb::FunctionStability::CONSISTENT,
         duckdb::FunctionNullHandling::DEFAULT_NULL_HANDLING);
@@ -1142,15 +1144,12 @@ duckdb::unique_ptr<duckdb::Expression> make_scalar_func_expr(
         duckdb::make_uniq<BodoScalarFunctionData>(
             args, out_schema, is_cfunc, has_state, arrow_compute_func);
 
-    std::vector<duckdb::ColumnBinding> source_cols =
-        source->GetColumnBindings();
-
-    // Add UDF input expressions for selected columns
+    // Add UDF input expressions columns
     std::vector<duckdb::unique_ptr<duckdb::Expression>> udf_in_exprs;
-    for (int col_idx : selected_columns) {
-        auto expr = duckdb::make_uniq<duckdb::BoundColumnRefExpression>(
-            source->types[col_idx], source_cols[col_idx]);
-        udf_in_exprs.emplace_back(std::move(expr));
+    for (auto &expr : in_exprs) {
+        // Convert std::unique_ptr to duckdb::unique_ptr.
+        auto expr_duck = to_duckdb(expr);
+        udf_in_exprs.push_back(std::move(expr_duck));
     }
 
     // Create UDF expression

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -261,11 +261,9 @@ std::vector<int> get_projection_pushed_down_columns(
 /**
  * @brief Creates an Expression node with a UDF inside.
  *
- * @param source input table plan
  * @param out_schema_py output data type (single column for df.apply)
+ * @param in_exprs input expressions for the function
  * @param args arguments to the UDF
- * @param selected_columns column indices for input table columns to pass to the
- * UDF
  * @param is_cfunc Whether to compile and run func as a cfunc
  * @param has_state Whether the UDF requires separate initialization state
  * @param func_name Name of Arrow Compute function, empty string for Python
@@ -273,9 +271,9 @@ std::vector<int> get_projection_pushed_down_columns(
  * @return duckdb::unique_ptr<duckdb::Expression> Expression node for UDF
  */
 duckdb::unique_ptr<duckdb::Expression> make_scalar_func_expr(
-    std::unique_ptr<duckdb::LogicalOperator> &source, PyObject *out_schema_py,
-    PyObject *args, const std::vector<int> &selected_columns, bool is_cfunc,
-    bool has_state, const std::string arrow_compute_func);
+    PyObject *out_schema_py,
+    std::vector<std::unique_ptr<duckdb::Expression>> &in_exprs, PyObject *args,
+    bool is_cfunc, bool has_state, const std::string arrow_compute_func);
 
 /**
  * @brief Create an expression for a NULL value of given type.

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -77,11 +77,11 @@ class LazyPlan:
             col_index = args[1]
             return f"ColRefExpression({col_index})"
         elif isinstance(self, PythonScalarFuncExpression):
-            func_name, col_indices = args[1][0], args[2]
-            return f"PythonScalarFuncExpression({func_name}, {col_indices})"
+            func_name = args[1][0]
+            return f"PythonScalarFuncExpression({func_name})"
         elif isinstance(self, ArrowScalarFuncExpression):
-            func_name, col_indices = args[2], args[1]
-            return f"ArrowScalarFuncExpression({func_name}, {col_indices})"
+            func_name = args[1]
+            return f"ArrowScalarFuncExpression({func_name})"
 
         out = f"{self.plan_class}: \n"
         args_str = ""
@@ -679,8 +679,8 @@ class PythonScalarFuncExpression(Expression):
     """Expression representing a Python scalar function call in the query plan."""
 
     @property
-    def source(self):
-        """Return the source of the expression."""
+    def input_exprs(self):
+        """Return the input expressions of the function."""
         return self.args[0]
 
     @property
@@ -689,24 +689,19 @@ class PythonScalarFuncExpression(Expression):
         return self.args[1]
 
     @property
-    def input_column_indices(self):
-        """Return the columns relevant to the expression."""
-        return self.args[2]
-
-    @property
     def is_cfunc(self):
         """Returns whether the scalar function is a cfunc."""
-        return self.args[3]
+        return self.args[2]
 
     @property
     def has_state(self):
         """Returns whether the scalar function has separate init state."""
-        return self.args[4]
+        return self.args[3]
 
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
         """Update the source and column index of the function expression."""
         if self.source != new_source_plan:
-            assert len(self.input_column_indices) == 1 + get_n_index_arrays(
+            assert len(self.input_exprs) == 1 + get_n_index_arrays(
                 self.empty_data.index
             ), (
                 "PythonScalarFuncExpression::update_func_expr_source: expected single input column"
@@ -749,29 +744,24 @@ class ArrowScalarFuncExpression(Expression):
     """Expression representing a Python scalar function call in the query plan."""
 
     @property
-    def source(self):
-        """Return the source of the expression."""
+    def input_exprs(self):
+        """Return the input expressions of the function."""
         return self.args[0]
-
-    @property
-    def input_column_indices(self):
-        """Return the columns relevant to the expression."""
-        return self.args[1]
 
     @property
     def function_name(self):
         """Return the function name."""
-        return self.args[2]
+        return self.args[1]
 
     @property
     def function_args(self):
         """Return the function args."""
-        return self.args[3]
+        return self.args[2]
 
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
         """Update the source and column index of the function expression."""
         if self.source != new_source_plan:
-            assert len(self.input_column_indices) == 1 + get_n_index_arrays(
+            assert len(self.input_exprs) == 1 + get_n_index_arrays(
                 self.empty_data.index
             ), (
                 "ArrowScalarFuncExpression::update_func_expr_source: expected single input column"
@@ -1322,9 +1312,10 @@ def _get_df_python_func_plan(
 
     udf_arg = PythonScalarFuncExpression(
         empty_data,
-        df_plan,
+        make_col_ref_exprs(
+            range(df_len + get_n_index_arrays(df_plan.empty_data.index)), df_plan
+        ),
         func_args,
-        tuple(range(df_len + get_n_index_arrays(df_plan.empty_data.index))),
         cfunc_decorator is not None,  # is_cfunc
         False,  # has_state
     )

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -698,6 +698,19 @@ class PythonScalarFuncExpression(Expression):
         """Returns whether the scalar function has separate init state."""
         return self.args[3]
 
+    @property
+    def source(self):
+        """Return the source of the function expression assuming all input expressions share the same source."""
+        assert len(self.input_exprs) != 0, (
+            "PythonScalarFuncExpression::source: expected at least one input expression"
+        )
+
+        source = self.input_exprs[0].source
+        for expr in self.input_exprs[1:]:
+            if expr.source != source:
+                return None
+        return source
+
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
         """Update the source and column index of the function expression."""
         if self.source != new_source_plan:
@@ -757,6 +770,19 @@ class ArrowScalarFuncExpression(Expression):
     def function_args(self):
         """Return the function args."""
         return self.args[2]
+
+    @property
+    def source(self):
+        """Return the source of the function expression assuming all input expressions share the same source."""
+        assert len(self.input_exprs) != 0, (
+            "ArrowScalarFuncExpression::source: expected at least one input expression"
+        )
+
+        source = self.input_exprs[0].source
+        for expr in self.input_exprs[1:]:
+            if expr.source != source:
+                return None
+        return source
 
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
         """Update the source and column index of the function expression."""

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -719,8 +719,11 @@ class PythonScalarFuncExpression(Expression):
             ), (
                 "PythonScalarFuncExpression::update_func_expr_source: expected single input column"
             )
+            assert is_col_ref(self.input_exprs[0]), (
+                "PythonScalarFuncExpression::update_func_expr_source: expected input expression to be a column reference"
+            )
             # Previous input data column index
-            in_col_ind = self.input_column_indices[0]
+            in_col_ind = self.input_exprs[0].col_index
             n_source_cols = len(new_source_plan.empty_data.columns)
             # Add Index columns of the new source plan as input
             index_cols = tuple(
@@ -732,9 +735,10 @@ class PythonScalarFuncExpression(Expression):
             )
             expr = PythonScalarFuncExpression(
                 self.empty_data,
-                new_source_plan,
+                make_col_ref_exprs(
+                    (in_col_ind + col_index_offset,) + index_cols, new_source_plan
+                ),
                 self.func_args,
-                (in_col_ind + col_index_offset,) + index_cols,
                 self.is_cfunc,
                 self.has_state,
             )
@@ -792,8 +796,11 @@ class ArrowScalarFuncExpression(Expression):
             ), (
                 "ArrowScalarFuncExpression::update_func_expr_source: expected single input column"
             )
+            assert is_col_ref(self.input_exprs[0]), (
+                "ArrowScalarFuncExpression::update_func_expr_source: expected input expression to be a column reference"
+            )
             # Previous input data column index
-            in_col_ind = self.input_column_indices[0]
+            in_col_ind = self.input_exprs[0].col_index
             n_source_cols = len(new_source_plan.empty_data.columns)
             # Add Index columns of the new source plan as input
             index_cols = tuple(
@@ -805,8 +812,9 @@ class ArrowScalarFuncExpression(Expression):
             )
             expr = ArrowScalarFuncExpression(
                 self.empty_data,
-                new_source_plan,
-                (in_col_ind + col_index_offset,) + index_cols,
+                make_col_ref_exprs(
+                    (in_col_ind + col_index_offset,) + index_cols, new_source_plan
+                ),
                 self.function_name,
                 self.function_args,
             )

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -708,7 +708,9 @@ class PythonScalarFuncExpression(Expression):
         source = self.input_exprs[0].source
         for expr in self.input_exprs[1:]:
             if expr.source != source:
-                return None
+                raise ValueError(
+                    "PythonScalarFuncExpression::source: input expressions have different sources"
+                )
         return source
 
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):
@@ -790,7 +792,9 @@ class ArrowScalarFuncExpression(Expression):
         source = self.input_exprs[0].source
         for expr in self.input_exprs[1:]:
             if expr.source != source:
-                return None
+                raise ValueError(
+                    "ArrowScalarFuncExpression::source: input expressions have different sources"
+                )
         return source
 
     def update_func_expr_source(self, new_source_plan: LazyPlan, col_index_offset: int):

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -752,7 +752,12 @@ class PythonScalarFuncExpression(Expression):
             return self
 
     def with_new_source(self, new_source):
-        out = PythonScalarFuncExpression(self.empty_data, new_source, *self.args[1:])
+        new_input_exprs = [
+            expr.with_new_source(new_source) for expr in self.input_exprs
+        ]
+        out = PythonScalarFuncExpression(
+            self.empty_data, new_input_exprs, *self.args[1:]
+        )
         out.is_series = self.is_series
         return out
 
@@ -828,7 +833,12 @@ class ArrowScalarFuncExpression(Expression):
             return self
 
     def with_new_source(self, new_source):
-        out = ArrowScalarFuncExpression(self.empty_data, new_source, *self.args[1:])
+        new_input_exprs = [
+            expr.with_new_source(new_source) for expr in self.input_exprs
+        ]
+        out = ArrowScalarFuncExpression(
+            self.empty_data, new_input_exprs, *self.args[1:]
+        )
         out.is_series = self.is_series
         return out
 

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -334,7 +334,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CLogicalDistinct] make_distinct(unique_ptr[CLogicalOperator] source, vector[unique_ptr[CExpression]] expr_vec, object out_schema) except +
     cdef unique_ptr[CLogicalOrder] make_order(unique_ptr[CLogicalOperator] source, vector[c_bool] asc, vector[c_bool] na_position, vector[int] cols, object in_schema) except +
     cdef unique_ptr[CLogicalAggregate] make_aggregate(unique_ptr[CLogicalOperator] source, vector[int] key_indices, vector[unique_ptr[CExpression]] expr_vec, object out_schema) except +
-    cdef unique_ptr[CExpression] make_scalar_func_expr(unique_ptr[CLogicalOperator] source, object out_schema, object args, vector[int] input_column_indices, c_bool is_cfunc, c_bool has_state, c_string arrow_compute_func) except +
+    cdef unique_ptr[CExpression] make_scalar_func_expr(object out_schema, vector[unique_ptr[CExpression]] in_exprs, object args, c_bool is_cfunc, c_bool has_state, c_string arrow_compute_func) except +
     cdef unique_ptr[CExpression] make_comparison_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_arithop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, c_string opstr, object out_schema) except +
     cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr) except +
@@ -664,22 +664,26 @@ cdef class AggregateExpression(Expression):
     def __str__(self):
         return f"AggregateExpression({self.function_name})"
 
+
 cdef class PythonScalarFuncExpression(Expression):
     """Wrapper around DuckDB's BoundFunctionExpression for running Python/Arrow functions.
     """
 
     def __cinit__(self,
         object out_schema,
-        LogicalOperator source,
+        list in_exprs,
         object args,
-        vector[int] input_column_indices,
         c_bool is_cfunc,
         c_bool has_state):
+        cdef vector[unique_ptr[CExpression]] in_c_exprs
+
+        for in_expr in in_exprs:
+            in_c_exprs.push_back(move((<Expression>in_expr).c_expression))
 
         self.out_schema = out_schema
         empty_str = ""
         self.c_expression = make_scalar_func_expr(
-            source.c_logical_operator, out_schema, args, input_column_indices, is_cfunc, has_state, empty_str.encode())
+            out_schema, in_c_exprs, args, is_cfunc, has_state, empty_str.encode())
 
     def __str__(self):
         return f"PythonScalarFuncExpression()"
@@ -691,14 +695,17 @@ cdef class ArrowScalarFuncExpression(Expression):
 
     def __cinit__(self,
         object out_schema,
-        LogicalOperator source,
-        vector[int] input_column_indices,
+        list in_exprs,
         str function_name,
         object args):
+        cdef vector[unique_ptr[CExpression]] in_c_exprs
+
+        for in_expr in in_exprs:
+            in_c_exprs.push_back(move((<Expression>in_expr).c_expression))
 
         self.out_schema = out_schema
         self.c_expression = make_scalar_func_expr(
-            source.c_logical_operator, out_schema, args, input_column_indices, False, False, function_name.encode())
+            out_schema, in_c_exprs, args, False, False, function_name.encode())
 
     def __str__(self):
         return f"ArrowScalarFuncExpression({self.function_name})"

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -3032,7 +3032,7 @@ def _get_series_func_plan(
         input_exprs = [series_proj.args[1][0]]
     else:
         source_data = series_proj
-        input_exprs = [make_col_ref_exprs(0, series_proj)]
+        input_exprs = make_col_ref_exprs([0], series_proj)
 
     n_cols = len(source_data.empty_data.columns)
     index_cols = range(

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -2874,8 +2874,11 @@ def make_expr(expr, plan, first, schema, index_cols, side="right"):
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
         return ColRefExpression(empty_data, plan, idx)
     elif is_python_scalar_func(expr):
-        idx = expr.input_column_indices[0]
-        idx = get_new_idx(idx, first, side)
+        first_input = expr.input_exprs[0]
+        assert is_col_ref(first_input), (
+            "make_expr: expected first input of PythonScalarFuncExpression to be a column reference."
+        )
+        idx = get_new_idx(first_input.col_index, first, side)
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
         return PythonScalarFuncExpression(
             empty_data,
@@ -2885,8 +2888,11 @@ def make_expr(expr, plan, first, schema, index_cols, side="right"):
             False,
         )
     elif is_arrow_scalar_func(expr):
-        idx = expr.input_column_indices[0]
-        idx = get_new_idx(idx, first, side)
+        first_input = expr.input_exprs[0]
+        assert is_col_ref(first_input), (
+            "make_expr: expected first input of ArrowScalarFuncExpression to be a column reference."
+        )
+        idx = get_new_idx(first_input.col_index, first, side)
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
         return ArrowScalarFuncExpression(
             empty_data,

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -2879,9 +2879,8 @@ def make_expr(expr, plan, first, schema, index_cols, side="right"):
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
         return PythonScalarFuncExpression(
             empty_data,
-            plan,
+            make_col_ref_exprs((idx,) + tuple(index_cols), plan),
             expr.func_args,
-            (idx,) + tuple(index_cols),
             expr.is_cfunc,
             False,
         )
@@ -2890,7 +2889,10 @@ def make_expr(expr, plan, first, schema, index_cols, side="right"):
         idx = get_new_idx(idx, first, side)
         empty_data = arrow_to_empty_df(pa.schema([expr.pa_schema[0]]))
         return ArrowScalarFuncExpression(
-            empty_data, plan, (idx,) + tuple(index_cols), expr.function_name, ()
+            empty_data,
+            make_col_ref_exprs((idx,) + tuple(index_cols), plan),
+            expr.function_name,
+            (),
         )
     elif is_arith_expr(expr):
         # TODO: recursively traverse arithmetic expr tree to update col idx.
@@ -2996,7 +2998,7 @@ def get_col_as_series_expr(idx, empty_data, series_out, index_cols):
     """
     return PythonScalarFuncExpression(
         empty_data,
-        series_out._plan,
+        make_col_ref_exprs((0,) + index_cols, series_out._plan),
         (
             "bodo.pandas.series._get_col_as_series",
             True,  # is_series
@@ -3005,7 +3007,6 @@ def get_col_as_series_expr(idx, empty_data, series_out, index_cols):
             {},  # kwargs
             True,  # use_arrow_dtypes
         ),
-        (0,) + index_cols,
         False,  # is_cfunc
         False,  # has_state
     )
@@ -3028,16 +3029,16 @@ def _get_series_func_plan(
     # Optimize out trivial df["col"] projections to simplify plans
     if is_single_colref_projection(series_proj):
         source_data = series_proj.args[0]
-        input_expr = series_proj.args[1][0]
-        col_index = input_expr.args[1]
+        input_exprs = [series_proj.args[1][0]]
     else:
         source_data = series_proj
-        col_index = 0
+        input_exprs = [make_col_ref_exprs(0, series_proj)]
 
     n_cols = len(source_data.empty_data.columns)
     index_cols = range(
         n_cols, n_cols + get_n_index_arrays(source_data.empty_data.index)
     )
+    input_exprs += make_col_ref_exprs(index_cols, source_data)
 
     # List of Series methods to be routed to Arrow Compute
     arrow_compute_list = (
@@ -3127,8 +3128,7 @@ def _get_series_func_plan(
         has_state = False
         expr = ArrowScalarFuncExpression(
             empty_data,
-            source_data,
-            (col_index,) + tuple(index_cols),
+            input_exprs,
             func_name,
             func_args,
         )
@@ -3151,9 +3151,8 @@ def _get_series_func_plan(
 
         expr = PythonScalarFuncExpression(
             empty_data,
-            source_data,
+            input_exprs,
             func_args,
-            (col_index,) + tuple(index_cols),
             is_cfunc,
             has_state,
         )


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Refactors function expressions in the Python plan to take input expressions instead of a source plan and column indices. This provides a lot more flexibility which is necessary for translating Java plans to Python.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Existing tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.