### PR TITLE
Support aggregation function lists in agg function dict [GPU]

### DIFF
--- a/bodo/pandas/groupby.py
+++ b/bodo/pandas/groupby.py
@@ -181,9 +181,14 @@ class DataFrameGroupBy:
             ]
         elif is_dict_like(func):
             # Handle cases like {"A": "sum"} -> creates sum column over column A
-            normalized_func = [
-                GroupbyAggFunc(col, func_) for col, func_ in func.items()
-            ]
+            for col, func_ in func.items():
+                # Handle cases like {"A": ["sum", "count"]} -> creates sum
+                # and count column for the input column A
+                if is_list_like(func_):
+                    for lagg in func_:
+                        normalized_func.append(GroupbyAggFunc(col, lagg))
+                else:
+                    normalized_func.append(GroupbyAggFunc(col, func_))
         elif is_list_like(func):
             # Handle cases like ["sum", "count"] -> creates a sum and count column
             # for each input column (column names are a multi-index) i.e.:

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1719,6 +1719,9 @@ def groupby_agg_df(request):
         pytest.param(["sum", "count"], {}, id="func_list"),
         pytest.param("sum", {}, id="func_str"),
         pytest.param(
+            {"A": ["mean", "count"], "D": ["count", "sum"]}, {}, id="func_dict"
+        ),
+        pytest.param(
             None,
             {
                 "mean_A": pd.NamedAgg("A", "mean"),

--- a/docs/docs/api_docs/dataframe_lib/groupby/frame_agg.md
+++ b/docs/docs/api_docs/dataframe_lib/groupby/frame_agg.md
@@ -16,6 +16,7 @@ Apply one or more aggregate functions to groups of data in a BodoDataFrame. This
     * The name of a supported aggregation function e.g. `"sum"`
     * A list of functions, which will be applied to each selected column e.g. `["sum"`, `"count"]`
     * A dictionary mapping column name to aggregate function e.g. `{"col_1": "sum", "col_2": "mean"}`
+    * A dictionary mapping column name to list of aggregate functions e.g. `{"col_1": ["sum", "count"], "col_2": ["count", "mean"]}`
     * None along with key word arguments specifying Named Aggregates.
 
     [Refer to our documentation][df-lib-groupby] for aggregate functions that are currently supported in addition to most user defined functions.


### PR DESCRIPTION
## Changes included in this PR
We now handle the case where there are multiple aggregations for a column, specified using the dictionary syntax where the value is the list of aggregation functions for that column. A test case was added to spot when this functionality does not work.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy

## User facing changes
A new aggregation function combination is supported.

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.