### PR TITLE
Fix parsing for unary operators in JIT dataframe query expression

### DIFF
--- a/bodo/hiframes/dataframe_impl.py
+++ b/bodo/hiframes/dataframe_impl.py
@@ -6340,6 +6340,11 @@ def _parse_query_expr(
 
     # replace 'in' operator with dummy function to convert to prange later
     def op__str__(self):
+        if len(self.operands) == 1:
+            return pandas.io.formats.printing.pprint_thing(
+                f"{self.op} ({pandas.io.formats.printing.pprint_thing(self.operands[0])})"
+            )
+
         parened = (
             f"({pandas.io.formats.printing.pprint_thing(opr)})" for opr in self.operands
         )

--- a/bodo/tests/test_df_query.py
+++ b/bodo/tests/test_df_query.py
@@ -17,6 +17,7 @@ pytestmark = pytest_pandas
     [
         "`B B` > @a + 1 & 5 > index > 1",
         pytest.param("(A == @a) | (C == 'AA')", marks=pytest.mark.slow),
+        pytest.param("not A < 5", marks=pytest.mark.slow),
         pytest.param("C in ['AA', 'C']", marks=pytest.mark.slow),
         pytest.param("C not in ['AA', 'C']", marks=pytest.mark.slow),
         pytest.param("C.str.contains('C')", marks=pytest.mark.slow),


### PR DESCRIPTION
## Changes included in this PR

This PR fixes a correctness issue when unary operators (such as `not`) are used in the `query()` expression string on the JIT side. The existing code seems to assume that there will be 2 or more operands; if there is just one operand it drops the operator.

## Testing strategy

Added a test to cover this case.

## User facing changes

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.