### PR TITLE
[GPU] Stop dict columns in pyarrow schemas.

### DIFF
--- a/BodoSQL/bodosql/tests/test_tpch_second_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_second_half.py
@@ -16,6 +16,7 @@ from bodosql.tests.utils import check_query, shrink_data
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q12(tpch_data, memory_leak_check):
     SHIPMODE1 = "MAIL"
     SHIPMODE2 = "SHIP"
@@ -426,6 +427,7 @@ def test_tpch_q18(tpch_data, memory_leak_check):
 
 @pytest.mark.timeout(600)
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q19(tpch_data, memory_leak_check):
     QUANTITY1 = 1
     QUANTITY2 = 10

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -60,6 +60,7 @@ from bodo.pandas.utils import (
     BodoLibNotImplementedException,
     arrow_to_empty_df,
     check_args_fallback,
+    df_to_pa_schema,
     ensure_datetime64ns,
     get_scalar_udf_result_type,
     wrap_module_functions_and_methods,
@@ -111,7 +112,7 @@ def from_pandas(df):
             df[col] = df[col].apply(lambda x: x.get_value() if x is not None else None)
 
     try:
-        pa_schema = pa.Schema.from_pandas(df.iloc[:sample_size])
+        pa_schema = df_to_pa_schema(df.iloc[:sample_size])
     except pa.lib.ArrowInvalid as e:
         # TODO: add specific unsupported columns to message.
         raise BodoLibNotImplementedException(
@@ -208,7 +209,6 @@ def _empty_like(val):
     and returns typed output.
     """
     import numpy as np
-    import pyarrow as pa
 
     if type(val) not in (
         BodoDataFrame,
@@ -245,7 +245,7 @@ def _empty_like(val):
         val = val.reset_index(drop=True)
 
     # Reuse arrow_to_empty_df to make sure details like Index handling are correct
-    out = arrow_to_empty_df(pa.Schema.from_pandas(val))
+    out = arrow_to_empty_df(df_to_pa_schema(val))
 
     for cname in cat_cols:
         out[cname] = original_val[cname].iloc[:0]

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -16,6 +16,7 @@ from bodo.pandas.utils import (
     arrow_to_empty_df,
     cpp_table_to_df,
     cpp_table_to_series,
+    df_to_pa_schema,
     get_n_index_arrays,
     wrap_plan,
 )
@@ -62,12 +63,12 @@ class LazyPlan:
             name = BODO_NONE_DUMMY if empty_data.name is None else empty_data.name
             self.empty_data = empty_data.to_frame(name=name)
 
-        self.pa_schema = pa.Schema.from_pandas(self.empty_data)
+        self.pa_schema = df_to_pa_schema(self.empty_data)
 
     def _update_column_names(self, new_cols):
         """Update column names in empty_data and pa_schema."""
         self.empty_data.columns = new_cols
-        self.pa_schema = pa.Schema.from_pandas(self.empty_data)
+        self.pa_schema = df_to_pa_schema(self.empty_data)
 
     def __str__(self):
         args = self.args

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -1675,9 +1675,10 @@ def scalarOutputNACheck(out, dtype):
 def df_to_pa_schema(df):
     """Convert a small Pandas dataframe to a pyarrow schema.
     Stop pyarrow from encoding columns as dictionaries."""
-    table = pa.Table.from_pandas(df)
+
+    normal_schema = pa.Schema.from_pandas(df)
     new_fields = []
-    for f in table.schema:
+    for f in normal_schema:
         if pa.types.is_dictionary(f.type):
             new_fields.append(
                 pa.field(
@@ -1686,5 +1687,5 @@ def df_to_pa_schema(df):
             )
         else:
             new_fields.append(f)
-    target_schema = pa.schema(new_fields)
+    target_schema = pa.schema(new_fields, metadata=normal_schema.metadata)
     return target_schema

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -1117,7 +1117,7 @@ def arrow_table_to_pandas(arrow_table, arrow_schema=None, use_arrow_dtypes=True)
 def _get_empty_series_arrow(ser: pd.Series) -> pd.Series:
     """Create an empty Series like ser possibly converting some dtype to use
     pyarrow"""
-    empty_df = arrow_to_empty_df(pa.Schema.from_pandas(ser.to_frame()))
+    empty_df = arrow_to_empty_df(df_to_pa_schema(ser.to_frame()))
     empty_series = empty_df.squeeze()
     empty_series.name = ser.name
     return empty_series
@@ -1670,3 +1670,21 @@ def scalarOutputNACheck(out, dtype):
             # plain NumPy ints/bools can't hold NA, pandas promotes to float NaN
             return np.nan
     return out
+
+
+def df_to_pa_schema(df):
+    """Convert a small Pandas dataframe to a pyarrow schema.
+    Stop pyarrow from encoding columns as dictionaries."""
+    table = pa.Table.from_pandas(df)
+    new_fields = []
+    for f in table.schema:
+        if pa.types.is_dictionary(f.type):
+            new_fields.append(
+                pa.field(
+                    f.name, f.type.value_type, nullable=f.nullable, metadata=f.metadata
+                )
+            )
+        else:
+            new_fields.append(f)
+    target_schema = pa.schema(new_fields)
+    return target_schema

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -1673,19 +1673,57 @@ def scalarOutputNACheck(out, dtype):
 
 
 def df_to_pa_schema(df):
-    """Convert a small Pandas dataframe to a pyarrow schema.
-    Stop pyarrow from encoding columns as dictionaries."""
+    """
+    Convert a small pandas DataFrame to a pyarrow.Schema while preventing
+    pyarrow from *automatically* dictionary-encoding columns.
 
-    normal_schema = pa.Schema.from_pandas(df)
+    Behavior:
+    - If pyarrow inferred a dictionary field for column X but the original
+      pandas Series X is backed by an Arrow DictionaryArray, keep the dictionary.
+    - If pyarrow inferred a dictionary field for column X but the original
+      pandas Series X is NOT a DictionaryArray, replace the field with the
+      dictionary's value_type (i.e., decode the dictionary in the schema).
+    - Non-dictionary fields are preserved unchanged.
+
+    """
+
+    # Let pyarrow infer a schema from the pandas sample
+    normal_schema = pa.Schema.from_pandas(df, preserve_index=False)
+
     new_fields = []
     for f in normal_schema:
-        if pa.types.is_dictionary(f.type):
-            new_fields.append(
-                pa.field(
-                    f.name, f.type.value_type, nullable=f.nullable, metadata=f.metadata
-                )
-            )
-        else:
+        if not pa.types.is_dictionary(f.type):
+            # not dictionary-encoded by inference -> keep as-is
             new_fields.append(f)
+            continue
+
+        # f.type is a dictionary type inferred by Arrow
+        col_name = f.name
+
+        # Try to inspect the pandas Series' underlying Arrow array type.
+        # If the Series is Arrow-backed, pandas exposes .array._pa_array.
+        original_is_dictionary = False
+        try:
+            series = df[col_name]
+            # Some pandas versions expose the Arrow array at series.array._pa_array
+            pa_array = getattr(series.array, "_pa_array", None)
+            if pa_array is not None:
+                original_is_dictionary = pa.types.is_dictionary(pa_array.type)
+        except Exception:
+            # If anything goes wrong inspecting the Series, assume it's not dictionary-backed.
+            original_is_dictionary = False
+
+        if original_is_dictionary:
+            # The incoming df already had a dictionary Arrow array for this column:
+            # preserve the dictionary encoding in the schema.
+            new_fields.append(f)
+        else:
+            # Arrow inferred a dictionary but the original Series was not dictionary-backed:
+            # replace the field with the dictionary's value_type to avoid automatic encoding.
+            value_type = f.type.value_type
+            new_fields.append(
+                pa.field(f.name, value_type, nullable=f.nullable, metadata=f.metadata)
+            )
+
     target_schema = pa.schema(new_fields, metadata=normal_schema.metadata)
     return target_schema


### PR DESCRIPTION
## Changes included in this PR

Added new utility function to convert pandas dataframe to pyarrow schema and that stops pyarrow from creating dictionary columns.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.