### PR TITLE
[GPU] More stopping non-GPU ranks from getting cuda contexts.

### DIFF
--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -258,13 +258,19 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
                 bododuckdb::JoinCondition::CreateExpression(std::move(cond)));
         }
 
-        rmm::cuda_stream_view stream = cudf::get_default_stream();
-        std::unique_ptr<CudfASTOwner> physExprTree =
-            duckdb_exprs.size()
-                ? std::make_unique<CudfASTOwner>(
-                      build_mixed_join_predicate(duckdb_exprs, left_col_ref_map,
-                                                 right_col_ref_map, stream))
-                : nullptr;
+        rmm::cuda_stream_view stream;
+        std::unique_ptr<CudfASTOwner> physExprTree;
+
+        if (is_gpu_rank()) {
+            stream = cudf::get_default_stream();
+
+            physExprTree =
+                duckdb_exprs.size()
+                    ? std::make_unique<CudfASTOwner>(build_mixed_join_predicate(
+                          duckdb_exprs, left_col_ref_map, right_col_ref_map,
+                          stream))
+                    : nullptr;
+        }
 
         bool build_table_outer =
             (logical_join.join_type == duckdb::JoinType::RIGHT) ||

--- a/bodo/pandas/physical/gpu_limit.h
+++ b/bodo/pandas/physical/gpu_limit.h
@@ -19,14 +19,15 @@ class PhysicalGPULimit : public PhysicalGPUSource, public PhysicalGPUSink {
    public:
     explicit PhysicalGPULimit(uint64_t nrows,
                               std::shared_ptr<bodo::Schema> input_schema)
-        : n(nrows),
-          local_remaining(nrows),
-          collected_rows(
-              GPU_DATA(
-                  empty_table_from_arrow_schema(input_schema->ToArrowSchema()),
-                  input_schema->ToArrowSchema(), make_stream_and_event(false)),
-              get_gpu_streaming_batch_size()),
-          output_schema(input_schema) {
+        : n(nrows), local_remaining(nrows), output_schema(input_schema) {
+        if (is_gpu_rank()) {
+            collected_rows = std::make_unique<GPUBatchGenerator>(
+                GPU_DATA(empty_table_from_arrow_schema(
+                             input_schema->ToArrowSchema()),
+                         input_schema->ToArrowSchema(),
+                         make_stream_and_event(false)),
+                get_gpu_streaming_batch_size());
+        }
         PhysicalGPUSource::EnsureNoNumpyColumns(this->output_schema);
         arrow_output_schema = output_schema->ToArrowSchema();
     }
@@ -54,7 +55,7 @@ class PhysicalGPULimit : public PhysicalGPUSource, public PhysicalGPUSink {
         std::vector<uint64_t> row_counts(n_pes);
 
         // Get total rows on this GPU.
-        uint64_t cur_rows = collected_rows.collected_rows;
+        uint64_t cur_rows = collected_rows->collected_rows;
         CHECK_MPI(MPI_Allgather(&cur_rows, 1, MPI_UNSIGNED_LONG_LONG,
                                 row_counts.data(), 1, MPI_UNSIGNED_LONG_LONG,
                                 gpu_mpi.get_mpi_comm()),
@@ -95,7 +96,7 @@ class PhysicalGPULimit : public PhysicalGPUSource, public PhysicalGPUSink {
                     std::make_unique<cudf::table>(
                         cudf::slice(input_batch.table->view(),
                                     {0, (int)select_local}, se->stream)[0]);
-                collected_rows.append_batch(
+                collected_rows->append_batch(
                     GPU_DATA(std::move(first_select_local_rows),
                              arrow_output_schema, se));
                 local_remaining -= select_local;
@@ -133,7 +134,7 @@ class PhysicalGPULimit : public PhysicalGPUSource, public PhysicalGPUSink {
                     OperatorResult::FINISHED};
         }
 
-        auto next_batch = collected_rows.next(se, true);
+        auto next_batch = collected_rows->next(se, true);
         if (next_batch.table->num_rows() >=
             static_cast<cudf::size_type>(local_remaining)) {
             cudf::table_view tv = next_batch.table->view();
@@ -162,7 +163,7 @@ class PhysicalGPULimit : public PhysicalGPUSource, public PhysicalGPUSink {
 
    private:
     uint64_t n, local_remaining;
-    GPUBatchGenerator collected_rows;
+    std::unique_ptr<GPUBatchGenerator> collected_rows = nullptr;
     const std::shared_ptr<bodo::Schema> output_schema;
     std::shared_ptr<arrow::Schema> arrow_output_schema;
 

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -686,7 +686,7 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
     }
     finished = static_cast<bool>(sync_is_last_non_blocking(
                    is_last_state.get(), static_cast<int32_t>(local_is_last))) &&
-               (gpu_batch_generator ? (gpu_batch_generator->collected_rows == 1)
+               (gpu_batch_generator ? (gpu_batch_generator->collected_rows == 0)
                                     : true);
 
     if (finished) {

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -646,13 +646,7 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
             return std::make_tuple(convertTableToGPU(input_batch, se),
                                    OperatorResult::FINISHED);
         } else {
-            std::unique_ptr<bodo::Schema> table_schema = input_batch->schema();
-            if (!table_schema->metadata) {
-                table_schema->metadata = std::make_shared<bodo::TableMetadata>(
-                    std::vector<std::string>({}), std::vector<std::string>({}));
-            }
-            auto output_batch =
-                GPU_DATA(nullptr, table_schema->ToArrowSchema(), nullptr);
+            auto output_batch = GPU_DATA(nullptr, nullptr, nullptr);
             return std::make_tuple(output_batch, OperatorResult::FINISHED);
         }
     }
@@ -688,13 +682,7 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
     if (is_gpu_rank()) {
         output_batch = gpu_batch_generator->next(se, local_is_last);
     } else {
-        std::unique_ptr<bodo::Schema> table_schema = input_batch->schema();
-        if (!table_schema->metadata) {
-            table_schema->metadata = std::make_shared<bodo::TableMetadata>(
-                std::vector<std::string>({}), std::vector<std::string>({}));
-        }
-        output_batch =
-            GPU_DATA(nullptr, table_schema->ToArrowSchema(), nullptr);
+        output_batch = GPU_DATA(nullptr, nullptr, nullptr);
     }
     finished = static_cast<bool>(sync_is_last_non_blocking(
                    is_last_state.get(), static_cast<int32_t>(local_is_last))) &&

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -647,6 +647,10 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
                                    OperatorResult::FINISHED);
         } else {
             std::unique_ptr<bodo::Schema> table_schema = input_batch->schema();
+            if (!table_schema->metadata) {
+                table_schema->metadata = std::make_shared<bodo::TableMetadata>(
+                    std::vector<std::string>({}), std::vector<std::string>({}));
+            }
             auto output_batch =
                 GPU_DATA(nullptr, table_schema->ToArrowSchema(), nullptr);
             return std::make_tuple(output_batch, OperatorResult::FINISHED);
@@ -668,19 +672,27 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
     }
     // Determine whether we need more input, have more output, or are finished
     // with the exchange.
-    bool request_input =
-        !(this->shuffle_state->BuffersFull() &&
-          (gpu_batch_generator ? (gpu_batch_generator->collected_rows >
-                                  (2 * gpu_batch_generator->out_batch_size))
-                               : false));
+    bool request_input;
+    if (!is_gpu_rank()) {
+        request_input = true;
+    } else {
+        request_input = !(this->shuffle_state->BuffersFull() &&
+                          (gpu_batch_generator->collected_rows >
+                           (2 * gpu_batch_generator->out_batch_size)));
+    }
+
     bool local_is_last = prev_op_result == OperatorResult::FINISHED &&
                          (this->shuffle_state->SendRecvEmpty());
 
     GPU_DATA output_batch;
-    if (gpu_batch_generator) {
+    if (is_gpu_rank()) {
         output_batch = gpu_batch_generator->next(se, local_is_last);
     } else {
         std::unique_ptr<bodo::Schema> table_schema = input_batch->schema();
+        if (!table_schema->metadata) {
+            table_schema->metadata = std::make_shared<bodo::TableMetadata>(
+                std::vector<std::string>({}), std::vector<std::string>({}));
+        }
         output_batch =
             GPU_DATA(nullptr, table_schema->ToArrowSchema(), nullptr);
     }

--- a/bodo/pandas/physical/operator.cpp
+++ b/bodo/pandas/physical/operator.cpp
@@ -642,8 +642,15 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
                 "CPUtoGPUExchange::operator(): Received non-empty batch after "
                 "exchange was marked finished");
         }
-        return std::make_tuple(convertTableToGPU(input_batch, se),
-                               OperatorResult::FINISHED);
+        if (is_gpu_rank()) {
+            return std::make_tuple(convertTableToGPU(input_batch, se),
+                                   OperatorResult::FINISHED);
+        } else {
+            std::unique_ptr<bodo::Schema> table_schema = input_batch->schema();
+            auto output_batch =
+                GPU_DATA(nullptr, table_schema->ToArrowSchema(), nullptr);
+            return std::make_tuple(output_batch, OperatorResult::FINISHED);
+        }
     }
 
     if (!this->shuffle_state) {
@@ -661,15 +668,26 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
     }
     // Determine whether we need more input, have more output, or are finished
     // with the exchange.
-    bool request_input = !(this->shuffle_state->BuffersFull() &&
-                           (gpu_batch_generator->collected_rows >
-                            (2 * gpu_batch_generator->out_batch_size)));
+    bool request_input =
+        !(this->shuffle_state->BuffersFull() &&
+          (gpu_batch_generator ? (gpu_batch_generator->collected_rows >
+                                  (2 * gpu_batch_generator->out_batch_size))
+                               : false));
     bool local_is_last = prev_op_result == OperatorResult::FINISHED &&
                          (this->shuffle_state->SendRecvEmpty());
-    auto output_batch = gpu_batch_generator->next(se, local_is_last);
+
+    GPU_DATA output_batch;
+    if (gpu_batch_generator) {
+        output_batch = gpu_batch_generator->next(se, local_is_last);
+    } else {
+        std::unique_ptr<bodo::Schema> table_schema = input_batch->schema();
+        output_batch =
+            GPU_DATA(nullptr, table_schema->ToArrowSchema(), nullptr);
+    }
     finished = static_cast<bool>(sync_is_last_non_blocking(
                    is_last_state.get(), static_cast<int32_t>(local_is_last))) &&
-               gpu_batch_generator->collected_rows == 0;
+               (gpu_batch_generator ? (gpu_batch_generator->collected_rows == 1)
+                                    : true);
 
     if (finished) {
         this->shuffle_state->Finalize();
@@ -683,10 +701,14 @@ std::tuple<GPU_DATA, OperatorResult> CPUtoGPUExchange::operator()(
 
 void CPUtoGPUExchange::Initialize(std::shared_ptr<table_info> input_batch,
                                   std::shared_ptr<StreamAndEvent> se) {
-    // Initialize GPU batch generator
-    auto dummy_gpu_data = convertTableToGPU(alloc_table_like(input_batch), se);
-    gpu_batch_generator = std::make_unique<GPUBatchGenerator>(
-        dummy_gpu_data, static_cast<size_t>(get_gpu_streaming_batch_size()));
+    if (is_gpu_rank()) {
+        // Initialize GPU batch generator
+        auto dummy_gpu_data =
+            convertTableToGPU(alloc_table_like(input_batch), se);
+        gpu_batch_generator = std::make_unique<GPUBatchGenerator>(
+            dummy_gpu_data,
+            static_cast<size_t>(get_gpu_streaming_batch_size()));
+    }
 
     // Initialize Shuffle State
     std::vector<std::shared_ptr<DictionaryBuilder>> dict_builders;

--- a/bodo/pandas/physical/operator.h
+++ b/bodo/pandas/physical/operator.h
@@ -179,7 +179,7 @@ class CPUtoGPUExchange : public RankDataExchange {
     void Initialize(std::shared_ptr<table_info> input_batch,
                     std::shared_ptr<StreamAndEvent> se);
 
-    std::unique_ptr<GPUBatchGenerator> gpu_batch_generator;
+    std::unique_ptr<GPUBatchGenerator> gpu_batch_generator = nullptr;
 };
 
 /**

--- a/bodo/pandas/physical/operator.h
+++ b/bodo/pandas/physical/operator.h
@@ -150,7 +150,7 @@ struct GPUBatchGenerator {
  */
 class CPUtoGPUExchange : public RankDataExchange {
    public:
-    CPUtoGPUExchange(int64_t op_id_) : RankDataExchange(op_id_) {};
+    CPUtoGPUExchange(int64_t op_id_) : RankDataExchange(op_id_) {}
 
     /**
      * @brief Send data from all ranks to GPUs.


### PR DESCRIPTION
## Changes included in this PR

Changes to cpu-to-gpu and gpu_join to stop non-GPU ranks from creating cuda contexts (and consuming memory on the GPU).

## Testing strategy

Tested locally for effect and run-ci for non-breaking.

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.