### PR TITLE
Enable non-equi join for bodosql cpp backend.

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -522,6 +522,18 @@ def java_join_to_python_join(ctx, java_join):
                 java_expr_to_python_expr(e, planJoinOrCross),
                 "__and__",
             )
+        # We convert a Calcite join with non-equi conditions into an equi join
+        # plus a filter for a few reasons.  First, the dataframe join side does
+        # not have an API that can create a join with non-equi conditions.
+        # Those are only created by the duckdb optimizer so it doesn't hurt to
+        # create the filter on top and left duckdb merge them.  Moreover, in
+        # the CPU backend we convert joins with non-equi conditions back to a
+        # join plus a filter so it is no big deal if duckdb doesn't merge the
+        # join and this filter.  Also, this approach is a nicer match to the
+        # architecture in this file and Calcite as the non-equi conditions
+        # reference the joined table whereas our infrastructure would require
+        # them to reference the build and probe side that is more tedious
+        # work to do the mapping.
         planFilter = LogicalFilter(empty_join_out, planJoinOrCross, non_equi_exprs)
         return planFilter
 

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -22,6 +22,7 @@ from bodo.pandas.plan import (
     ConstantExpression,
     LogicalAggregate,
     LogicalComparisonJoin,
+    LogicalCrossProduct,
     LogicalDistinct,
     LogicalFilter,
     LogicalJoinFilter,
@@ -474,10 +475,9 @@ def java_join_to_python_join(ctx, java_join):
     )
 
     join_info = java_join.analyzeCondition()
-
-    # TODO[BSE-5149]: support non-equi joins
-    if not join_info.isEqui():
-        raise NotImplementedError("Only equi-joins are supported")
+    join_info_cls = join_info.getClass()
+    field = join_info_cls.getField("nonEquiConditions")
+    nonEquiConds = field.get(join_info)
 
     left_keys, right_keys = join_info.keys()
     key_indices = list(zip(left_keys, right_keys))
@@ -497,16 +497,33 @@ def java_join_to_python_join(ctx, java_join):
     empty_join_out = pd.concat([left_plan.empty_data, right_plan.empty_data], axis=1)
     empty_join_out.columns = java_join.getRowType().getFieldNames()
 
-    # TODO[BSE-5150]: support broadcast join flag
-    planComparisonJoin = LogicalComparisonJoin(
-        empty_join_out,
-        left_plan,
-        right_plan,
-        join_type,
-        key_indices,
-        java_join.getJoinFilterID(),
-    )
-    return planComparisonJoin
+    if len(key_indices) > 0:
+        # TODO[BSE-5150]: support broadcast join flag
+        planJoinOrCross = LogicalComparisonJoin(
+            empty_join_out,
+            left_plan,
+            right_plan,
+            join_type,
+            key_indices,
+            java_join.getJoinFilterID(),
+        )
+    else:
+        planJoinOrCross = LogicalCrossProduct(empty_join_out, left_plan, right_plan)
+
+    if len(nonEquiConds) == 0:
+        return planJoinOrCross
+    else:
+        non_equi_exprs = java_expr_to_python_expr(nonEquiConds[0], planJoinOrCross)
+        # And all the conditions together with the first one above.
+        for e in nonEquiConds[1:]:
+            non_equi_exprs = ConjunctionOpExpression(
+                non_equi_exprs.empty_data,
+                non_equi_exprs,
+                java_expr_to_python_expr(e, planJoinOrCross),
+                "__and__",
+            )
+        planFilter = LogicalFilter(empty_join_out, planJoinOrCross, non_equi_exprs)
+        return planFilter
 
 
 def java_rtjf_to_python_rtjf(ctx, java_plan):

--- a/BodoSQL/bodosql/tests/test_join.py
+++ b/BodoSQL/bodosql/tests/test_join.py
@@ -593,7 +593,6 @@ def test_join_invalid_condition(memory_leak_check):
 @pytest.mark.skipif(
     "AGENT_NAME" in os.environ, reason="Assertion fails on Azure only [BSE-3585]"
 )
-@pytest.mark.bodosql_cpp
 def test_join_broadcast_hint(memory_leak_check, capfd):
     """
     Test that providing a broadcast hint for a join provides

--- a/BodoSQL/bodosql/tests/test_join.py
+++ b/BodoSQL/bodosql/tests/test_join.py
@@ -70,6 +70,7 @@ def test_join(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_multitable_join_cond(join_dataframes, spark_info, memory_leak_check):
     """tests selecting from multiple tables based upon a where clause"""
     if any(
@@ -88,6 +89,7 @@ def test_multitable_join_cond(join_dataframes, spark_info, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_join_alias(join_dataframes, spark_info, memory_leak_check):
     """
     Test that checks that joining two tables that share a column name
@@ -139,6 +141,7 @@ def test_natural_join(join_dataframes, spark_info, join_type, memory_leak_check)
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_and_join(join_dataframes, spark_info, memory_leak_check):
     """
     Query that demonstrates that a join with an AND expression
@@ -161,6 +164,7 @@ def test_and_join(join_dataframes, spark_info, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_or_join(join_dataframes, spark_info, memory_leak_check):
     """
     Query that demonstrates that a join with an OR expression and common conds
@@ -231,6 +235,7 @@ def test_join_different_size_tables(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_nested_join(join_dataframes, spark_info, memory_leak_check):
     """tests that nested joins work properly"""
 
@@ -266,6 +271,7 @@ def test_nested_join(join_dataframes, spark_info, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_nested_or_join(join_dataframes, spark_info, memory_leak_check):
     """tests that nested joins work with implicit joins using 'or'"""
 
@@ -356,6 +362,7 @@ def test_multi_key_join_types(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_trimmed_multi_key_cond_inner_join(
     join_dataframes, spark_info, memory_leak_check
 ):
@@ -418,6 +425,7 @@ def test_nonascii_in_implicit_join(spark_info, memory_leak_check):
     check_query(query, ctx, spark_info, check_names=False, check_dtype=False)
 
 
+@pytest.mark.bodosql_cpp
 def test_tz_aware_join(representative_tz, memory_leak_check):
     """
     Test join, including non-equality, on tz_aware data
@@ -500,6 +508,7 @@ def test_join_pow(spark_info, join_type, memory_leak_check):
     check_query(query2, ctx, spark_info, check_dtype=False, check_names=False)
 
 
+@pytest.mark.bodosql_cpp
 def test_interval_join_compilation(memory_leak_check):
     """
     Tests that the Interval Join detection code correctly determines that
@@ -541,6 +550,7 @@ def test_interval_join_compilation(memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_join_div(spark_info, join_type, memory_leak_check):
     """
     Make sure div operation works inside join conditions
@@ -583,6 +593,7 @@ def test_join_invalid_condition(memory_leak_check):
 @pytest.mark.skipif(
     "AGENT_NAME" in os.environ, reason="Assertion fails on Azure only [BSE-3585]"
 )
+@pytest.mark.bodosql_cpp
 def test_join_broadcast_hint(memory_leak_check, capfd):
     """
     Test that providing a broadcast hint for a join provides

--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -952,16 +952,41 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalCrossProduct& op) {
         this->active_pipeline->getPrevOpOutputSchema();
 
 #ifdef USE_CUDF
-    std::shared_ptr<PhysicalGPUJoin> physical_join;
-    physical_join = std::make_shared<PhysicalGPUJoin>(op, build_table_schema,
-                                                      probe_table_schema);
+    std::variant<std::shared_ptr<PhysicalJoin>,
+                 std::shared_ptr<PhysicalGPUJoin>>
+        physical_join;
+    if (node_run_on_gpu(op)) {
+        physical_join = std::make_shared<PhysicalGPUJoin>(
+            op, build_table_schema, probe_table_schema);
+    } else {
+        physical_join = std::make_shared<PhysicalJoin>(op, build_table_schema,
+                                                       probe_table_schema);
+    }
 #else   // USE_CUDF
     auto physical_join = std::make_shared<PhysicalJoin>(op, build_table_schema,
                                                         probe_table_schema);
 #endif  // USE_CUDF
-    std::shared_ptr<Pipeline> done_pipeline =
-        rhs_builder.active_pipeline->Build(physical_join);
+
+    std::shared_ptr<Pipeline> done_pipeline;
+#ifdef USE_CUDF
+    std::visit(
+        [&](auto& vop) {
+            done_pipeline = rhs_builder.active_pipeline->Build(vop);
+        },
+        physical_join);
+#else   // USE_CUDF
+    done_pipeline = rhs_builder.active_pipeline->Build(physical_join);
+#endif  // USE_CUDF
+    if (!done_pipeline) {
+        throw std::runtime_error("done_pipeline null in CrossProduct.");
+    }
+
+#ifdef USE_CUDF
+    std::visit([&](auto& vop) { this->active_pipeline->AddOperator(vop); },
+               physical_join);
+#else   // USE_CUDF
     this->active_pipeline->AddOperator(physical_join);
+#endif  // USE_CUDF
     // Build side pipeline runs before probe side.
     this->active_pipeline->addRunBefore(done_pipeline);
 }

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1173,6 +1173,17 @@ std::shared_ptr<arrow::Array> get_py_isin_arg_as_arrow_array(PyObject *args) {
     return result.ValueOrDie();
 }
 
+size_t col_ref_map_lookup(
+    std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> &col_ref_map,
+    duckdb::idx_t table, duckdb::idx_t column) {
+    auto iter = col_ref_map.find({table, column});
+    if (iter == col_ref_map.end()) {
+        throw std::runtime_error(
+            "Did not find table and column indices in col_ref_map");
+    }
+    return iter->second;
+}
+
 #ifdef USE_CUDF
 
 template std::tuple<int64_t, int64_t, int64_t>

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -431,6 +431,18 @@ std::tuple<int64_t, int64_t, int64_t> get_py_slice_args(PyObject *args);
  */
 std::shared_ptr<arrow::Array> get_py_isin_arg_as_arrow_array(PyObject *args);
 
+/**
+ * @brief Lookup entry in col_ref_map.  Raise exception if not found.
+ *
+ * @param table the bound table index
+ * @param column the bound column index within that table
+ * @return size_t the raw column index for that table and column in the internal
+ * table
+ */
+size_t col_ref_map_lookup(
+    std::map<std::pair<duckdb::idx_t, duckdb::idx_t>, size_t> &col_ref_map,
+    duckdb::idx_t table, duckdb::idx_t column);
+
 #ifdef USE_CUDF
 
 #include <cstdint>

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -549,8 +549,8 @@ std::shared_ptr<PhysicalExpression> buildPhysicalExprTree(
             // type.
             auto& bce = expr.Cast<duckdb::BoundColumnRefExpression>();
             duckdb::ColumnBinding binding = bce.binding;
-            size_t col_idx =
-                col_ref_map[{binding.table_index, binding.column_index}];
+            size_t col_idx = col_ref_map_lookup(
+                col_ref_map, binding.table_index, binding.column_index);
             return std::static_pointer_cast<PhysicalExpression>(
                 std::make_shared<PhysicalColumnRefExpression>(col_idx, binding,
                                                               bce.GetName()));

--- a/bodo/pandas/physical/gpu_expression.cpp
+++ b/bodo/pandas/physical/gpu_expression.cpp
@@ -223,8 +223,8 @@ std::shared_ptr<PhysicalGPUExpression> buildPhysicalGPUExprTree(
             // type.
             auto& bce = expr.Cast<duckdb::BoundColumnRefExpression>();
             duckdb::ColumnBinding binding = bce.binding;
-            size_t col_idx =
-                col_ref_map[{binding.table_index, binding.column_index}];
+            size_t col_idx = col_ref_map_lookup(
+                col_ref_map, binding.table_index, binding.column_index);
             return std::static_pointer_cast<PhysicalGPUExpression>(
                 std::make_shared<PhysicalGPUColumnRefExpression>(
                     col_idx, bce.GetName()));

--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -188,11 +188,12 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
                 cond.GetLHS().Cast<duckdb::BoundColumnRefExpression>();
             auto& right_bce =
                 cond.GetRHS().Cast<duckdb::BoundColumnRefExpression>();
-            probe_keys.push_back(left_col_ref_map[{
-                left_bce.binding.table_index, left_bce.binding.column_index}]);
-            build_keys.push_back(
-                right_col_ref_map[{right_bce.binding.table_index,
-                                   right_bce.binding.column_index}]);
+            probe_keys.push_back(col_ref_map_lookup(
+                left_col_ref_map, left_bce.binding.table_index,
+                left_bce.binding.column_index));
+            build_keys.push_back(col_ref_map_lookup(
+                right_col_ref_map, right_bce.binding.table_index,
+                right_bce.binding.column_index));
         }
 
         // Get the indices of kept build columns

--- a/bodo/pandas/physical/gpu_sort.h
+++ b/bodo/pandas/physical/gpu_sort.h
@@ -108,8 +108,9 @@ class PhysicalGPUSortOperator : public PhysicalGPUSource,
             }
             auto& bce =
                 order.expression->Cast<duckdb::BoundColumnRefExpression>();
-            key_indices.push_back(static_cast<cudf::size_type>(col_ref_map[{
-                bce.binding.table_index, bce.binding.column_index}]));
+            key_indices.push_back(static_cast<cudf::size_type>(
+                col_ref_map_lookup(col_ref_map, bce.binding.table_index,
+                                   bce.binding.column_index)));
         }
 
         this->cuda_sort_state = std::make_unique<CudaSortState>(

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -91,12 +91,12 @@ class PhysicalJoin : public PhysicalProcessBatch, public PhysicalSink {
                     cond.GetLHS().Cast<duckdb::BoundColumnRefExpression>();
                 auto& right_bce =
                     cond.GetRHS().Cast<duckdb::BoundColumnRefExpression>();
-                left_keys.push_back(
-                    left_col_ref_map[{left_bce.binding.table_index,
-                                      left_bce.binding.column_index}]);
-                right_keys.push_back(
-                    right_col_ref_map[{right_bce.binding.table_index,
-                                       right_bce.binding.column_index}]);
+                left_keys.push_back(col_ref_map_lookup(
+                    left_col_ref_map, left_bce.binding.table_index,
+                    left_bce.binding.column_index));
+                right_keys.push_back(col_ref_map_lookup(
+                    right_col_ref_map, right_bce.binding.table_index,
+                    right_bce.binding.column_index));
             } else {
                 has_non_equi_cond = true;
             }

--- a/bodo/pandas/physical/project_utils.h
+++ b/bodo/pandas/physical/project_utils.h
@@ -60,8 +60,9 @@ inline std::shared_ptr<bodo::Schema> getProjectionOutputSchema(
 
         if (expr->type == duckdb::ExpressionType::BOUND_COLUMN_REF) {
             auto& colref = expr->Cast<duckdb::BoundColumnRefExpression>();
-            size_t col_idx = col_ref_map[{colref.binding.table_index,
-                                          colref.binding.column_index}];
+            size_t col_idx =
+                col_ref_map_lookup(col_ref_map, colref.binding.table_index,
+                                   colref.binding.column_index);
             std::unique_ptr<bodo::DataType> col_type =
                 input_schema->column_types[col_idx]->copy();
             output_schema->append_column(std::move(col_type));

--- a/bodo/pandas/physical/sort.h
+++ b/bodo/pandas/physical/sort.h
@@ -95,8 +95,9 @@ class PhysicalSort : public PhysicalSource, public PhysicalSink {
             }
             auto& bce =
                 order.expression->Cast<duckdb::BoundColumnRefExpression>();
-            keys.push_back(col_ref_map[{bce.binding.table_index,
-                                        bce.binding.column_index}]);
+            keys.push_back(col_ref_map_lookup(col_ref_map,
+                                              bce.binding.table_index,
+                                              bce.binding.column_index));
         }
 
         // Establish table reordering so key are at beginning.


### PR DESCRIPTION
## Changes included in this PR

Add support for non-equi join in bodosql cpp backend by building a filter on top of the join/crossproduct.  Add flags for join tests in bodosql that now work.  Changed col_ref_map lookups to use a function that throws if the matching table and column indices are not found.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.