### PR TITLE
Add pytest fixture to disable JIT fallback for bodosql_cpp tests

### DIFF
--- a/BodoSQL/bodosql/tests/conftest.py
+++ b/BodoSQL/bodosql/tests/conftest.py
@@ -29,7 +29,7 @@ from bodo.tests.conftest import (  # noqa
     memory_leak_check,
 )
 from bodo.tests.iceberg_database_helpers.utils import get_spark
-from bodo.tests.utils import gen_nonascii_list
+from bodo.tests.utils import gen_nonascii_list, set_config
 
 # Patch to avoid PySpark's Py4j exception handler in testing.
 # See:
@@ -104,6 +104,19 @@ def enable_numba_alloc_stats():
     from numba.core.runtime import _nrt_python
 
     _nrt_python.memsys_enable_stats()
+
+
+@pytest.fixture(autouse=True)
+def cpp_backend_disable_jit_fallback(request):
+    """Ensure that an error is thrown instead of falling back to JIT mode when a test marked BODOSQL_CPP utilizes an unsupported plan."""
+    if bodosql.cpp_backend_fallback:
+        marker = request.node.get_closest_marker("bodosql_cpp")
+        if marker:
+            set_config("bodosql.cpp_backend_fallback", False)
+            yield
+            set_config("bodosql.cpp_backend_fallback", True)
+            return
+    yield
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Changes included in this PR

Added Pytest fixture to set the `bodosql.cpp_backend_fallback` config variable to False at the beginning of each BODOSQL_CPP test and back to True after it completes (assuming fallback was enabled to start with).

## Testing strategy

Ran some tests marked `bodosql_cpp` and some that weren't to make sure everything still works. Also tried marking an unsupported test as `bodosql_cpp` to check that it does throw an error instead of falling back.

## User facing changes

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.