### PR TITLE
More fixes for enabling BodoSQL C++ backend

### DIFF
--- a/.github/workflows/_test_nightly_python_source.yml
+++ b/.github/workflows/_test_nightly_python_source.yml
@@ -255,6 +255,10 @@ jobs:
           # create Pandas manager states for testing that are not fully functional.
           BODO_ENABLE_DATAFRAME_LIBRARY: ${{ endsWith(inputs.test-type, 'spawn') && '0' || '1' }}
           BODO_ENABLE_TEST_DATAFRAME_LIBRARY: ${{ inputs.test-type == 'df_lib' && '1' || '0' }}
+          # BodoSQL C++ Backend
+          BODOSQL_CPP_BACKEND: 1
+          BODOSQL_VERBOSE_CPP_BACKEND: 1
+          BODOSQL_CPP_BACKEND_FALLBACK: 1
           # For caching tests we need to update the location of the decryption file.
           # We set the absolute path as an environment variable.
           BODO_TRACING_DECRYPTION_FILE_PATH: ${{ github.workspace }}/buildscripts/decompress_traces.py

--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -202,9 +202,9 @@ jobs:
             BODO_BUFFER_POOL_REMOTE_MODE: "1"
             BODO_BUFFER_POOL_DEBUG_MODE: "1"
             # BodoSQL C++ Backend
-            BODOSQL_CPP_BACKEND: ${{ inputs.test-type == 'BODOSQL_CPP' && '1' || '0' }}
+            BODOSQL_CPP_BACKEND: 1
             BODOSQL_VERBOSE_CPP_BACKEND: 1
-            BODOSQL_CPP_BACKEND_FALLBACK: ${{ inputs.test-type == 'BODOSQL_CPP' && '0' || '1' }}
+            BODOSQL_CPP_BACKEND_FALLBACK: 1
             # Testing Credentials
             SF_USERNAME: ${{ secrets.SF_USERNAME }}
             SF_PASSWORD: ${{ secrets.SF_PASSWORD }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -228,20 +228,6 @@ jobs:
       bodo-version: ${{ needs.get_version.outputs.bodo_version }}
     secrets: inherit
 
-  bodosql-cpp-ci:
-    needs: [compile-bodo, get_version]
-    name: Test BodoSQL C++ Backend
-    uses: ./.github/workflows/_test_python_source.yml
-    with:
-      batch: 1
-      total-batches: 1
-      pytest-marker: "bodosql_cpp and not weekly"
-      collect-coverage: true
-      runner-id: ${{ inputs.runner_os || 'ubuntu-latest' }}
-      test-type: "BODOSQL_CPP"
-      bodo-version: ${{ needs.get_version.outputs.bodo_version }}
-    secrets: inherit
-
   java-ci:
     name: Test Java
     needs: [validate]
@@ -329,7 +315,6 @@ jobs:
       - collect-results
       - df-lib-ci
       - df-lib-non-jit-ci
-      - bodosql-cpp-ci
       - gpu-ci
       - validate
     runs-on: ubuntu-latest

--- a/BodoSQL/bodosql/__init__.py
+++ b/BodoSQL/bodosql/__init__.py
@@ -18,7 +18,7 @@ from bodosql.bodosql_types.s3_tables_catalog import (
 
 
 
-use_cpp_backend = os.environ.get("BODOSQL_CPP_BACKEND", "0") != "0"
+use_cpp_backend = os.environ.get("BODOSQL_CPP_BACKEND", "1") != "0"
 verbose_cpp_backend = os.environ.get("BODOSQL_VERBOSE_CPP_BACKEND", "0") != "0"
 # Used for testing purposes to disable fallback to JIT backend
 cpp_backend_fallback = os.environ.get("BODOSQL_CPP_BACKEND_FALLBACK", "1") != "0"

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -637,11 +637,11 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         func_name = op.getName().upper()
 
         if func_name in ("UTC_TIMESTAMP", "UTC_DATE"):
-            curr_ts = pd.Timestamp.now(tz="UTC")
+            curr_ts = pd.Timestamp.now()
             if func_name == "UTC_DATE":
                 curr_ts = curr_ts.normalize()
             dummy_empty_data = pd.Series(
-                [curr_ts], dtype=pd.ArrowDtype(pa.timestamp("ns", tz="UTC"))
+                [curr_ts], dtype=pd.ArrowDtype(pa.timestamp("ns"))
             )
             return ConstantExpression(dummy_empty_data, input_plan, curr_ts)
 

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -931,6 +931,13 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             # sarg is an org.apache.calcite.util.Sarg
             sarg = search_expr.value
             assert sarg.getClass().getSimpleName() == "Sarg"
+            if (
+                sarg.getClass().getDeclaredField("nullAs").get(sarg).toString()
+                != "UNKNOWN"
+            ):
+                raise NotImplementedError(
+                    "SEARCH operator with nullAs not UNKNOWN not supported in C++ backend yet"
+                )
             # sarg_rangeSet is a com.google.common.collect.ImmutableRangeSet
             sarg_rangeSet = sarg.getClass().getDeclaredField("rangeSet").get(sarg)
             assert sarg_rangeSet.getClass().getSimpleName() == "ImmutableRangeSet"

--- a/BodoSQL/bodosql/runtests.py
+++ b/BodoSQL/bodosql/runtests.py
@@ -9,8 +9,10 @@ import sys
 
 # first arg is the name of the testing pipeline
 pipeline_name = sys.argv[1]
-# second arg is the number of processes to run the tests with
-num_processes = int(sys.argv[2])
+# second arg is the number of workers to run the tests with
+num_workers = int(sys.argv[2])
+# NOTE: BodoSQL C++ backend always uses spawn (JIT fallback will be sequential here)
+os.environ["BODO_NUM_WORKERS"] = str(num_workers)
 # all other args go to pytest
 pytest_args = sys.argv[3:]
 # Get File-Level Timeout Info from Environment Variable (in seconds)
@@ -58,13 +60,8 @@ for i, m in enumerate(modules):
         mod_pytest_args[mark_arg_idx + 1] += " and single_mod"
     except ValueError:
         mod_pytest_args += ["-m", "single_mod"]
-    # run tests with mpiexec + pytest always. If you just use
-    # pytest then out of memory won't tell you which test failed.
+
     cmd = [
-        "mpiexec",
-        "-prepend-rank",
-        "-n",
-        str(num_processes),
         "pytest",
         "-Wignore",
         # junitxml generates test report file that can be displayed by CodeBuild website


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
A few final fixes for enabling the BodoSQL C++ backend.
Nightly run passes (except some flakiness): https://github.com/bodo-ai/Bodo/actions/runs/27562625798/job/81478331493

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Nightly.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.