### PR TITLE
Don't read tpch data with bodo jit so it doesn't add dict columns.

### DIFF
--- a/BodoSQL/bodosql/tests/conftest.py
+++ b/BodoSQL/bodosql/tests/conftest.py
@@ -1253,7 +1253,6 @@ def tpch_data_helper(datapath):
     return dataframe_dict
 
 
-@bodo.jit(returns_maybe_distributed=False, cache=True)
 def load_tpch_data(dir_name):
     """Load the necessary TPCH DataFrames given a root directory.
     We use bodo.jit so we can read easily from a directory.

--- a/BodoSQL/bodosql/tests/test_tpch_second_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_second_half.py
@@ -16,6 +16,7 @@ from bodosql.tests.utils import check_query, shrink_data
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q12(tpch_data, memory_leak_check):
     SHIPMODE1 = "MAIL"
     SHIPMODE2 = "SHIP"
@@ -426,6 +427,7 @@ def test_tpch_q18(tpch_data, memory_leak_check):
 
 @pytest.mark.timeout(600)
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q19(tpch_data, memory_leak_check):
     QUANTITY1 = 1
     QUANTITY2 = 10


### PR DESCRIPTION
## Changes included in this PR

Don't use jit to read tpch data so it doesn't create dict[string] columns.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.