### PR TITLE
Run unimportant BodoSQL test cases less frequently

### DIFF
--- a/BodoSQL/bodosql/tests/conftest.py
+++ b/BodoSQL/bodosql/tests/conftest.py
@@ -132,33 +132,33 @@ def zeros_df():
 
 @pytest.fixture(
     params=[
-        pytest.param(np.int8, marks=pytest.mark.slow),
+        pytest.param(np.int8, marks=pytest.mark.weekly),
         pytest.param(
             np.uint8,
             marks=[
-                pytest.mark.slow,
+                pytest.mark.weekly,
                 pytest.mark.skipif(
                     sys.platform == "win32",
                     reason="Spark doesn't support unsigned int on Windows.",
                 ),
             ],
         ),
-        pytest.param(np.int16, marks=pytest.mark.slow),
+        pytest.param(np.int16, marks=pytest.mark.weekly),
         pytest.param(
             np.uint16,
             marks=[
-                pytest.mark.slow,
+                pytest.mark.weekly,
                 pytest.mark.skipif(
                     sys.platform == "win32",
                     reason="Spark doesn't support unsigned int on Windows.",
                 ),
             ],
         ),
-        pytest.param(np.int32, marks=pytest.mark.slow),
+        pytest.param(np.int32, marks=pytest.mark.weekly),
         pytest.param(
             np.uint32,
             marks=[
-                pytest.mark.slow,
+                pytest.mark.weekly,
                 pytest.mark.skipif(
                     sys.platform == "win32",
                     reason="Spark doesn't support unsigned int on Windows.",
@@ -169,14 +169,14 @@ def zeros_df():
         pytest.param(
             np.uint64,
             marks=[
-                pytest.mark.slow,
+                pytest.mark.weekly,
                 pytest.mark.skipif(
                     sys.platform == "win32",
                     reason="Spark doesn't support unsigned int on Windows.",
                 ),
             ],
         ),
-        pytest.param(np.float32, marks=pytest.mark.slow),
+        pytest.param(np.float32, marks=pytest.mark.weekly),
         np.float64,
     ]
 )
@@ -357,7 +357,7 @@ def simple_join_fixture(request):
                     dtype=np.uint64,
                 )
             },
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             {
@@ -369,7 +369,7 @@ def simple_join_fixture(request):
                     dtype=np.int64,
                 )
             },
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             {
@@ -381,7 +381,7 @@ def simple_join_fixture(request):
                     dtype=np.uint32,
                 )
             },
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             {
@@ -393,7 +393,7 @@ def simple_join_fixture(request):
                     dtype=np.int32,
                 )
             },
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
     ]
 )
@@ -607,9 +607,9 @@ def bodosql_boolean_types(request):
 @pytest.fixture(
     params=[
         "2011-01-01",
-        pytest.param("1971-02-02", marks=pytest.mark.slow),
+        pytest.param("1971-02-02", marks=pytest.mark.weekly),
         "2021-03-03",
-        pytest.param("2004-12-07", marks=pytest.mark.slow),
+        pytest.param("2004-12-07", marks=pytest.mark.weekly),
         "2007-01-01 03:30:00",
     ]
 )
@@ -641,7 +641,7 @@ def timestamp_literal_strings(request):
                     }
                 )
             },
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             {
@@ -653,7 +653,7 @@ def timestamp_literal_strings(request):
                     }
                 )
             },
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
     ]
 )
@@ -682,7 +682,7 @@ def bodosql_string_types(request):
                     }
                 )
             },
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
     ]
 )
@@ -728,14 +728,14 @@ def bodosql_date_string_types(request):
 
 @pytest.fixture(
     params=[
-        pytest.param("Int8", marks=pytest.mark.slow),
-        pytest.param("UInt8", marks=pytest.mark.slow),
-        pytest.param("Int16", marks=pytest.mark.slow),
-        pytest.param("UInt16", marks=pytest.mark.slow),
-        pytest.param("Int32", marks=pytest.mark.slow),
-        pytest.param("UInt32", marks=pytest.mark.slow),
+        pytest.param("Int8", marks=pytest.mark.weekly),
+        pytest.param("UInt8", marks=pytest.mark.weekly),
+        pytest.param("Int16", marks=pytest.mark.weekly),
+        pytest.param("UInt16", marks=pytest.mark.weekly),
+        pytest.param("Int32", marks=pytest.mark.weekly),
+        pytest.param("UInt32", marks=pytest.mark.weekly),
         "Int64",
-        pytest.param("UInt64", marks=pytest.mark.slow),
+        pytest.param("UInt64", marks=pytest.mark.weekly),
     ]
 )
 def bodosql_nullable_numeric_types(request):
@@ -1082,13 +1082,13 @@ def numeric_agg_builtin_funcs(request):
 
 @pytest.fixture(
     params=[
-        pytest.param("TINYINT", marks=pytest.mark.slow),
-        pytest.param("SMALLINT", marks=pytest.mark.slow),
+        pytest.param("TINYINT", marks=pytest.mark.weekly),
+        pytest.param("SMALLINT", marks=pytest.mark.weekly),
         "INTEGER",
-        pytest.param("BIGINT", marks=pytest.mark.slow),
+        pytest.param("BIGINT", marks=pytest.mark.weekly),
         "FLOAT",
-        pytest.param("DOUBLE", marks=pytest.mark.slow),
-        pytest.param("DECIMAL", marks=pytest.mark.slow),
+        pytest.param("DOUBLE", marks=pytest.mark.weekly),
+        pytest.param("DECIMAL", marks=pytest.mark.weekly),
     ]
 )
 def sql_numeric_typestrings(request):
@@ -1121,16 +1121,16 @@ def sql_datetime_typestrings(request):
 @pytest.fixture(
     params=[
         0,
-        pytest.param(1, marks=pytest.mark.slow),
-        pytest.param(-1, marks=pytest.mark.slow),
-        pytest.param(0.0, marks=pytest.mark.slow),
-        pytest.param(1.0, marks=pytest.mark.slow),
+        pytest.param(1, marks=pytest.mark.weekly),
+        pytest.param(-1, marks=pytest.mark.weekly),
+        pytest.param(0.0, marks=pytest.mark.weekly),
+        pytest.param(1.0, marks=pytest.mark.weekly),
         -1.0,
-        pytest.param(2, marks=pytest.mark.slow),
+        pytest.param(2, marks=pytest.mark.weekly),
         0.001,
-        pytest.param(4, marks=pytest.mark.slow),
+        pytest.param(4, marks=pytest.mark.weekly),
         -7,
-        pytest.param(11, marks=pytest.mark.slow),
+        pytest.param(11, marks=pytest.mark.weekly),
     ]
 )
 def numeric_values(request):
@@ -1925,10 +1925,10 @@ def timeadd_dataframe():
 @pytest.fixture(
     params=[
         "HOUR",
-        pytest.param("MINUTE", marks=pytest.mark.slow),
+        pytest.param("MINUTE", marks=pytest.mark.weekly),
         "SECOND",
         "MILLISECOND",
-        pytest.param("MICROSECOND", marks=pytest.mark.slow),
+        pytest.param("MICROSECOND", marks=pytest.mark.weekly),
         "NANOSECOND",
     ]
 )

--- a/BodoSQL/bodosql/tests/test_comparison.py
+++ b/BodoSQL/bodosql/tests/test_comparison.py
@@ -31,23 +31,34 @@ def between_clause(request):
 @pytest.fixture(
     params=[
         pytest.param(
-            ([None, 1, 2, 4, 8, 127, 128, 255, 0], pd.UInt8Dtype()), id="uint8"
+            ([None, 1, 2, 4, 8, 127, 128, 255, 0], pd.UInt8Dtype()),
+            id="uint8",
+            marks=pytest.mark.weekly,
         ),
-        pytest.param(([None, 1, 2, 4, 8, 127, -128, -1, 0], pd.Int8Dtype()), id="int8"),
+        pytest.param(
+            ([None, 1, 2, 4, 8, 127, -128, -1, 0], pd.Int8Dtype()),
+            id="int8",
+            marks=pytest.mark.weekly,
+        ),
         pytest.param(
             ([None, 1, 2, 65535, 32767, 127, 128, 255, 0], pd.UInt16Dtype()),
             id="uint16",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
-            ([None, 1, 2, -32768, 32767, 127, -128, -1, 0], pd.Int16Dtype()), id="int16"
+            ([None, 1, 2, -32768, 32767, 127, -128, -1, 0], pd.Int16Dtype()),
+            id="int16",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             ([None, 1, 7, 4, 8, 4294967295, 1234567890, 255, 0], pd.UInt32Dtype()),
             id="uint32",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             ([None, 1, 2, 13, 8, 2147483647, -2147483647, -1, 0], pd.Int32Dtype()),
             id="int32",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (
@@ -65,6 +76,7 @@ def between_clause(request):
                 pd.UInt64Dtype(),
             ),
             id="uint64",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (

--- a/BodoSQL/bodosql/tests/test_decimal.py
+++ b/BodoSQL/bodosql/tests/test_decimal.py
@@ -534,6 +534,7 @@ def test_decimal_int_multiply_vector(decimal_data, memory_leak_check):
                 type=pa.decimal128(38, 2),
             ),
             id="int8",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.array([1, 20, 30, 0, 50], dtype=pd.Int16Dtype()),
@@ -542,6 +543,7 @@ def test_decimal_int_multiply_vector(decimal_data, memory_leak_check):
                 type=pa.decimal128(38, 2),
             ),
             id="int16",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.array([1, -125, 300, 0, 131072], dtype=pd.Int32Dtype()),
@@ -550,6 +552,7 @@ def test_decimal_int_multiply_vector(decimal_data, memory_leak_check):
                 type=pa.decimal128(38, 2),
             ),
             id="int32",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.array([1, 2, 3, 0, 987654321], dtype=pd.Int64Dtype()),
@@ -566,6 +569,7 @@ def test_decimal_int_multiply_vector(decimal_data, memory_leak_check):
                 type=pa.decimal128(38, 2),
             ),
             id="uint8",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.array([1, 20, 300, 0, 5000], dtype=pd.UInt16Dtype()),
@@ -574,6 +578,7 @@ def test_decimal_int_multiply_vector(decimal_data, memory_leak_check):
                 type=pa.decimal128(38, 2),
             ),
             id="uint16",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.array([1, 21, 321, 0, 54321], dtype=pd.UInt32Dtype()),
@@ -582,6 +587,7 @@ def test_decimal_int_multiply_vector(decimal_data, memory_leak_check):
                 type=pa.decimal128(38, 2),
             ),
             id="uint32",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.array([1, 54321, 654321, 0, 7654321], dtype=pd.UInt64Dtype()),
@@ -1576,6 +1582,7 @@ def test_decimal_subtraction(df, expr, answer, memory_leak_check):
                 ],
             ),
             id="array-negative-round-case",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.DataFrame(
@@ -1603,6 +1610,7 @@ def test_decimal_subtraction(df, expr, answer, memory_leak_check):
                 ],
             ),
             id="array-round-negative_scale-case",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.DataFrame(
@@ -1630,6 +1638,7 @@ def test_decimal_subtraction(df, expr, answer, memory_leak_check):
                 ],
             ),
             id="array-negative-round-negative_scale-case",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.DataFrame(
@@ -1657,6 +1666,7 @@ def test_decimal_subtraction(df, expr, answer, memory_leak_check):
                 ],
             ),
             id="array-no_change-case",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.DataFrame(
@@ -1684,6 +1694,7 @@ def test_decimal_subtraction(df, expr, answer, memory_leak_check):
                 ],
             ),
             id="array-round-propagate-case",
+            marks=pytest.mark.slow,
         ),
     ],
 )
@@ -3111,6 +3122,7 @@ def test_decimal_median(df, expected, spark_info, memory_leak_check):
                 }
             ),
             id="twenty-row-group",
+            marks=pytest.mark.weekly,
         ),
         # 15-row group
         pytest.param(
@@ -3131,6 +3143,7 @@ def test_decimal_median(df, expected, spark_info, memory_leak_check):
                 }
             ),
             id="fifteen-row-group",
+            marks=pytest.mark.weekly,
         ),
         # 17-row group
         pytest.param(
@@ -3151,6 +3164,7 @@ def test_decimal_median(df, expected, spark_info, memory_leak_check):
                 }
             ),
             id="seventeen-row-group",
+            marks=pytest.mark.weekly,
         ),
         # Large numbers
         pytest.param(
@@ -3191,6 +3205,7 @@ def test_decimal_median(df, expected, spark_info, memory_leak_check):
                 }
             ),
             id="exact-first",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.DataFrame(
@@ -3229,6 +3244,7 @@ def test_decimal_median(df, expected, spark_info, memory_leak_check):
                 }
             ),
             id="exact-last",
+            marks=pytest.mark.slow,
         ),
         # Multiple groups
         pytest.param(
@@ -3379,6 +3395,7 @@ def test_decimal_percentile_cont(
                 }
             ),
             id="fifteen-row-group",
+            marks=pytest.mark.slow,
         ),
         # Multiple groups
         pytest.param(
@@ -3471,6 +3488,7 @@ def test_decimal_percentile_disc(
             ),
             "too large for MEDIAN operation",
             id="overflow_2",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.DataFrame(

--- a/BodoSQL/bodosql/tests/test_decimal_array.py
+++ b/BodoSQL/bodosql/tests/test_decimal_array.py
@@ -399,13 +399,18 @@ def test_decimal_arr_nbytes(memory_leak_check):
     "value",
     [
         # int32 array
-        pd.array([1, -1, 3, 4, -2, 0, None, 4], "Int32"),
+        pytest.param(
+            pd.array([1, -1, 3, 4, -2, 0, None, 4], "Int32"), marks=pytest.mark.weekly
+        ),
         # int64 array
         pd.array([5, -1, 0, None, -2, 10, None, 12], "Int64"),
         # numpy array
         np.array([5, -21131, 0, 7, -2, 10, 12340, 12]),
         # float32 array
-        pd.array([5.1, -1.1, 0.54, None, -2.1, 101.1, None, 1.234], "Float32"),
+        pytest.param(
+            pd.array([5.1, -1.1, 0.54, None, -2.1, 101.1, None, 1.234], "Float32"),
+            marks=pytest.mark.weekly,
+        ),
         # float64 array
         pd.array(
             [1.111, -1.12, 1000000.54, None, -2000.1, -101.1, None, 1.234], "Float64"
@@ -424,11 +429,11 @@ def test_decimal_arr_nbytes(memory_leak_check):
             ]
         ),
         # int32 scalar
-        np.int32(1),
+        pytest.param(np.int32(1), marks=pytest.mark.weekly),
         # int64 scalar
         -1,
         # float32 scalar
-        np.float32(1.4),
+        pytest.param(np.float32(1.4), marks=pytest.mark.weekly),
         # float64 scalar
         -0.4,
         # decimal scalar
@@ -3336,6 +3341,7 @@ def test_round_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 2),
             ),
             id="scalar-positive_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(
@@ -3372,6 +3378,7 @@ def test_round_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 0),
             ),
             id="scalar-negative_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(
@@ -3408,6 +3415,7 @@ def test_round_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 0),
             ),
             id="scalar-zero_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         # Array tests
         pytest.param(
@@ -3461,6 +3469,7 @@ def test_round_decimal_overflow(arg, round_scale):
                 dtype=pd.ArrowDtype(pa.decimal128(38, 0)),
             ),
             id="array-stress_test",
+            marks=pytest.mark.slow,
         ),
     ],
 )
@@ -3563,6 +3572,7 @@ def test_ceil_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 2),
             ),
             id="scalar-positive_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(
@@ -3599,6 +3609,7 @@ def test_ceil_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 0),
             ),
             id="scalar-negative_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(
@@ -3635,6 +3646,7 @@ def test_ceil_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 0),
             ),
             id="scalar-zero_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         # Array tests
         pytest.param(
@@ -3688,6 +3700,7 @@ def test_ceil_decimal_overflow(arg, round_scale):
                 dtype=pd.ArrowDtype(pa.decimal128(38, 0)),
             ),
             id="array-stress_test",
+            marks=pytest.mark.slow,
         ),
     ],
 )
@@ -3792,6 +3805,7 @@ def test_floor_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 2),
             ),
             id="scalar-positive_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(
@@ -3828,6 +3842,7 @@ def test_floor_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 0),
             ),
             id="scalar-negative_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(
@@ -3864,6 +3879,7 @@ def test_floor_decimal_overflow(arg, round_scale):
                 pa.decimal128(21, 0),
             ),
             id="scalar-zero_scale-close_to_zero",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(
@@ -3929,6 +3945,7 @@ def test_floor_decimal_overflow(arg, round_scale):
                 dtype=pd.ArrowDtype(pa.decimal128(38, 0)),
             ),
             id="array-stress_test",
+            marks=pytest.mark.slow,
         ),
     ],
 )
@@ -4798,6 +4815,7 @@ def test_decimal_array_float_division(arg1, arg2, expected, memory_leak_check):
                 dtype=pd.ArrowDtype(pa.decimal128(22, 2)),
             ),
             id="array-decimal_first",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(Decimal("1.5"), pa.decimal128(38, 2)),
@@ -4893,6 +4911,7 @@ def test_decimal_int_multiplication(arg1, arg2, expected):
                 dtype=pd.ArrowDtype(pa.decimal128(22, 3)),
             ),
             id="array-decimal_first",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(Decimal("1.5"), pa.decimal128(38, 2)),
@@ -4988,6 +5007,7 @@ def test_decimal_int_division(arg1, arg2, expected):
                 dtype=pd.ArrowDtype(pa.decimal128(22, 3)),
             ),
             id="array-decimal_first",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(Decimal("3.25"), pa.decimal128(38, 2)),
@@ -5085,6 +5105,7 @@ def test_decimal_int_addition(arg1, arg2, expected):
                 dtype=pd.ArrowDtype(pa.decimal128(22, 3)),
             ),
             id="array-decimal_first",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pa.scalar(Decimal("3.25"), pa.decimal128(38, 2)),
@@ -5290,6 +5311,7 @@ def test_decimal_int_subtraction(arg1, arg2, expected):
                 dtype=pd.Float64Dtype(),
             ),
             id="max_values",
+            marks=pytest.mark.weekly,
         ),
     ],
 )
@@ -5894,6 +5916,7 @@ def test_decimal_median(df, expected, memory_leak_check):
             ),
             "too large for MEDIAN operation",
             id="overflow_2",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.DataFrame(

--- a/BodoSQL/bodosql/tests/test_javascript_udfs.py
+++ b/BodoSQL/bodosql/tests/test_javascript_udfs.py
@@ -722,18 +722,21 @@ def test_javascript_udf_calculate_upc(calculate_upc, memory_leak_check):
             IntegerArrayType(bodo.types.uint8),
             255,
             id="uint8",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             "return 2 ** 16 - 1",
             IntegerArrayType(bodo.types.uint16),
             2**16 - 1,
             id="uint16",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             "return 2 ** 32 -1",
             IntegerArrayType(bodo.types.uint32),
             2**32 - 1,
             id="uint32",
+            marks=pytest.mark.weekly,
         ),
         # This is bigint syntax in javascript, all numerics are double by default which can't represent this value
         pytest.param(
@@ -741,24 +744,28 @@ def test_javascript_udf_calculate_upc(calculate_upc, memory_leak_check):
             IntegerArrayType(bodo.types.uint64),
             2**64 - 1,
             id="uint64",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             "return 2 ** 8 / 2 - 1",
             IntegerArrayType(bodo.types.int8),
             127,
             id="int8",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             "return 2 ** 16 / 2 - 1",
             IntegerArrayType(bodo.types.int16),
             2**16 / 2 - 1,
             id="int16",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             "return 2 ** 32 / 2 - 1",
             IntegerArrayType(bodo.types.int32),
             2**32 / 2 - 1,
             id="int32",
+            marks=pytest.mark.weekly,
         ),
         # This is bigint syntax in javascript, all numerics are double by default which can't represent this value
         pytest.param(
@@ -772,6 +779,7 @@ def test_javascript_udf_calculate_upc(calculate_upc, memory_leak_check):
             IntegerArrayType(bodo.types.float32),
             3.1,
             id="float32",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             # Bigger than a float32 can represent

--- a/BodoSQL/bodosql/tests/test_kernels/test_datetime_array_kernels.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_datetime_array_kernels.py
@@ -1550,56 +1550,142 @@ def test_dayofyear(dates_scalar_vector, memory_leak_check):
     [
         # Basic datetime tests
         pytest.param(datetime.date(2016, 1, 4), (0, 7), (1, 2016), id="datetime-1"),
-        pytest.param(datetime.date(2016, 1, 4), (0, 1), (1, 2016), id="datetime-2"),
-        pytest.param(datetime.date(2016, 1, 4), (1, 7), (2, 2016), id="datetime-3"),
-        pytest.param(datetime.date(2016, 1, 4), (1, 1), (2, 2016), id="datetime-4"),
-        pytest.param(datetime.date(2000, 12, 31), (0, 7), (1, 2001), id="datetime-5"),
-        pytest.param(datetime.date(2000, 12, 31), (0, 1), (52, 2000), id="datetime-6"),
-        pytest.param(datetime.date(2000, 12, 31), (1, 7), (54, 2000), id="datetime-7"),
-        pytest.param(datetime.date(2000, 12, 31), (1, 1), (53, 2000), id="datetime-8"),
+        pytest.param(
+            datetime.date(2016, 1, 4),
+            (0, 1),
+            (1, 2016),
+            id="datetime-2",
+            marks=pytest.mark.weekly,
+        ),
+        pytest.param(
+            datetime.date(2016, 1, 4),
+            (1, 7),
+            (2, 2016),
+            id="datetime-3",
+            marks=pytest.mark.slow,
+        ),
+        pytest.param(
+            datetime.date(2016, 1, 4),
+            (1, 1),
+            (2, 2016),
+            id="datetime-4",
+            marks=pytest.mark.weekly,
+        ),
+        pytest.param(
+            datetime.date(2000, 12, 31),
+            (0, 7),
+            (1, 2001),
+            id="datetime-5",
+            marks=pytest.mark.slow,
+        ),
+        pytest.param(
+            datetime.date(2000, 12, 31),
+            (0, 1),
+            (52, 2000),
+            id="datetime-6",
+            marks=pytest.mark.slow,
+        ),
+        pytest.param(
+            datetime.date(2000, 12, 31),
+            (1, 7),
+            (54, 2000),
+            id="datetime-7",
+            marks=pytest.mark.weekly,
+        ),
+        pytest.param(
+            datetime.date(2000, 12, 31),
+            (1, 1),
+            (53, 2000),
+            id="datetime-8",
+            marks=pytest.mark.weekly,
+        ),
         # Basic timestamp tests
         pytest.param(
             pd.Timestamp("2012-01-01T23"), (1, 1), (1, 2012), id="timestamp-1"
         ),
         pytest.param(
-            pd.Timestamp("2012-01-01T23"), (1, 7), (1, 2012), id="timestamp-2"
+            pd.Timestamp("2012-01-01T23"),
+            (1, 7),
+            (1, 2012),
+            id="timestamp-2",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
-            pd.Timestamp("2012-01-01T23"), (0, 1), (52, 2011), id="timestamp-3"
+            pd.Timestamp("2012-01-01T23"),
+            (0, 1),
+            (52, 2011),
+            id="timestamp-3",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
-            pd.Timestamp("2012-01-01T23"), (0, 7), (1, 2012), id="timestamp-4"
+            pd.Timestamp("2012-01-01T23"),
+            (0, 7),
+            (1, 2012),
+            id="timestamp-4",
+            marks=pytest.mark.weekly,
         ),
         # Test different start_day parameters with datetime objects
         pytest.param(
             datetime.date(1970, 2, 2), (1, 2), (5, 1970), id="datetime-day-start-2"
         ),
         pytest.param(
-            datetime.date(1970, 2, 2), (1, 3), (5, 1970), id="datetime-day-start-3"
+            datetime.date(1970, 2, 2),
+            (1, 3),
+            (5, 1970),
+            id="datetime-day-start-3",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
-            datetime.date(1970, 2, 2), (1, 4), (5, 1970), id="datetime-day-start-4"
+            datetime.date(1970, 2, 2),
+            (1, 4),
+            (5, 1970),
+            id="datetime-day-start-4",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
-            datetime.date(1970, 2, 2), (1, 5), (6, 1970), id="datetime-day-start-5"
+            datetime.date(1970, 2, 2),
+            (1, 5),
+            (6, 1970),
+            id="datetime-day-start-5",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
-            datetime.date(1970, 2, 2), (1, 6), (6, 1970), id="datetime-day-start-6"
+            datetime.date(1970, 2, 2),
+            (1, 6),
+            (6, 1970),
+            id="datetime-day-start-6",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.Timestamp("2000-12-31"), (0, 2), (52, 2000), id="timestamp-day-start-2"
         ),
         pytest.param(
-            pd.Timestamp("2014-03-01"), (0, 3), (9, 2014), id="timestamp-day-start-3"
+            pd.Timestamp("2014-03-01"),
+            (0, 3),
+            (9, 2014),
+            id="timestamp-day-start-3",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
-            pd.Timestamp("2008-12-31"), (0, 4), (52, 2008), id="timestamp-day-start-4"
+            pd.Timestamp("2008-12-31"),
+            (0, 4),
+            (52, 2008),
+            id="timestamp-day-start-4",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
-            pd.Timestamp("1980-04-01"), (0, 5), (13, 1980), id="timestamp-day-start-5"
+            pd.Timestamp("1980-04-01"),
+            (0, 5),
+            (13, 1980),
+            id="timestamp-day-start-5",
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
-            pd.Timestamp("2004-12-31"), (0, 6), (52, 2004), id="timestamp-day-start-6"
+            pd.Timestamp("2004-12-31"),
+            (0, 6),
+            (52, 2004),
+            id="timestamp-day-start-6",
+            marks=pytest.mark.weekly,
         ),
         # Timezone aware timestamp tests
         pytest.param(
@@ -1613,18 +1699,21 @@ def test_dayofyear(dates_scalar_vector, memory_leak_check):
             (1, 7),
             (9, 2024),
             id="tz-timestamp-2",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.Timestamp("2024-02-28T23", tz="Pacific/Honolulu"),
             (0, 1),
             (9, 2024),
             id="tz-timestamp-3",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             pd.Timestamp("2024-02-28T23", tz="Europe/Stockholm"),
             (0, 7),
             (9, 2024),
             id="tz-timestamp-4",
+            marks=pytest.mark.slow,
         ),
     ],
 )
@@ -4436,26 +4525,11 @@ def test_time_slice_scalars(date_expr, func_args, answer, memory_leak_check):
             2,
             pd.Timestamp("2019-10-29"),
         ),
-        pytest.param(
-            3,
-            pd.Timestamp("2019-10-30"),
-        ),
-        pytest.param(
-            4,
-            pd.Timestamp("2019-10-31"),
-        ),
-        pytest.param(
-            5,
-            pd.Timestamp("2019-10-25"),
-        ),
-        pytest.param(
-            6,
-            pd.Timestamp("2019-10-26"),
-        ),
-        pytest.param(
-            7,
-            pd.Timestamp("2019-10-27"),
-        ),
+        pytest.param(3, pd.Timestamp("2019-10-30"), marks=pytest.mark.weekly),
+        pytest.param(4, pd.Timestamp("2019-10-31"), marks=pytest.mark.weekly),
+        pytest.param(5, pd.Timestamp("2019-10-25"), marks=pytest.mark.slow),
+        pytest.param(6, pd.Timestamp("2019-10-26"), marks=pytest.mark.weekly),
+        pytest.param(7, pd.Timestamp("2019-10-27"), marks=pytest.mark.weekly),
     ],
 )
 def test_time_slice_week_scalars(start_day, answer, memory_leak_check):

--- a/BodoSQL/bodosql/tests/test_kernels/test_lead_lag.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_lead_lag.py
@@ -293,7 +293,10 @@ def test_lead_lag_seq(
 
 @pytest.mark.parametrize(
     "use_default",
-    [pytest.param(True, id="with_default"), pytest.param(False, id="no_default")],
+    [
+        pytest.param(True, id="with_default"),
+        pytest.param(False, id="no_default", marks=pytest.mark.slow),
+    ],
 )
 @pytest.mark.parametrize(
     "shift, answer, pattern_list",

--- a/BodoSQL/bodosql/tests/test_kernels/test_numeric_array_kernels.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_numeric_array_kernels.py
@@ -769,7 +769,7 @@ def test_log(args):
                 )
             ),
             id="vector_uint8",
-            makrks=pytest.mark.weekly,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.Series(

--- a/BodoSQL/bodosql/tests/test_kernels/test_numeric_array_kernels.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_numeric_array_kernels.py
@@ -759,7 +759,7 @@ def test_log(args):
         pytest.param(
             pd.Series(pd.array([0, 1, 32, 127, -126, 125], dtype=pd.Int8Dtype())),
             id="vector_int8",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.Series(
@@ -769,13 +769,14 @@ def test_log(args):
                 )
             ),
             id="vector_uint8",
+            makrks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.Series(
                 pd.array([0, 1, 100, 1000, 32767, 32768, 65535], dtype=pd.UInt16Dtype())
             ),
             id="vector_uint16",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.Series(
@@ -784,7 +785,7 @@ def test_log(args):
                 )
             ),
             id="vector_uint32",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             pd.Series(
@@ -935,15 +936,15 @@ def test_width_bucket_error(args):
     [
         # We only test nullable types at this time because
         # we don't avoid nullable output yet.
-        pytest.param("Int8", marks=pytest.mark.slow),
-        pytest.param("UInt8", marks=pytest.mark.slow),
-        pytest.param("Int16", marks=pytest.mark.slow),
-        pytest.param("UInt16", marks=pytest.mark.slow),
-        pytest.param("Int32", marks=pytest.mark.slow),
-        pytest.param("UInt32", marks=pytest.mark.slow),
+        pytest.param("Int8", marks=pytest.mark.weekly),
+        pytest.param("UInt8", marks=pytest.mark.weekly),
+        pytest.param("Int16", marks=pytest.mark.weekly),
+        pytest.param("UInt16", marks=pytest.mark.weekly),
+        pytest.param("Int32", marks=pytest.mark.weekly),
+        pytest.param("UInt32", marks=pytest.mark.weekly),
         "Int64",
-        pytest.param("UInt64", marks=pytest.mark.slow),
-        pytest.param("Float32", marks=pytest.mark.slow),
+        pytest.param("UInt64", marks=pytest.mark.weekly),
+        pytest.param("Float32", marks=pytest.mark.weekly),
         "Float64",
     ],
 )
@@ -1279,22 +1280,27 @@ def test_negate_option():
 
 
 test_arrs = [
-    pd.Series([0, 0.5, 1, -1, -0.5, 0.3212, -0.78]),
-    pd.Series(
-        [
-            0,
-            1,
-            -1,
-            10000,
-            -10000,
-            20,
-            -139,
-        ]
+    pytest.param(
+        pd.Series([0, 0.5, 1, -1, -0.5, 0.3212, -0.78]), marks=pytest.mark.weekly
     ),
-    pd.Series([0, 1, 2, 3, 4, 5, 20]),
+    pytest.param(
+        pd.Series(
+            [
+                0,
+                1,
+                -1,
+                10000,
+                -10000,
+                20,
+                -139,
+            ]
+        ),
+        marks=pytest.mark.weekly,
+    ),
+    pytest.param(pd.Series([0, 1, 2, 3, 4, 5, 20]), marks=pytest.mark.weekly),
     pd.Series([1, -1, 0.1, -0.1, 1234, np.nan, -4321, 3], dtype=np.float32),
     pd.Series([-1, 0, 1, None, 2], dtype=pd.Int32Dtype()),
-    pd.Series([0, 2, 3, 5, 3], dtype=np.uint32),
+    pytest.param(pd.Series([0, 2, 3, 5, 3], dtype=np.uint32), marks=pytest.mark.weekly),
 ]
 
 single_arg_np_map = {
@@ -1366,9 +1372,11 @@ def test_numeric_single_arg_option(func):
 @pytest.mark.parametrize(
     "arr1",
     [
-        pd.Series([0, 1, 2, 3, 4, 5, 6] * 2),
+        pytest.param(pd.Series([0, 1, 2, 3, 4, 5, 6] * 2), marks=pytest.mark.weekly),
         pd.Series([0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5] * 2),
-        pd.Series([0, -1.5, -2, -3.5, -4.5, -5, -6.5] * 2),
+        pytest.param(
+            pd.Series([0, -1.5, -2, -3.5, -4.5, -5, -6.5] * 2), marks=pytest.mark.weekly
+        ),
         pd.Series([0, -1, -2, -3, -4, -5, -6] * 2, dtype=np.int32),
     ],
 )

--- a/BodoSQL/bodosql/tests/test_kernels/test_snowflake_date_conversion_array_kernels.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_snowflake_date_conversion_array_kernels.py
@@ -344,7 +344,7 @@ def to_date_td_vals(request):
 
 @pytest.fixture(
     params=[
-        pytest.param("try_to_date", id="try_to_date"),
+        pytest.param("try_to_date", id="try_to_date", marks=pytest.mark.slow),
         pytest.param("to_date", id="to_date"),
     ]
 )
@@ -355,7 +355,7 @@ def to_date_kernel(request):
 @pytest.fixture(
     params=[
         pytest.param("to_timestamp", id="to_timestamp"),
-        pytest.param("try_to_timestamp", id="try_to_timestamp"),
+        pytest.param("try_to_timestamp", id="try_to_timestamp", marks=pytest.mark.slow),
     ]
 )
 def to_timestamp_kernel(request):

--- a/BodoSQL/bodosql/tests/test_kernels/test_trig_array_kernels.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_trig_array_kernels.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from _pytest.mark.structures import ParameterSet
 
 import bodosql
 from bodo.tests.utils import check_func, pytest_slow_unless_codegen
@@ -12,17 +13,22 @@ from bodosql.kernels.array_kernel_utils import vectorized_sol
 pytestmark = pytest_slow_unless_codegen
 
 test_arrs = [
-    pd.Series([0, 1, -1, 0.5, -0.5, 0.3212, -0.78]),
-    pd.Series(
-        [
-            0,
-            1,
-            -1,
-            10000,
-            -100000,
-            20,
-            -139,
-        ]
+    pytest.param(
+        pd.Series([0, 1, -1, 0.5, -0.5, 0.3212, -0.78]), marks=pytest.mark.weekly
+    ),
+    pytest.param(
+        pd.Series(
+            [
+                0,
+                1,
+                -1,
+                10000,
+                -100000,
+                20,
+                -139,
+            ]
+        ),
+        marks=pytest.mark.weekly,
     ),
     pd.Series([1, -1, 0.1, -0.1, 1234, pd.NA, -4321, 3], dtype=pd.Float32Dtype()),
     pd.Series([-1, 0, 1, None, 2], dtype=pd.Int32Dtype()),
@@ -106,11 +112,23 @@ def test_trig_single_arg_option(func, memory_leak_check):
 
 @pytest.mark.parametrize(
     "arr1",
-    [pd.Series(list(arr), dtype=arr.dtype) for arr in test_arrs],
+    [
+        pd.Series(list(arr), dtype=arr.dtype)
+        for arr in [
+            (arr_param.values[0] if isinstance(arr_param, ParameterSet) else arr_param)
+            for arr_param in test_arrs
+        ]
+    ],
 )
 @pytest.mark.parametrize(
     "arr0",
-    [pd.Series(list(arr)[::-1], dtype=arr.dtype) for arr in test_arrs],
+    [
+        pd.Series(list(arr)[::-1], dtype=arr.dtype)
+        for arr in [
+            (arr_param.values[0] if isinstance(arr_param, ParameterSet) else arr_param)
+            for arr_param in test_arrs
+        ]
+    ],
 )
 @pytest.mark.parametrize("func", double_arg_np_list)
 def test_trig_double_arg_funcs(arr0, arr1, func, memory_leak_check):

--- a/BodoSQL/bodosql/tests/test_kernels/test_window_agg_kernels.py
+++ b/BodoSQL/bodosql/tests/test_kernels/test_window_agg_kernels.py
@@ -110,7 +110,10 @@ def test_approx_percentile(data, memory_leak_check):
 
 @pytest.mark.parametrize(
     "use_default",
-    [pytest.param(True, id="with_default"), pytest.param(False, id="no_default")],
+    [
+        pytest.param(True, id="with_default"),
+        pytest.param(False, id="no_default", marks=pytest.mark.slow),
+    ],
 )
 @pytest.mark.parametrize(
     "shift, answer",
@@ -262,7 +265,7 @@ def test_null_ignoring_shift(
                 pd.Series([0, 1, 2, 3, 4, 5, 6, 7]),
             ),
             id="int8_sorted_no_null_no_duplicates",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (
@@ -273,7 +276,7 @@ def test_null_ignoring_shift(
                 pd.Series([0, 0, 0, 0, 0, 0, 1, 2, 2, 2, 3]),
             ),
             id="uint16_sorted_with_null_with_duplicates",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (
@@ -281,7 +284,7 @@ def test_null_ignoring_shift(
                 pd.Series([0, 0, 1, 2, 3, 4]),
             ),
             id="int16_sorted_with_null_no_duplicates",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (
@@ -292,7 +295,7 @@ def test_null_ignoring_shift(
                 pd.Series([0, 0, 1, 1, 1, 2, 3, 4, 4, 4, 5, 5]),
             ),
             id="uint32_unsorted_no_null_with_duplicates",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (
@@ -300,7 +303,7 @@ def test_null_ignoring_shift(
                 pd.Series([0, 1, 2, 3, 4]),
             ),
             id="int32_unsorted_no_null_no_duplicates",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (
@@ -318,7 +321,7 @@ def test_null_ignoring_shift(
                 pd.Series([0, 1, 2, 2, 3, 4]),
             ),
             id="int64_unsorted_with_null_no_duplicates",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.weekly,
         ),
         pytest.param(
             (

--- a/BodoSQL/bodosql/tests/test_literals.py
+++ b/BodoSQL/bodosql/tests/test_literals.py
@@ -245,35 +245,58 @@ def test_interval_literals(
 @pytest.fixture(
     params=[
         ("1 day", lambda x: x + pd.DateOffset(days=1)),
-        ("2 month", lambda x: x + pd.DateOffset(months=2)),
-        ("3 year", lambda x: x + pd.DateOffset(years=3)),
-        ("1 quarter", lambda x: x + pd.DateOffset(months=3)),
-        ("10 seconds", lambda x: x + pd.Timedelta(seconds=10)),
+        pytest.param(
+            ("2 month", lambda x: x + pd.DateOffset(months=2)), marks=pytest.mark.weekly
+        ),
+        pytest.param(
+            ("3 year", lambda x: x + pd.DateOffset(years=3)), marks=pytest.mark.weekly
+        ),
+        pytest.param(
+            ("1 quarter", lambda x: x + pd.DateOffset(months=3)),
+            marks=pytest.mark.weekly,
+        ),
+        pytest.param(
+            ("10 seconds", lambda x: x + pd.Timedelta(seconds=10)),
+            marks=pytest.mark.weekly,
+        ),
         ("1 year, 1 quarter, 1 month", lambda x: x + pd.DateOffset(years=1, months=4)),
-        (
-            "1 year, 2 second",
-            lambda x: (x + pd.DateOffset(years=1)) + pd.Timedelta(seconds=2),
-        ),
-        (
-            "1 second, 2 year",
-            lambda x: (x + pd.DateOffset(years=2)) + pd.Timedelta(seconds=1),
-        ),
-        (
-            "1 year, 2 month, 3 second",
-            lambda x: (x + pd.DateOffset(years=1, months=2)) + pd.Timedelta(seconds=3),
-        ),
-        (
-            "1 days, 2 hrs, 3 mins, 4s, 5ms, 6us, 7ns",
-            lambda x: x
-            + pd.Timedelta(
-                days=1,
-                hours=2,
-                minutes=3,
-                seconds=4,
-                milliseconds=5,
-                microseconds=6,
-                nanoseconds=7,
+        pytest.param(
+            (
+                "1 year, 2 second",
+                lambda x: (x + pd.DateOffset(years=1)) + pd.Timedelta(seconds=2),
             ),
+            marks=pytest.mark.weekly,
+        ),
+        pytest.param(
+            (
+                "1 second, 2 year",
+                lambda x: (x + pd.DateOffset(years=2)) + pd.Timedelta(seconds=1),
+            ),
+            marks=pytest.mark.weekly,
+        ),
+        pytest.param(
+            (
+                "1 year, 2 month, 3 second",
+                lambda x: (x + pd.DateOffset(years=1, months=2))
+                + pd.Timedelta(seconds=3),
+            ),
+            marks=pytest.mark.weekly,
+        ),
+        pytest.param(
+            (
+                "1 days, 2 hrs, 3 mins, 4s, 5ms, 6us, 7ns",
+                lambda x: x
+                + pd.Timedelta(
+                    days=1,
+                    hours=2,
+                    minutes=3,
+                    seconds=4,
+                    milliseconds=5,
+                    microseconds=6,
+                    nanoseconds=7,
+                ),
+            ),
+            marks=pytest.mark.weekly,
         ),
         (
             "1 months, 2 days, 3 hrs, 4 mins, 5s, 6ms, 7us, 8ns",

--- a/BodoSQL/bodosql/tests/test_set_ops.py
+++ b/BodoSQL/bodosql/tests/test_set_ops.py
@@ -151,19 +151,27 @@ def make_tz_aware_df(tz):
     "numeric_dfs",
     [
         # Integer
-        {
-            "TABLE1": pd.DataFrame({"A": pd.Series([3, 1, 2, 2, 3, 4], dtype="int32")}),
-            "TABLE2": pd.DataFrame({"B": pd.Series([5, 1, 2, 2], dtype="Int8")}),
-        },
+        pytest.param(
+            {
+                "TABLE1": pd.DataFrame(
+                    {"A": pd.Series([3, 1, 2, 2, 3, 4], dtype="int32")}
+                ),
+                "TABLE2": pd.DataFrame({"B": pd.Series([5, 1, 2, 2], dtype="Int8")}),
+            },
+            marks=pytest.mark.weekly,
+        ),
         # Float
-        {
-            "TABLE1": pd.DataFrame(
-                {"A": pd.Series([3.0, 1.0, 2.0, 2.0, 3.0, 4.0], dtype="float64")}
-            ),
-            "TABLE2": pd.DataFrame(
-                {"B": pd.Series([5.0, 1.0, 2.0, 2.0], dtype="Float32")}
-            ),
-        },
+        pytest.param(
+            {
+                "TABLE1": pd.DataFrame(
+                    {"A": pd.Series([3.0, 1.0, 2.0, 2.0, 3.0, 4.0], dtype="float64")}
+                ),
+                "TABLE2": pd.DataFrame(
+                    {"B": pd.Series([5.0, 1.0, 2.0, 2.0], dtype="Float32")}
+                ),
+            },
+            marks=pytest.mark.weekly,
+        ),
         # Float <-> Integer
         {
             "TABLE1": pd.DataFrame(
@@ -172,58 +180,64 @@ def make_tz_aware_df(tz):
             "TABLE2": pd.DataFrame({"B": pd.Series([5, 1, 2, 2], dtype="Int64")}),
         },
         # Decimal
-        {
-            "TABLE1": pd.DataFrame(
-                {
-                    "A": np.array(
-                        [
-                            Decimal("1.6"),
-                            None,
-                            Decimal("-0.222"),
-                            Decimal("1111.316"),
-                            Decimal("1234.00046"),
-                            Decimal("5.1"),
-                            Decimal("-11131.0056"),
-                            Decimal("0.0"),
-                        ]
-                    )
-                }
-            ),
-            "TABLE2": pd.DataFrame(
-                {
-                    "B": np.array(
-                        [
-                            Decimal("1.6"),
-                            None,
-                            Decimal("200.78"),
-                            Decimal("-0.222"),
-                            Decimal("-15.78"),
-                            Decimal("1111.316"),
-                        ]
-                    )
-                }
-            ),
-        },
+        pytest.param(
+            {
+                "TABLE1": pd.DataFrame(
+                    {
+                        "A": np.array(
+                            [
+                                Decimal("1.6"),
+                                None,
+                                Decimal("-0.222"),
+                                Decimal("1111.316"),
+                                Decimal("1234.00046"),
+                                Decimal("5.1"),
+                                Decimal("-11131.0056"),
+                                Decimal("0.0"),
+                            ]
+                        )
+                    }
+                ),
+                "TABLE2": pd.DataFrame(
+                    {
+                        "B": np.array(
+                            [
+                                Decimal("1.6"),
+                                None,
+                                Decimal("200.78"),
+                                Decimal("-0.222"),
+                                Decimal("-15.78"),
+                                Decimal("1111.316"),
+                            ]
+                        )
+                    }
+                ),
+            },
+            marks=pytest.mark.weekly,
+        ),
         # Decimal <-> Float
-        {
-            "TABLE1": pd.DataFrame(
-                {"A": pd.Series([3.0, 1.0, 2.0, 2.0, 3.0, 4.0], dtype="float64")}
-            ),
-            "TABLE2": pd.DataFrame(
-                {
-                    "B": np.array(
-                        [
-                            Decimal("1.6"),
-                            None,
-                            Decimal("200.78"),
-                            Decimal("3.000"),
-                            Decimal("-15.78"),
-                            Decimal("1111.316"),
-                        ]
-                    )
-                }
-            ),
-        },
+        pytest.param(
+            {
+                "TABLE1": pd.DataFrame(
+                    {"A": pd.Series([3.0, 1.0, 2.0, 2.0, 3.0, 4.0], dtype="float64")}
+                ),
+                "TABLE2": pd.DataFrame(
+                    {
+                        "B": np.array(
+                            [
+                                Decimal("1.6"),
+                                None,
+                                Decimal("200.78"),
+                                Decimal("3.000"),
+                                Decimal("-15.78"),
+                                Decimal("1111.316"),
+                            ]
+                        )
+                    }
+                ),
+            },
+            marks=pytest.mark.weekly,
+        ),
         # Decimal <-> Integer
         {
             "TABLE1": pd.DataFrame(

--- a/BodoSQL/bodosql/tests/test_time_constructors.py
+++ b/BodoSQL/bodosql/tests/test_time_constructors.py
@@ -20,7 +20,7 @@ pytestmark = pytest_slow_unless_codegen
             "time", marks=pytest.mark.skip(reason="waiting for calcite support")
         ),
         "to_time",
-        "try_to_time",
+        pytest.param("try_to_time", marks=pytest.mark.slow),
     ],
 )
 def to_time_fn(request):

--- a/BodoSQL/bodosql/tests/test_types/test_snowflake_catalog_basic.py
+++ b/BodoSQL/bodosql/tests/test_types/test_snowflake_catalog_basic.py
@@ -120,9 +120,15 @@ def test_snowflake_catalog_constructor(memory_leak_check):
     "conn_str",
     [
         # Basic Connection Str
-        "snowflake://myusername:mypassword@myaccount/mydatabase?warehouse=mywarehouse",
+        pytest.param(
+            "snowflake://myusername:mypassword@myaccount/mydatabase?warehouse=mywarehouse",
+            marks=pytest.mark.weekly,
+        ),
         # With Schema
-        "snowflake://myusername:mypassword@myaccount/mydatabase/myschema?warehouse=mywarehouse",
+        pytest.param(
+            "snowflake://myusername:mypassword@myaccount/mydatabase/myschema?warehouse=mywarehouse",
+            marks=pytest.mark.weekly,
+        ),
         # Additional Connection Param. Note, order of params matter for test
         "snowflake://myusername:mypassword@myaccount/mydatabase/myschema?role=USERADMIN&warehouse=mywarehouse",
         # Missing Password


### PR DESCRIPTION
## Changes included in this PR

Some BodoSQL tests are now marked as `weekly` instead of `slow` so that they don't run in the nightly CI. Most notably, this includes smaller size integer types, unsigned integers, and float32. Most of this was taken care of by changing the marks in the fixtures in conftest.py.

Aside from that, I also found a few miscellaneous test cases that didn't seem very distinct or particularly useful, and marked them as `slow` or `weekly`.

## Testing strategy

Only Pytest markers were changed. I ran `pytest --collect-only` to verify that tests are scheduled under the right conditions.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.