### PR TITLE
Add suffix to query profile directory to avoid collisions

### DIFF
--- a/bodo/libs/_query_profile_collector.cpp
+++ b/bodo/libs/_query_profile_collector.cpp
@@ -82,15 +82,30 @@ void QueryProfileCollector::Init() {
             std::chrono::duration_cast<std::chrono::minutes>(seconds - hour);
         auto second = std::chrono::duration_cast<std::chrono::seconds>(
             seconds - hour - minute);
-        output_dir = fmt::format("{}/run_{}{:02}{:02}_{:02}{:02}{:02}",
-                                 parent_dir, year, month, day, hour.count(),
-                                 minute.count(), second.count());
-        int res = makedir(output_dir.data(), 0700);
-        if (res != 0) {
-            // TODO XXX Needs error synchronization!
-            throw std::runtime_error(
-                fmt::format("Failed to create output directory {}: {}",
-                            output_dir, strerror(errno)));
+        std::string output_dir_base = fmt::format(
+            "{}/run_{}{:02}{:02}_{:02}{:02}{:02}", parent_dir, year, month, day,
+            hour.count(), minute.count(), second.count());
+
+        int run_suffix = 0;
+        while (true) {
+            std::string candidate =
+                run_suffix == 0
+                    ? output_dir_base
+                    : output_dir_base + "_" + std::to_string(run_suffix);
+
+            if (mkdir(candidate.c_str(), 0700) == 0) {
+                output_dir = candidate;
+                break;
+            }
+
+            if (errno != EEXIST) {
+                // TODO XXX Needs error synchronization!
+                throw std::runtime_error(
+                    fmt::format("Failed to create output directory {}: {}",
+                                candidate, strerror(errno)));
+            }
+
+            run_suffix++;
         }
     }
     // Broadcast the output_dir length to all ranks


### PR DESCRIPTION
## Changes included in this PR

When queries are executed in rapid succession, such as a simple test script, query profile directories with the same path can be created leading to hangs. 

This PR avoids this by adding a suffix to the end of subsequent query profile directories with the same name. 

This directory name will be generated by rank 0 and broadcasted out.

## Testing strategy
CI, 
Used small test script on the platform:
``` py
import numpy as np

import bodo.pandas as pd

df = pd.DataFrame({"A": np.arange(1000), "B": np.random.rand(1000)})
df2 = pd.DataFrame({"A": np.arange(900, 10000), "C": np.random.rand(9100)})

print(df.merge(df2))
```

Which hangs on main but runs on my branch. 

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.