### PR TITLE
[GPU] Avoid setting CUDA launcher to Sccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,9 @@ find_program(SCCACHE_EXECUTABLE "sccache")
 if ((NOT DEFINED ENV{DISABLE_CCACHE}) AND CCACHE_EXECUTABLE)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
 elseif ((NOT DEFINED ENV{DISABLE_SCCACHE}) AND SCCACHE_EXECUTABLE)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE sccache)
+    set(CMAKE_C_COMPILER_LAUNCHER sccache)
+    set(CMAKE_CXX_COMPILER_LAUNCHER sccache)
+    # Avoid setting CUDA launcher due to CUDA 13.3 + sccache fatbinary/PTX issues
 endif()
 
 # ---------------------------- Enable C++ Linting ----------------------------


### PR DESCRIPTION
## Changes included in this PR

Newer CUDA (13.3) provided by conda-forge gives and error when using Sccache:
```
fatbinary fatal : Could not open input file 'gpu_utils.compute_75.ptx' sccache: Compiler killed by signal 1
```
Disabling sccache for CUDA files for now seems like a reasonable workaround since the number of .cu files we have is small. 

## Testing strategy
https://github.com/bodo-ai/Bodo/actions/runs/26641310969/job/78514839714
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.