### PR TITLE
Support test_arith.py in BodoSQL C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -16,6 +16,7 @@ from bodo.pandas.plan import (
     ArithOpExpression,
     ArrowScalarFuncExpression,
     CaseExpression,
+    CastExpression,
     ComparisonOpExpression,
     ConjunctionOpExpression,
     ConstantExpression,
@@ -196,6 +197,14 @@ def java_call_to_python_call(java_call, input_plan):
         ) and target_type.getSqlTypeName().equals(SqlTypeName.TIMESTAMP):
             # Cast of DATE to TIMESTAMP is unnecessary in C++ backend
             return java_expr_to_python_expr(operand, input_plan)
+
+        empty_data = pd.Series(
+            dtype=pd.ArrowDtype(sql_type_to_pa_type(operand_type.getSqlTypeName()))
+        )
+        return CastExpression(
+            empty_data,
+            java_expr_to_python_expr(operand, input_plan),
+        )
 
     if (
         operator_class_name == "SqlPostfixOperator"

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -243,6 +243,10 @@ def java_call_to_python_call(java_call, input_plan):
         kind = op.getKind()
         SqlKind = gateway.jvm.org.apache.calcite.sql.SqlKind
 
+        if kind.equals(SqlKind.MINUS_PREFIX):
+            out_empty = -input.empty_data.iloc[:, 0]
+            return UnaryOpExpression(out_empty, input, "__neg__")
+
         if kind.equals(SqlKind.NOT):
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return UnaryOpExpression(bool_empty_data, input, "__invert__")

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -655,9 +655,6 @@ def java_agg_to_python_agg(ctx, java_plan):
 
     keys = list(java_plan.getGroupSet().toList())
 
-    if len(keys) == 0:
-        raise NotImplementedError("Aggregations without group by not supported yet")
-
     input_plan = java_plan_to_python_plan(ctx, java_plan.getInput())
 
     exprs = []

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -158,6 +158,7 @@ def test_nested_arithmetic_select(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_multicolumn_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(
@@ -179,6 +180,7 @@ def test_multicolumn_arithmetic_select(bodosql_numeric_types, memory_leak_check)
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_select_col_arith(bodosql_numeric_types, memory_leak_check):
     """test selecting a single column and performing arithmetic
     on that columns

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -446,6 +446,7 @@ def test_add_sub_intervals(bodosql_datetime_types, memory_leak_check, interval):
         ),
     ],
 )
+@pytest.mark.bodosql_cpp
 def test_negation(query, bodosql_numeric_types, memory_leak_check):
     """Tests unary negation"""
 

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -204,6 +204,7 @@ def test_addition_constants(basic_df, memory_leak_check):
     check_query(query, basic_df, None, check_dtype=False, use_duckdb=True)
 
 
+@pytest.mark.bodosql_cpp
 def test_addition_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that addition works on columns
@@ -219,6 +220,7 @@ def test_addition_columns(bodosql_numeric_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_subtraction_constants(basic_df, memory_leak_check):
     """
     Tests that subtraction works on constants
@@ -227,6 +229,7 @@ def test_subtraction_constants(basic_df, memory_leak_check):
     check_query(query, basic_df, None, check_dtype=False, use_duckdb=True)
 
 
+@pytest.mark.bodosql_cpp
 def test_subtraction_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that subtraction works on columns
@@ -242,6 +245,7 @@ def test_subtraction_columns(bodosql_numeric_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_multiplication_constants(basic_df, memory_leak_check):
     """
     Tests that multiplication works on constants
@@ -252,6 +256,7 @@ def test_multiplication_constants(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_multiply_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that multiplication works on columns

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -128,30 +128,32 @@ def test_nested_arithmetic_select(bodosql_numeric_types, memory_leak_check):
         check_names=False,
         use_duckdb=True,
     )
-    check_query(
-        "select A - 1 - 1 from table1",
-        bodosql_numeric_types,
-        None,
-        check_dtype=False,
-        check_names=False,
-        use_duckdb=True,
-    )
-    check_query(
-        "select 1 - A - 1 from table1",
-        bodosql_numeric_types,
-        None,
-        check_dtype=False,
-        check_names=False,
-        use_duckdb=True,
-    )
-    check_query(
-        "select 1 - 1 - A from table1",
-        bodosql_numeric_types,
-        None,
-        check_dtype=False,
-        check_names=False,
-        use_duckdb=True,
-    )
+    # Avoid overflow errors for unsigned integer
+    if bodosql_numeric_types["TABLE1"].A.dtype.kind != "u":
+        check_query(
+            "select A - 1 - 1 from table1",
+            bodosql_numeric_types,
+            None,
+            check_dtype=False,
+            check_names=False,
+            use_duckdb=True,
+        )
+        check_query(
+            "select 1 - A - 1 from table1",
+            bodosql_numeric_types,
+            None,
+            check_dtype=False,
+            check_names=False,
+            use_duckdb=True,
+        )
+        check_query(
+            "select 1 - 1 - A from table1",
+            bodosql_numeric_types,
+            None,
+            check_dtype=False,
+            check_names=False,
+            use_duckdb=True,
+        )
 
 
 @pytest.mark.slow

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -87,6 +87,7 @@ def test_column_arithmetic_select(bodosql_numeric_types, memory_leak_check):
         )
 
 
+@pytest.mark.bodosql_cpp
 def test_sum_arith_select(bodosql_numeric_types, memory_leak_check):
     """test sum on a call with an arithmetic expression"""
     check_query(

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -16,272 +16,326 @@ pytestmark = pytest_slow_unless_codegen
 
 
 @pytest.mark.slow
-def test_basic_arithmetic_select(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_basic_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(
         "select A + 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select 1 + A from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select A - 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select 1 - A from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
 
 
 @pytest.mark.slow
-def test_column_arithmetic_select(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_column_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(
         "select A + C from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select C - A from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select A * (1 - C) from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
 
 
-def test_sum_arith_select(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_sum_arith_select(bodosql_numeric_types, memory_leak_check):
     """test sum on a call with an arithmetic expression"""
     check_query(
         "select sum(A + 1) from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
         is_out_distributed=False,
+        use_duckdb=True,
     )
 
 
 @pytest.mark.slow
-def test_nested_arithmetic_select(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_nested_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(
         "select A + 1 + 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select 1 + A + 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select 1 + 1 + A from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select A - 1 - 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select 1 - A - 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select 1 - 1 - A from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
 
 
 @pytest.mark.slow
-def test_multicolumn_arithmetic_select(
-    bodosql_numeric_types, spark_info, memory_leak_check
-):
+def test_multicolumn_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(
         "select A + 1, B from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
     check_query(
         "select 1 + A, A - 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
 
 
 @pytest.mark.slow
-def test_select_col_arith(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_select_col_arith(bodosql_numeric_types, memory_leak_check):
     """test selecting a single column and performing arithmetic
     on that columns
     """
     check_query(
         "select A, A + 1 from table1",
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
+        use_duckdb=True,
     )
 
 
-def test_addition_constants(basic_df, spark_info, memory_leak_check):
+def test_addition_constants(basic_df, memory_leak_check):
     """
     Tests that addition works on integer constants
     """
     query = "Select A from table1 where B = .8 + 1 + 1 + -2 + 4 + .2"
-    check_query(query, basic_df, spark_info, check_dtype=False)
+    check_query(query, basic_df, None, check_dtype=False, use_duckdb=True)
 
 
-def test_addition_columns(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_addition_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that addition works on columns
     """
     query = "Select A + B from table1"
     check_query(
-        query, bodosql_numeric_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_numeric_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
-def test_subtraction_constants(basic_df, spark_info, memory_leak_check):
+def test_subtraction_constants(basic_df, memory_leak_check):
     """
     Tests that subtraction works on constants
     """
     query = "Select A from table1 where B = 10 - .001 - -2 - 1 - .2 - .7 - .3 -.8 - 2"
-    check_query(query, basic_df, spark_info, check_dtype=False)
+    check_query(query, basic_df, None, check_dtype=False, use_duckdb=True)
 
 
-def test_subtraction_columns(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_subtraction_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that subtraction works on columns
     """
     query = "Select B - A from table1"
     check_query(
-        query, bodosql_numeric_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_numeric_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
-def test_multiplication_constants(basic_df, spark_info, memory_leak_check):
+def test_multiplication_constants(basic_df, memory_leak_check):
     """
     Tests that multiplication works on constants
     """
     query = "Select A from table1 where B = -1.0 * -1.0 * 2 * 3"
-    check_query(query, basic_df, spark_info, check_dtype=False, check_names=False)
+    check_query(
+        query, basic_df, None, check_dtype=False, check_names=False, use_duckdb=True
+    )
 
 
-def test_multiply_columns(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_multiply_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that multiplication works on columns
     """
     query = "Select A * B from table1"
     check_query(
-        query, bodosql_numeric_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_numeric_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
-def test_division_constants(basic_df, spark_info, memory_leak_check):
+def test_division_constants(basic_df, memory_leak_check):
     """
     Tests that division works on constants
     """
     query = "Select A from table1 where A = 24 / 2 / 4 / -1.0 / -1.0"
-    check_query(query, basic_df, spark_info, check_dtype=False, check_names=False)
+    check_query(
+        query, basic_df, None, check_dtype=False, check_names=False, use_duckdb=True
+    )
 
 
-def test_division_columns(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_division_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that division works on columns
     """
     query = "Select B / A from table1"
     check_query(
-        query, bodosql_numeric_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_numeric_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
 @pytest.mark.slow
-def test_op_order(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_op_order(bodosql_numeric_types, memory_leak_check):
     """
     Tests that order of operations is correct
     """
     query = "Select A from table1 where B = 5 + 10 / 2 - 3 / 3 - 5"
     check_query(
-        query, bodosql_numeric_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_numeric_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
 @pytest.mark.slow
-def test_op_order_cols(bodosql_numeric_types, spark_info, memory_leak_check):
+def test_op_order_cols(bodosql_numeric_types, memory_leak_check):
     """
     Tests that order of operations is correct on columns
     """
     query = "Select A + C / B - A from table1"
     check_query(
-        query, bodosql_numeric_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_numeric_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
 @pytest.mark.slow
-def test_arith_ops_between_tables(basic_df, spark_info, memory_leak_check):
+def test_arith_ops_between_tables(basic_df, memory_leak_check):
     """
     Tests that arith operations between tables work as intended
     """
     query = "Select table1.A + table2.C / table1.B - table2.A from table1, table2"
     newCtx = {"TABLE1": basic_df["TABLE1"], "TABLE2": basic_df["TABLE1"]}
-    check_query(query, newCtx, spark_info, check_dtype=False, check_names=False)
+    check_query(
+        query, newCtx, None, check_dtype=False, check_names=False, use_duckdb=True
+    )
 
 
 @pytest.mark.skip("BS[112]")
-def test_wraparound_unsigned_numerics(
-    bodosql_numeric_types, spark_info, memory_leak_check
-):
+def test_wraparound_unsigned_numerics(bodosql_numeric_types, memory_leak_check):
     """
     Tests that wraparound occurs when dealing with unsigned integer types
     """
     query = "Select A - B from table1"
     check_query(
-        query, bodosql_numeric_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_numeric_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
@@ -315,9 +369,7 @@ def test_wraparound_unsigned_numerics(
         ),
     ],
 )
-def test_add_sub_intervals(
-    bodosql_datetime_types, spark_info, memory_leak_check, interval
-):
+def test_add_sub_intervals(bodosql_datetime_types, memory_leak_check, interval):
     """
     Tests support for + and - with various intervals.
     """
@@ -325,19 +377,39 @@ def test_add_sub_intervals(
     negative_interval = interval[0] + "-" + interval[1:]
     query = f"Select A + interval {interval} from table1"
     check_query(
-        query, bodosql_datetime_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_datetime_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
     query = f"Select A + interval {negative_interval} from table1"
     check_query(
-        query, bodosql_datetime_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_datetime_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
     query = f"Select A - interval {interval} from table1"
     check_query(
-        query, bodosql_datetime_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_datetime_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
     query = f"Select A - interval {negative_interval} from table1"
     check_query(
-        query, bodosql_datetime_types, spark_info, check_dtype=False, check_names=False
+        query,
+        bodosql_datetime_types,
+        None,
+        check_dtype=False,
+        check_names=False,
+        use_duckdb=True,
     )
 
 
@@ -351,7 +423,7 @@ def test_add_sub_intervals(
         ),
     ],
 )
-def test_negation(query, bodosql_numeric_types, spark_info, memory_leak_check):
+def test_negation(query, bodosql_numeric_types, memory_leak_check):
     """Tests unary negation"""
     # Exact value depends on bitwidth so we have to pass the Spark schema
     pyspark_schemas = {}
@@ -361,10 +433,11 @@ def test_negation(query, bodosql_numeric_types, spark_info, memory_leak_check):
     check_query(
         query,
         bodosql_numeric_types,
-        spark_info,
+        None,
         check_dtype=False,
         check_names=False,
         pyspark_schemas=pyspark_schemas,
+        use_duckdb=True,
     )
 
 

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -42,14 +42,16 @@ def test_basic_arithmetic_select(bodosql_numeric_types, memory_leak_check):
         check_names=False,
         use_duckdb=True,
     )
-    check_query(
-        "select 1 - A from table1",
-        bodosql_numeric_types,
-        None,
-        check_dtype=False,
-        check_names=False,
-        use_duckdb=True,
-    )
+    # Avoid overflow errors for unsigned integer
+    if bodosql_numeric_types["TABLE1"].A.dtype.kind != "u":
+        check_query(
+            "select 1 - A from table1",
+            bodosql_numeric_types,
+            None,
+            check_dtype=False,
+            check_names=False,
+            use_duckdb=True,
+        )
 
 
 @pytest.mark.slow

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -2,13 +2,13 @@
 Test correctness of SQL arithmetic operations on BodoSQL
 """
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from bodo.tests.utils import pytest_slow_unless_codegen
 from bodosql.tests.utils import (
     check_query,
-    create_pyspark_schema_from_dataframe,
 )
 
 # Skip unless any codegen files were changed
@@ -434,10 +434,10 @@ def test_add_sub_intervals(bodosql_datetime_types, memory_leak_check, interval):
 )
 def test_negation(query, bodosql_numeric_types, memory_leak_check):
     """Tests unary negation"""
-    # Exact value depends on bitwidth so we have to pass the Spark schema
-    pyspark_schemas = {}
-    for table_name, df in bodosql_numeric_types.items():
-        pyspark_schemas[table_name] = create_pyspark_schema_from_dataframe(df)
+
+    # Avoid overflow errors
+    if bodosql_numeric_types["TABLE1"].A.dtype not in (np.int64, np.float64):
+        return
 
     check_query(
         query,
@@ -445,7 +445,6 @@ def test_negation(query, bodosql_numeric_types, memory_leak_check):
         None,
         check_dtype=False,
         check_names=False,
-        pyspark_schemas=pyspark_schemas,
         use_duckdb=True,
     )
 

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -102,6 +102,7 @@ def test_sum_arith_select(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_nested_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -195,6 +195,7 @@ def test_select_col_arith(bodosql_numeric_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_addition_constants(basic_df, memory_leak_check):
     """
     Tests that addition works on integer constants

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -65,22 +65,24 @@ def test_column_arithmetic_select(bodosql_numeric_types, memory_leak_check):
         check_names=False,
         use_duckdb=True,
     )
-    check_query(
-        "select C - A from table1",
-        bodosql_numeric_types,
-        None,
-        check_dtype=False,
-        check_names=False,
-        use_duckdb=True,
-    )
-    check_query(
-        "select A * (1 - C) from table1",
-        bodosql_numeric_types,
-        None,
-        check_dtype=False,
-        check_names=False,
-        use_duckdb=True,
-    )
+    # Avoid overflow errors for unsigned integer
+    if bodosql_numeric_types["TABLE1"].A.dtype.kind != "u":
+        check_query(
+            "select C - A from table1",
+            bodosql_numeric_types,
+            None,
+            check_dtype=False,
+            check_names=False,
+            use_duckdb=True,
+        )
+        check_query(
+            "select A * (1 - C) from table1",
+            bodosql_numeric_types,
+            None,
+            check_dtype=False,
+            check_names=False,
+            use_duckdb=True,
+        )
 
 
 def test_sum_arith_select(bodosql_numeric_types, memory_leak_check):

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -283,6 +283,7 @@ def test_division_constants(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_division_columns(bodosql_numeric_types, memory_leak_check):
     """
     Tests that division works on columns
@@ -299,6 +300,7 @@ def test_division_columns(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_op_order(bodosql_numeric_types, memory_leak_check):
     """
     Tests that order of operations is correct
@@ -315,6 +317,7 @@ def test_op_order(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_op_order_cols(bodosql_numeric_types, memory_leak_check):
     """
     Tests that order of operations is correct on columns
@@ -331,6 +334,7 @@ def test_op_order_cols(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_arith_ops_between_tables(basic_df, memory_leak_check):
     """
     Tests that arith operations between tables work as intended

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -272,6 +272,7 @@ def test_multiply_columns(bodosql_numeric_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_division_constants(basic_df, memory_leak_check):
     """
     Tests that division works on constants

--- a/BodoSQL/bodosql/tests/test_arith.py
+++ b/BodoSQL/bodosql/tests/test_arith.py
@@ -16,6 +16,7 @@ pytestmark = pytest_slow_unless_codegen
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_basic_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(
@@ -55,6 +56,7 @@ def test_basic_arithmetic_select(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_column_arithmetic_select(bodosql_numeric_types, memory_leak_check):
     """test select calls with an arithmetic expression"""
     check_query(

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -432,7 +432,8 @@ duckdb::unique_ptr<duckdb::Expression> make_conjunction_expr(
 }
 
 duckdb::unique_ptr<duckdb::Expression> make_unary_expr(
-    std::unique_ptr<duckdb::Expression> &lhs, duckdb::ExpressionType etype) {
+    std::unique_ptr<duckdb::Expression> &lhs, duckdb::ExpressionType etype,
+    PyObject *out_schema_py) {
     // Convert std::unique_ptr to duckdb::unique_ptr.
     auto lhs_duck = to_duckdb(lhs);
 
@@ -443,6 +444,16 @@ duckdb::unique_ptr<duckdb::Expression> make_unary_expr(
         case duckdb::ExpressionType::OPERATOR_IS_NOT_NULL: {
             auto ret = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
                 etype, duckdb::LogicalType(duckdb::LogicalTypeId::BOOLEAN));
+            ret->children.push_back(std::move(lhs_duck));
+            return ret;
+        } break;
+        case duckdb::ExpressionType::OPERATOR_NEG: {
+            std::shared_ptr<arrow::Schema> out_schema =
+                unwrap_schema(out_schema_py);
+            auto field = out_schema->field(0);
+            auto [_, out_type] = arrow_field_to_duckdb(field);
+            auto ret = duckdb::make_uniq<duckdb::BoundOperatorExpression>(
+                etype, out_type);
             ret->children.push_back(std::move(lhs_duck));
             return ret;
         } break;

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -430,10 +430,12 @@ duckdb::unique_ptr<duckdb::Expression> make_conjunction_expr(
  *
  * @param lhs - the left-hand side of the expression
  * @param etype - the expression type (e.g., not) to apply to the source
+ * @param out_schema_py - the output schema for the expression
  * @return duckdb::unique_ptr<duckdb::Expression> - the output expr
  */
 duckdb::unique_ptr<duckdb::Expression> make_unary_expr(
-    std::unique_ptr<duckdb::Expression> &lhs, duckdb::ExpressionType etype);
+    std::unique_ptr<duckdb::Expression> &lhs, duckdb::ExpressionType etype,
+    PyObject *out_schema_py);
 
 /**
  * @brief Create a case expression from a source.

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -491,6 +491,14 @@ std::shared_ptr<arrow::DataType> duckdbTypeToArrow(
             return arrow::time64(arrow::TimeUnit::NANO);
         case duckdb::LogicalTypeId::BLOB:
             return arrow::large_binary();
+        // DuckDB sometimes generates non-standard HUGEINT types for cases like
+        // A+1 for uint64 (see test_nested_arithmetic_select) We just use
+        // int64/uint64 for HUGEINT/UHUGEINT since we don't have a larger
+        // integer type.
+        case duckdb::LogicalTypeId::HUGEINT:
+            return arrow::int64();
+        case duckdb::LogicalTypeId::UHUGEINT:
+            return arrow::uint64();
         default:
             throw std::runtime_error(
                 "duckdbTypeToArrow unsupported LogicalType conversion " +

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -267,6 +267,13 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
         cmp_res = cast_res;
     }
 
+    auto res = cmp_res.ValueOrDie();
+    if (res.is_scalar()) {
+        return arrow_array_to_bodo(
+            arrow::MakeArrayFromScalar(*res.scalar(), 1).ValueOrDie(),
+            bodo::BufferPool::DefaultPtr());
+    }
+
     std::shared_ptr<arrow::Array> arrow_arr = cmp_res.ValueOrDie().make_array();
     return arrow_array_to_bodo(arrow_arr, bodo::BufferPool::DefaultPtr());
 }
@@ -339,7 +346,14 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
             cmp_res.status().message());
     }
 
-    return arrow_array_to_bodo(cmp_res.ValueOrDie().make_array(),
+    auto res = cmp_res.ValueOrDie();
+    if (res.is_scalar()) {
+        return arrow_array_to_bodo(
+            arrow::MakeArrayFromScalar(*res.scalar(), 1).ValueOrDie(),
+            bodo::BufferPool::DefaultPtr());
+    }
+
+    return arrow_array_to_bodo(res.make_array(),
                                bodo::BufferPool::DefaultPtr());
 }
 

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -281,6 +281,13 @@ class PhysicalComparisonExpression : public PhysicalExpression {
             children[1]->ProcessBatch(input_batch);
 
         auto result = do_arrow_compute_binary(left_res, right_res, comparator);
+        auto left_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(left_res);
+        auto right_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(right_res);
+        if (left_as_scalar && right_as_scalar) {
+            return std::make_shared<ScalarExprResult>(result);
+        }
         return std::make_shared<ArrayExprResult>(result,
                                                  "Comparison" + comparator);
     }
@@ -696,6 +703,11 @@ class PhysicalConjunctionExpression : public PhysicalExpression {
             children[1]->ProcessBatch(input_batch);
 
         auto result = do_arrow_compute_binary(left_res, right_res, comparator);
+        auto right_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(right_res);
+        if (left_as_scalar && right_as_scalar) {
+            return std::make_shared<ScalarExprResult>(result);
+        }
         return std::make_shared<ArrayExprResult>(result,
                                                  "Conjunction" + comparator);
     }
@@ -772,6 +784,11 @@ class PhysicalCastExpression : public PhysicalExpression {
         std::shared_ptr<ExprResult> left_res =
             children[0]->ProcessBatch(input_batch);
         auto result = do_arrow_compute_cast(left_res, return_type);
+        auto left_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(left_res);
+        if (left_as_scalar) {
+            return std::make_shared<ScalarExprResult>(result);
+        }
         return std::make_shared<ArrayExprResult>(result, "Cast");
     }
 
@@ -839,6 +856,12 @@ class PhysicalUnaryExpression : public PhysicalExpression {
         std::shared_ptr<ExprResult> left_res =
             children[0]->ProcessBatch(input_batch);
         auto result = do_arrow_compute_unary(left_res, comparator);
+        auto left_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(left_res);
+        if (left_as_scalar) {
+            return std::make_shared<ScalarExprResult>(result);
+        }
+
         return std::make_shared<ArrayExprResult>(result, "Unary" + comparator);
     }
 
@@ -928,6 +951,13 @@ class PhysicalBinaryExpression : public PhysicalExpression {
 
         std::shared_ptr<array_info> result = do_arrow_compute_binary(
             left_res, right_res, comparator, result_type);
+        auto left_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(left_res);
+        auto right_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(right_res);
+        if (left_as_scalar && right_as_scalar) {
+            return std::make_shared<ScalarExprResult>(result);
+        }
         return std::make_shared<ArrayExprResult>(result, "Binary" + comparator);
     }
 
@@ -981,6 +1011,15 @@ class PhysicalCaseExpression : public PhysicalExpression {
             children[2]->ProcessBatch(input_batch);
 
         auto result = do_arrow_compute_case(when_res, then_res, else_res);
+        auto when_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(when_res);
+        auto then_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(then_res);
+        auto else_as_scalar =
+            std::dynamic_pointer_cast<ScalarExprResult>(else_res);
+        if (when_as_scalar && then_as_scalar && else_as_scalar) {
+            return std::make_shared<ScalarExprResult>(result);
+        }
         return std::make_shared<ArrayExprResult>(result, "Case");
     }
 

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -829,6 +829,9 @@ class PhysicalUnaryExpression : public PhysicalExpression {
             case duckdb::ExpressionType::OPERATOR_IS_TRUE:
                 comparator = "is_true";
                 break;
+            case duckdb::ExpressionType::OPERATOR_NEG:
+                comparator = "negate";
+                break;
             default:
                 throw std::runtime_error("Unhandled unary op expression type.");
         }

--- a/bodo/pandas/physical/project_utils.h
+++ b/bodo/pandas/physical/project_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <arrow/api.h>
+#include <arrow/type.h>
 #include <arrow/type_traits.h>
 
 /**
@@ -173,18 +174,12 @@ inline std::shared_ptr<bodo::Schema> getProjectionOutputSchema(
                 col_names.emplace_back("Not");
             }
         } else if (expr->type == duckdb::ExpressionType::OPERATOR_NEG) {
+            auto& neg_expr = expr->Cast<duckdb::BoundOperatorExpression>();
+
             std::unique_ptr<bodo::DataType> col_type =
-                input_schema->column_types[expr_idx]->copy();
-            // Convert unsigned integers to signed integers for negate operator
-            std::shared_ptr<arrow::DataType> arrow_type =
-                col_type->ToArrowDataType();
-            if (arrow::is_integer(arrow_type->id()) &&
-                !arrow::is_signed_integer(arrow_type->id())) {
-                std::shared_ptr<arrow::DataType> signed_arrow_type =
-                    ToSignedArrowInt(arrow_type);
-                col_type =
-                    arrow_type_to_bodo_data_type(signed_arrow_type)->copy();
-            }
+                arrow_type_to_bodo_data_type(
+                    duckdbTypeToArrow(neg_expr.return_type))
+                    ->copy();
             output_schema->append_column(std::move(col_type));
             if (input_schema->column_names.size() > 0) {
                 col_names.emplace_back(input_schema->column_names[0]);

--- a/bodo/pandas/physical/project_utils.h
+++ b/bodo/pandas/physical/project_utils.h
@@ -1,5 +1,41 @@
 #pragma once
 
+#include <arrow/api.h>
+#include <arrow/type_traits.h>
+
+/**
+ * @brief Convert an unsigned Arrow integer type to its signed counterpart.
+ *
+ * @param type The Arrow data type to convert.
+ * @return std::shared_ptr<arrow::DataType> The signed Arrow data type.
+ */
+inline std::shared_ptr<arrow::DataType> ToSignedArrowInt(
+    const std::shared_ptr<arrow::DataType>& type) {
+    if (!arrow::is_integer(type->id())) {
+        throw std::runtime_error(
+            "Type " + type->ToString() +
+            " is not an integer type, cannot convert to signed.");
+    }
+
+    if (arrow::is_signed_integer(type->id())) {
+        return type;  // already signed
+    }
+
+    switch (type->id()) {
+        case arrow::Type::UINT8:
+            return arrow::int8();
+        case arrow::Type::UINT16:
+            return arrow::int16();
+        case arrow::Type::UINT32:
+            return arrow::int32();
+        case arrow::Type::UINT64:
+            return arrow::int64();
+        default:
+            throw std::runtime_error("Unhandled integer type: " +
+                                     type->ToString());
+    }
+}
+
 template <typename EXPR_TYPE, typename BUILD_EXPR>
 inline std::shared_ptr<bodo::Schema> getProjectionOutputSchema(
     std::vector<duckdb::ColumnBinding>& source_cols,
@@ -135,6 +171,25 @@ inline std::shared_ptr<bodo::Schema> getProjectionOutputSchema(
                 col_names.emplace_back(input_schema->column_names[0]);
             } else {
                 col_names.emplace_back("Not");
+            }
+        } else if (expr->type == duckdb::ExpressionType::OPERATOR_NEG) {
+            std::unique_ptr<bodo::DataType> col_type =
+                input_schema->column_types[expr_idx]->copy();
+            // Convert unsigned integers to signed integers for negate operator
+            std::shared_ptr<arrow::DataType> arrow_type =
+                col_type->ToArrowDataType();
+            if (arrow::is_integer(arrow_type->id()) &&
+                !arrow::is_signed_integer(arrow_type->id())) {
+                std::shared_ptr<arrow::DataType> signed_arrow_type =
+                    ToSignedArrowInt(arrow_type);
+                col_type =
+                    arrow_type_to_bodo_data_type(signed_arrow_type)->copy();
+            }
+            output_schema->append_column(std::move(col_type));
+            if (input_schema->column_names.size() > 0) {
+                col_names.emplace_back(input_schema->column_names[0]);
+            } else {
+                col_names.emplace_back("NEGATE");
             }
         } else {
             throw std::runtime_error(

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -995,6 +995,37 @@ class CaseExpression(Expression):
         return out
 
 
+class CastExpression(Expression):
+    """Expression representing a type cast in the query plan."""
+
+    def __init__(self, empty_data, source_expr):
+        self.empty_data = empty_data
+        self.source_expr = source_expr
+        super().__init__(empty_data, source_expr)
+
+    @property
+    def source(self):
+        """Return the source of the cast expression."""
+        return self.source_expr.source
+
+    def replace_source(self, new_source: LazyPlan):
+        """Replace the source of the expression with a new source plan."""
+        new_source_expr = self.source_expr.replace_source(new_source)
+        if new_source_expr is None:
+            return None
+
+        out = CastExpression(self.empty_data, new_source_expr)
+        out.is_series = self.is_series
+        return out
+
+    def with_new_source(self, new_source):
+        out = CastExpression(
+            self.empty_data, self.source_expr.with_new_source(new_source)
+        )
+        out.is_series = self.is_series
+        return out
+
+
 class ArithOpExpression(BinaryExpression):
     """Expression representing an arithmetic operation (e.g. addition, subtraction)
     in the query plan.

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -151,6 +151,8 @@ cdef extern from "duckdb/common/enums/expression_type.hpp" namespace "duckdb" no
         BOUND_LAMBDA_REF "duckdb::ExpressionType::BOUND_LAMBDA_REF"
         BOUND_EXPANDED "duckdb::ExpressionType::BOUND_EXPANDED"
         OPERATOR_IS_TRUE "duckdb::ExpressionType::OPERATOR_IS_TRUE"
+        OPERATOR_NEG "duckdb::ExpressionType::OPERATOR_NEG"
+
 
 def str_to_expr_type(val):
     if val is operator.eq:
@@ -171,6 +173,8 @@ def str_to_expr_type(val):
         return CExpressionType.CONJUNCTION_OR
     elif val == "__invert__":
         return CExpressionType.OPERATOR_NOT
+    elif val == "__neg__":
+        return CExpressionType.OPERATOR_NEG
     elif val == "notnull":
         return CExpressionType.OPERATOR_IS_NOT_NULL
     elif val == "isnull":
@@ -340,7 +344,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr) except +
     cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema) except +
     cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
-    cdef unique_ptr[CExpression] make_unary_expr(unique_ptr[CExpression] lhs, CExpressionType etype) except +
+    cdef unique_ptr[CExpression] make_unary_expr(unique_ptr[CExpression] lhs, CExpressionType etype, object out_schema) except +
     cdef unique_ptr[CExpression] make_case_expr(unique_ptr[CExpression] when, unique_ptr[CExpression] then, unique_ptr[CExpression] else_) except +
     cdef unique_ptr[CLogicalFilter] make_filter(unique_ptr[CLogicalOperator] source, unique_ptr[CExpression] filter_expr) except +
     cdef unique_ptr[CExpression] make_const_null(object arrow_schema, int64_t field_idx) except +
@@ -881,7 +885,7 @@ cdef class UnaryOpExpression(Expression):
         self.out_schema = out_schema
         self.c_expression = make_unary_expr(
             source_expr,
-            str_to_expr_type(op))
+            str_to_expr_type(op), out_schema)
 
     def __str__(self):
         return f"UnaryOpExpression({self.out_schema})"

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -910,6 +910,24 @@ cdef class CaseExpression(Expression):
         return f"CaseExpression({self.out_schema})"
 
 
+cdef class CastExpression(Expression):
+    """Wrapper around DuckDB's BoundCastExpression to provide access in Python.
+    """
+
+    def __cinit__(self, object out_schema, source):
+        cdef unique_ptr[CExpression] source_expr
+
+        source_expr = move((<Expression>source).c_expression) if isinstance(source, Expression) else move(make_const_expr(None, source))
+
+        self.out_schema = out_schema
+        self.c_expression = make_cast_expr(
+            source_expr,
+            out_schema)
+
+    def __str__(self):
+        return f"CastExpression({self.out_schema})"
+
+
 cdef class LogicalLimit(LogicalOperator):
     cdef public int n
 

--- a/bodo/pandas/vendor/duckdb/src/common/enums/expression_type.cpp
+++ b/bodo/pandas/vendor/duckdb/src/common/enums/expression_type.cpp
@@ -154,6 +154,8 @@ string ExpressionTypeToString(ExpressionType type) {
 	// Bodo change: added new operator
 	case ExpressionType::OPERATOR_IS_TRUE:
 		return "IS_TRUE";
+	case ExpressionType::OPERATOR_NEG:
+		return "NEG";
 	case ExpressionType::INVALID:
 		break;
 	}

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/common/enums/expression_type.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/common/enums/expression_type.hpp
@@ -154,7 +154,8 @@ enum class ExpressionType : uint8_t {
 	BOUND_EXPANDED = 234,
 
 	// Bodo change: added new operator
-	OPERATOR_IS_TRUE = 250
+	OPERATOR_IS_TRUE = 250,
+	OPERATOR_NEG = 251
 };
 
 //===--------------------------------------------------------------------===//

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/parser/expression/operator_expression.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/parser/expression/operator_expression.hpp
@@ -87,6 +87,9 @@ public:
 			return "(" + entry.children[0]->ToString() + " IS NULL)";
 		case ExpressionType::OPERATOR_IS_NOT_NULL:
 			return "(" + entry.children[0]->ToString() + " IS NOT NULL)";
+		// Bodo change: add new operator
+		case ExpressionType::OPERATOR_NEG:
+			return "(-" + entry.children[0]->ToString() + ")";
 		case ExpressionType::ARRAY_EXTRACT:
 			return entry.children[0]->ToString() + "[" + entry.children[1]->ToString() + "]";
 		case ExpressionType::ARRAY_SLICE: {


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Adds support to most of test_artith.py tests in BodoSQL C++ backend.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added markers.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.