### PR TITLE
Support more string operations in BodoSQL C++ backend (first batch)

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -5,6 +5,7 @@ import zoneinfo
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 
@@ -17,6 +18,7 @@ from bodo.pandas.plan import (
     ArrowScalarFuncExpression,
     CaseExpression,
     CastExpression,
+    ColRefExpression,
     ComparisonOpExpression,
     ConjunctionOpExpression,
     ConstantExpression,
@@ -279,6 +281,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 return java_binop_to_python_expr(
                     ctx,
                     SqlKind.PLUS,
+                    "+",
                     [
                         java_expr_to_python_expr(
                             ctx, java_call.getOperands()[i], input_plan
@@ -338,6 +341,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 return java_binop_to_python_expr(
                     ctx,
                     SqlKind.MINUS,
+                    "-",
                     [
                         java_expr_to_python_expr(
                             ctx, java_call.getOperands()[i], input_plan
@@ -349,6 +353,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 return java_binop_to_python_expr(
                     ctx,
                     SqlKind.MINUS,
+                    "-",
                     [
                         java_expr_to_python_expr(
                             ctx, java_call.getOperands()[2], input_plan
@@ -369,7 +374,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         # Calcite may add more than 2 operand for the same binary operator
         op_exprs = [java_expr_to_python_expr(ctx, o, input_plan) for o in operands]
         kind = op.getKind()
-        return java_binop_to_python_expr(ctx, kind, op_exprs)
+        return java_binop_to_python_expr(ctx, kind, op.getName(), op_exprs)
 
     if operator_class_name == "SqlCastFunction" and len(java_call.getOperands()) == 1:
         operand = java_call.getOperands()[0]
@@ -749,6 +754,78 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 op_exprs[0].empty_data, op_exprs, "nullif", ()
             )
 
+        if func_name in ("CHAR_LENGTH", "CHARACTER_LENGTH") and len(op_exprs) == 1:
+            src = op_exprs[0]
+            ensure_type_of_expr(src, "src", str)
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            return ArrowScalarFuncExpression(
+                int_empty_data,
+                [src],
+                "utf8_length",
+                (),
+            )
+
+        if func_name == "LOWER" and len(op_exprs) == 1:
+            return ArrowScalarFuncExpression(
+                op_exprs[0].empty_data, op_exprs, "utf8_lower", ()
+            )
+
+        if func_name == "UPPER" and len(op_exprs) == 1:
+            return ArrowScalarFuncExpression(
+                op_exprs[0].empty_data, op_exprs, "utf8_upper", ()
+            )
+
+        if func_name in ("LPAD", "RPAD") and len(op_exprs) in (2, 3):
+            src = op_exprs[0]
+            length = op_exprs[1]
+
+            if not isinstance(length, bodo.pandas.plan.ConstantExpression):
+                raise ValueError(
+                    f"length should be ConstantExpression but instead was {type(length)}"
+                )
+            if not isinstance(length.value, int):
+                raise ValueError(
+                    f"length.value should be integer but instead was {type(length.value)}"
+                )
+
+            arrow_func_args = (length.value,)
+
+            if len(op_exprs) == 3:
+                pattern = op_exprs[2]
+
+                if not isinstance(pattern, bodo.pandas.plan.ConstantExpression):
+                    raise ValueError(
+                        f"pattern should be ConstantExpression but instead was {type(pattern)}"
+                    )
+                if not isinstance(pattern.value, str):
+                    raise ValueError(
+                        f"pattern.value should be string but instead was {type(pattern.value)}"
+                    )
+                arrow_func_args += (pattern.value,)
+
+            return ArrowScalarFuncExpression(
+                src.empty_data,
+                [src],
+                f"utf8_{func_name.lower()}",
+                arrow_func_args,
+            )
+
+        if func_name == "REPLACE" and len(op_exprs) == 3:
+            src = op_exprs[0]
+            search_expr = op_exprs[1]
+            replacement_expr = op_exprs[2]
+
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(search_expr, "search_expr", str)
+            ensure_arg_is_const_expr_of_type(replacement_expr, "replacement_expr", str)
+
+            return ArrowScalarFuncExpression(
+                src.empty_data,
+                [src],
+                "replace_substring",
+                (search_expr.value, replacement_expr.value),
+            )
+
         # If we didn't match a supported basic function, fall through to NotImplemented
         raise NotImplementedError(
             f"SqlBasicFunction {func_name} not supported yet: " + java_call.toString()
@@ -770,17 +847,24 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             return ArrowScalarFuncExpression(
                 out_empty, [left], "utf8_slice_codeunits", (0, len_expr.value, 1)
             )
+        elif func_name == "RIGHT" and len(op_exprs) == 2:
+            # Implement RIGHT as substr(-len,...)
+            left = op_exprs[0]
+            len_expr = op_exprs[1]
+            if not isinstance(len_expr, ConstantExpression):
+                raise ValueError("len_expr not a ConstantExpression")
+
+            out_empty = left.empty_data.iloc[:, 0]
+            return ArrowScalarFuncExpression(
+                out_empty, [left], "utf8_slice_codeunits", (-len_expr.value, None, 1)
+            )
         elif func_name == "STARTSWITH" and len(op_exprs) == 2:
             src = op_exprs[0]
             match_expr = op_exprs[1]
-            if not isinstance(match_expr, bodo.pandas.plan.ConstantExpression):
-                raise ValueError(
-                    f"match_expr should be ConstantExpression but instead was {type(match_expr)}"
-                )
-            if not isinstance(match_expr.value, str):
-                raise ValueError(
-                    f"match_expr.value should be string but instead was {type(match_expr.value)}"
-                )
+
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return ArrowScalarFuncExpression(
                 bool_empty_data,
@@ -791,14 +875,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         elif func_name == "ENDSWITH" and len(op_exprs) == 2:
             src = op_exprs[0]
             match_expr = op_exprs[1]
-            if not isinstance(match_expr, bodo.pandas.plan.ConstantExpression):
-                raise ValueError(
-                    f"match_expr should be ConstantExpression but instead was {type(match_expr)}"
-                )
-            if not isinstance(match_expr.value, str):
-                raise ValueError(
-                    f"match_expr.value should be string but instead was {type(match_expr.value)}"
-                )
+
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return ArrowScalarFuncExpression(
                 bool_empty_data,
@@ -809,14 +889,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         elif func_name == "CONTAINS" and len(op_exprs) == 2:
             src = op_exprs[0]
             match_expr = op_exprs[1]
-            if not isinstance(match_expr, bodo.pandas.plan.ConstantExpression):
-                raise ValueError(
-                    f"match_expr should be ConstantExpression but instead was {type(match_expr)}"
-                )
-            if not isinstance(match_expr.value, str):
-                raise ValueError(
-                    f"match_expr.value should be string but instead was {type(match_expr.value)}"
-                )
+
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return ArrowScalarFuncExpression(
                 bool_empty_data,
@@ -824,26 +900,156 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 "match_substring",
                 (match_expr.value,),
             )
+        elif func_name in ("LENGTH", "LEN") and len(op_exprs) == 1:
+            src = op_exprs[0]
+            ensure_type_of_expr(src, "src", str)
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            return ArrowScalarFuncExpression(
+                int_empty_data,
+                [src],
+                "utf8_length",
+                (),
+            )
+        elif func_name == "INSTR" and len(op_exprs) == 2:
+            src = op_exprs[0]
+            match_expr = op_exprs[1]
+
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            zero_indexed_expr = ArrowScalarFuncExpression(
+                int_empty_data,
+                [src],
+                "find_substring",
+                (match_expr.value,),
+            )
+            # Add 1 to find_substring expression since find_substring is 0-indexed instead of 1-based like INSTR
+            one = ConstantExpression(int_empty_data, input_plan, 1)
+            return ArithOpExpression(int_empty_data, zero_indexed_expr, one, "__add__")
+        elif func_name == "INITCAP" and len(op_exprs) in (1, 2):
+            src = op_exprs[0]
+            if len(op_exprs) == 2:
+                delim_expr = op_exprs[1]
+                if not isinstance(delim_expr, bodo.pandas.plan.ConstantExpression):
+                    raise ValueError(
+                        f"delim_expr should be ConstantExpression but instead was {type(delim_expr)}"
+                    )
+                if not isinstance(delim_expr.value, str):
+                    raise ValueError(
+                        f"delim_expr.value should be string but instead was {type(delim_expr.value)}"
+                    )
+                raise ValueError("Delimiter argument to INITCAP not yet supported")
+            # Note that Arrow's utf8_title considers numbers to be delimiters, which may differ from some implementations of INITCAP
+            return ArrowScalarFuncExpression(
+                src.empty_data,
+                [src],
+                "utf8_title",
+                (),
+            )
+        elif func_name == "CONCAT" and len(op_exprs) > 0:
+            src = op_exprs[0]
+
+            ensure_type_of_expr(src, "src", str)
+
+            separator = bodo.pandas.plan.ConstantExpression(
+                src.empty_data,
+                src.source,
+                "",  # empty separator to concat without anything in between
+            )
+
+            input_exprs = [src]
+
+            if len(op_exprs) > 1:
+                for other_str_src in op_exprs[1:]:
+                    ensure_type_of_expr(other_str_src, "other_str_src", str)
+                    input_exprs.append(other_str_src)
+
+            input_exprs.append(separator)
+
+            return ArrowScalarFuncExpression(
+                src.empty_data,
+                input_exprs,
+                "binary_join_element_wise",
+                (),
+            )
+        elif func_name == "CONCAT_WS" and len(op_exprs) > 1:
+            separator = op_exprs[0]
+            ensure_type_of_expr(separator, "separator", str)
+
+            input_exprs = []
+            for str_src in op_exprs[1:]:
+                ensure_type_of_expr(str_src, "str_src", str)
+                input_exprs.append(str_src)
+            input_exprs.append(separator)
+
+            return ArrowScalarFuncExpression(
+                separator.empty_data,
+                input_exprs,
+                "binary_join_element_wise",
+                (
+                    "skip",
+                ),  # Ensure null string arguments are treated as empty / skipped
+            )
+        elif func_name == "REPEAT" and len(op_exprs) == 2:
+            src = op_exprs[0]
+            num_repeats_expr = op_exprs[1]
+
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(num_repeats_expr, "num_repeats_expr", int)
+
+            return ArrowScalarFuncExpression(
+                src.empty_data, [src], "binary_repeat", (num_repeats_expr.value,)
+            )
+        elif func_name == "SPACE" and len(op_exprs) == 1:
+            num_repeats_expr = op_exprs[0]
+            ensure_arg_is_const_expr_of_type(num_repeats_expr, "num_repeats_expr", int)
+
+            str_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.string()))
+
+            space_expr = bodo.pandas.plan.ConstantExpression(
+                str_empty_data, input_plan, " "
+            )
+
+            return ArrowScalarFuncExpression(
+                str_empty_data, [space_expr], "binary_repeat", (num_repeats_expr.value,)
+            )
+        elif func_name == "REVERSE" and len(op_exprs) == 1:
+            src = op_exprs[0]
+            ensure_type_of_expr(src, "src", str)
+
+            return ArrowScalarFuncExpression(src.empty_data, [src], "utf8_reverse", ())
 
     if operator_class_name == "SqlSubstringFunction":
         operands = java_call.getOperands()
         op_exprs = [java_expr_to_python_expr(ctx, o, input_plan) for o in operands]
         func_name = op.getName().upper()
 
-        if func_name == "SUBSTRING" and len(op_exprs) == 3:
+        if func_name == "SUBSTRING" and len(op_exprs) in (2, 3):
             src = op_exprs[0]
             start_expr = op_exprs[1]
-            if not isinstance(start_expr, ConstantExpression):
-                raise ValueError("start_expr not a ConstantExpression")
-            len_expr = op_exprs[2]
-            if not isinstance(len_expr, ConstantExpression):
-                raise ValueError("len_expr not a ConstantExpression")
+            ensure_arg_is_const_expr_of_type(start_expr, "start_expr", int)
+            # start = max(start_expr.value - 1, 0)
+            start = start_expr.value - 1  # Subtract 1 here for 1-based
+
+            if len(op_exprs) == 3:
+                len_expr = op_exprs[2]
+                ensure_arg_is_const_expr_of_type(len_expr, "len_expr", int)
+                # stop = max(start_expr.value - 1 + len_expr.value, 0)
+                stop = (
+                    start_expr.value - 1 + len_expr.value
+                )  # Subtract 1 here for 1-based
+                if start_expr.value < 0 and stop >= 0:
+                    stop = None
+            else:
+                stop = None
+
             out_empty = src.empty_data.iloc[:, 0]
             return ArrowScalarFuncExpression(
                 out_empty,
                 [src],
                 "utf8_slice_codeunits",
-                (start_expr.value, len_expr.value, 1),
+                (start, stop, 1),
             )
 
     if operator_class_name == "SqlLikeOperator":
@@ -851,20 +1057,24 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         op_exprs = [java_expr_to_python_expr(ctx, o, input_plan) for o in operands]
         func_name = op.getName().upper()
 
-        if func_name == "LIKE" and len(op_exprs) == 2:
+        if func_name in ("LIKE", "ILIKE") and len(op_exprs) in (2, 3):
             left = op_exprs[0]
             like_expr = op_exprs[1]
-            if not isinstance(like_expr, ConstantExpression):
-                raise ValueError("lik_expr not a ConstantExpression")
+            if len(op_exprs) == 3:
+                ensure_arg_is_const_expr_of_type(op_exprs[2], "escape_expr", str)
+                escape_val = op_exprs[2].value
+            else:
+                escape_val = ""
+            ensure_arg_is_const_expr_of_type(like_expr, "like_expr", str)
 
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             converted_like, needs_regex, start_match, end_match, match_anything = (
                 bodo.ir.filter.convert_sql_pattern_to_python_compile_time(
-                    like_expr.value, "", False
+                    like_expr.value, escape_val, False
                 )
             )
             if needs_regex:
-                if start_match or end_match or match_anything:
+                if match_anything:
                     raise NotImplementedError(
                         "LIKE conversion supports nothing else if regex is required."
                     )
@@ -872,7 +1082,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     bool_empty_data,
                     [left],
                     "match_substring_regex",
-                    (converted_like,),
+                    (converted_like, func_name == "ILIKE"),
                 )
             elif start_match:
                 if end_match or match_anything:
@@ -883,7 +1093,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     bool_empty_data,
                     [left],
                     "starts_with",
-                    (converted_like,),
+                    (converted_like, func_name == "ILIKE"),
                 )
             elif end_match:
                 if match_anything:
@@ -894,12 +1104,27 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     bool_empty_data,
                     [left],
                     "ends_with",
-                    (converted_like,),
+                    (converted_like, func_name == "ILIKE"),
                 )
-            else:
+            elif match_anything:
                 raise NotImplementedError(
                     "LIKE conversion does not currently support match anything."
                 )
+            else:
+                return ArrowScalarFuncExpression(
+                    bool_empty_data,
+                    [left],
+                    "match_substring",
+                    (converted_like, func_name == "ILIKE"),
+                )
+
+    if operator_class_name == "SqlTranslate3Function":
+        operands = java_call.getOperands()
+        op_exprs = [java_expr_to_python_expr(ctx, o, input_plan) for o in operands]
+        func_name = op.getName().upper()
+
+        if func_name == "TRANSLATE3" and len(op_exprs) == 3:
+            pass
 
     raise NotImplementedError(
         f"Call operator {operator_class_name} not supported yet: "
@@ -907,14 +1132,77 @@ def java_call_to_python_call(ctx, java_call, input_plan):
     )
 
 
-def java_binop_to_python_expr(ctx, kind, op_exprs):
+def ensure_arg_is_const_expr_of_type(expr, expr_name, dtype):
+    if not isinstance(expr, bodo.pandas.plan.ConstantExpression):
+        raise ValueError(
+            f"{expr_name} should be ConstantExpression but instead was {type(expr)}"
+        )
+    if not isinstance(expr.value, dtype):
+        raise ValueError(
+            f"{expr_name}.value should be {str(dtype)} but instead was {type(expr.value)}"
+        )
+
+
+def ensure_type_of_expr(expr, expr_name, dtype):
+    # Type checker that accounts for pandas dtypes
+    def instanceof(obj, dtype):
+        if isinstance(obj, dtype):
+            return True
+        obj_type = (
+            type(obj) if not isinstance(obj, (pd.Series, np.ndarray)) else obj.dtype
+        )
+        if dtype is int:
+            return pd.api.types.is_integer_dtype(obj_type)
+        if dtype is float:
+            return pd.api.types.is_float_dtype(obj_type)
+        if dtype is str:
+            return pd.api.types.is_string_dtype(obj_type)
+        if dtype is bool:
+            return pd.api.types.is_bool_dtype(obj_type)
+        if isinstance(dtype, np.dtype):
+            return np.issubdtype(obj_type, dtype)
+        # At this point we could try converting dtypes to pandas dtypes
+        if isinstance(dtype, pd.api.extensions.ExtensionDtype):
+            return pd.api.types.is_dtype_equal(obj_type, dtype)
+        return False
+
+    if instanceof(expr, dtype):
+        return
+    elif isinstance(expr, bodo.pandas.plan.ConstantExpression):
+        if instanceof(expr.value, dtype):
+            return
+        else:
+            expr_dtype = type(expr.value)
+    elif isinstance(expr, ColRefExpression):
+        if isinstance(expr.empty_data, pd.Series):
+            expr_dtype = expr.empty_data.dtype
+            if instanceof(expr.empty_data, dtype):
+                return
+        elif isinstance(expr.empty_data, pd.DataFrame):
+            assert len(expr.empty_data.columns) == 1
+            expr_dtype = expr.empty_data.columns[0].dtype
+            if instanceof(expr.empty_data.columns[0], dtype):
+                return
+        else:
+            raise ValueError(
+                f"Unsupported type of {expr_name}.empty_data:", type(expr.empty_data)
+            )
+    else:
+        raise ValueError(f"Unsupported type of {expr_name}:", type(expr))
+
+    raise ValueError(
+        f"Expected {expr_name} ({type(expr)}) to hold datatype {str(dtype)}, instead was {expr_dtype}"
+    )
+
+
+def java_binop_to_python_expr(ctx, kind, op_name, op_exprs):
     """Convert a BodoSQL Java binary operator call to a DataFrame library expression."""
 
     left = op_exprs[0]
 
     # Calcite may add more than 2 operand for the same binary operator
     if len(op_exprs) > 2:
-        right = java_binop_to_python_expr(ctx, kind, op_exprs[1:])
+        right = java_binop_to_python_expr(ctx, kind, op_name, op_exprs[1:])
     else:
         right = op_exprs[1]
 
@@ -967,6 +1255,23 @@ def java_binop_to_python_expr(ctx, kind, op_exprs):
 
     if kind.equals(SqlKind.OR):
         return ConjunctionOpExpression(bool_empty_data, left, right, "__or__")
+
+    if kind.equals(SqlKind.OTHER):
+        if op_name == "||":  # string concatenation
+            for op_expr in (left, right):
+                ensure_type_of_expr(op_expr, "op_expr (|| arg)", str)
+
+            separator = bodo.pandas.plan.ConstantExpression(
+                left.empty_data,
+                left.source,
+                "",  # empty separator
+            )
+            return ArrowScalarFuncExpression(
+                left.empty_data,
+                [left, right, separator],
+                "binary_join_element_wise",
+                (),
+            )
 
     raise NotImplementedError(f"Binary operator {kind.toString()} not supported yet")
 

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1182,6 +1182,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             one = ConstantExpression(int_empty_data, input_plan, 1)
             return ArithOpExpression(int_empty_data, zero_indexed_expr, one, "__add__")
         elif func_name == "INITCAP" and len(op_exprs) in (1, 2):
+            raise ValueError("INITCAP currently disabled on C++ backend")
+
             src = op_exprs[0]
             if len(op_exprs) == 2:
                 delim_expr = op_exprs[1]
@@ -1374,14 +1376,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     "match_substring",
                     (converted_like, func_name == "ILIKE"),
                 )
-
-    if operator_class_name == "SqlTranslate3Function":
-        operands = java_call.getOperands()
-        op_exprs = [java_expr_to_python_expr(ctx, o, input_plan) for o in operands]
-        func_name = op.getName().upper()
-
-        if func_name == "TRANSLATE3" and len(op_exprs) == 3:
-            pass
 
     if operator_class_name == "SqlSearchOperator":
         operands = java_call.getOperands()

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1279,13 +1279,13 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             start_expr = op_exprs[1]
             ensure_arg_is_const_expr_of_type(start_expr, "start_expr", int)
-            if start_expr.value <= 0:
-                raise ValueError(
-                    "negative or zero start not supported in SUBSTRING in C++ backend yet"
-                )
-            # start = max(start_expr.value - 1, 0)
+
             start = start_expr.value
-            start -= 1  # SQL substring is 1-indexed but Arrow is 0-indexed
+            if (
+                start > 0
+            ):  # start_expr.value = 0 is treated the same as start_expr.value = 1
+                start -= 1  # SQL substring is 1-indexed but Arrow is 0-indexed
+            # Arrow's utf8_slice_codeunits will handle the wraparound for negative start index
 
             if len(op_exprs) == 3:
                 len_expr = op_exprs[2]
@@ -1294,10 +1294,9 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     raise ValueError(
                         "negative length not allowed in SUBSTRING in C++ backend"
                     )
-                # stop = max(start + len_expr.value, 0)
                 stop = start + len_expr.value
                 # Deal with negative start index and length beyond the end of the string
-                if start_expr.value < 0 and stop >= 0:
+                if start < 0 and stop >= 0:
                     stop = None
             else:
                 stop = None

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -785,30 +785,16 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
         if func_name in ("LPAD", "RPAD") and len(op_exprs) in (2, 3):
             src = op_exprs[0]
-            length = op_exprs[1]
+            ensure_type_of_expr(src, "src", str)
 
-            if not isinstance(length, bodo.pandas.plan.ConstantExpression):
-                raise ValueError(
-                    f"length should be ConstantExpression but instead was {type(length)}"
-                )
-            if not isinstance(length.value, int):
-                raise ValueError(
-                    f"length.value should be integer but instead was {type(length.value)}"
-                )
+            length = op_exprs[1]
+            ensure_arg_is_const_expr_of_type(length, "length", int)
 
             arrow_func_args = (length.value,)
 
             if len(op_exprs) == 3:
                 pattern = op_exprs[2]
-
-                if not isinstance(pattern, bodo.pandas.plan.ConstantExpression):
-                    raise ValueError(
-                        f"pattern should be ConstantExpression but instead was {type(pattern)}"
-                    )
-                if not isinstance(pattern.value, str):
-                    raise ValueError(
-                        f"pattern.value should be string but instead was {type(pattern.value)}"
-                    )
+                ensure_arg_is_const_expr_of_type(pattern, "pattern", str)
                 arrow_func_args += (pattern.value,)
 
             return ArrowScalarFuncExpression(
@@ -846,25 +832,27 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
         if func_name == "LEFT" and len(op_exprs) == 2:
             # Implement LEFT as substr(0,...)
-            left = op_exprs[0]
+            src = op_exprs[0]
             len_expr = op_exprs[1]
-            if not isinstance(len_expr, ConstantExpression):
-                raise ValueError("len_expr not a ConstantExpression")
 
-            out_empty = left.empty_data.iloc[:, 0]
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(len_expr, "len_expr", str)
+
+            out_empty = src.empty_data.iloc[:, 0]
             return ArrowScalarFuncExpression(
-                out_empty, [left], "utf8_slice_codeunits", (0, len_expr.value, 1)
+                out_empty, [src], "utf8_slice_codeunits", (0, len_expr.value, 1)
             )
         elif func_name == "RIGHT" and len(op_exprs) == 2:
             # Implement RIGHT as substr(-len,...)
-            left = op_exprs[0]
+            src = op_exprs[0]
             len_expr = op_exprs[1]
-            if not isinstance(len_expr, ConstantExpression):
-                raise ValueError("len_expr not a ConstantExpression")
 
-            out_empty = left.empty_data.iloc[:, 0]
+            ensure_type_of_expr(src, "src", str)
+            ensure_arg_is_const_expr_of_type(len_expr, "len_expr", str)
+
+            out_empty = src.empty_data.iloc[:, 0]
             return ArrowScalarFuncExpression(
-                out_empty, [left], "utf8_slice_codeunits", (-len_expr.value, None, 1)
+                out_empty, [src], "utf8_slice_codeunits", (-len_expr.value, None, 1)
             )
         elif func_name == "STARTSWITH" and len(op_exprs) == 2:
             src = op_exprs[0]
@@ -939,14 +927,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             if len(op_exprs) == 2:
                 delim_expr = op_exprs[1]
-                if not isinstance(delim_expr, bodo.pandas.plan.ConstantExpression):
-                    raise ValueError(
-                        f"delim_expr should be ConstantExpression but instead was {type(delim_expr)}"
-                    )
-                if not isinstance(delim_expr.value, str):
-                    raise ValueError(
-                        f"delim_expr.value should be string but instead was {type(delim_expr.value)}"
-                    )
+                ensure_arg_is_const_expr_of_type(delim_expr, "delim_expr", str)
                 raise ValueError("Delimiter argument to INITCAP not yet supported")
             # Note that Arrow's utf8_title considers numbers to be delimiters, which may differ from some implementations of INITCAP
             return ArrowScalarFuncExpression(

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1094,7 +1094,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             len_expr = op_exprs[1]
 
             ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(len_expr, "len_expr", str)
+            ensure_arg_is_const_expr_of_type(len_expr, "len_expr", int)
 
             out_empty = src.empty_data.iloc[:, 0]
             return ArrowScalarFuncExpression(
@@ -1106,7 +1106,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             len_expr = op_exprs[1]
 
             ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(len_expr, "len_expr", str)
+            ensure_arg_is_const_expr_of_type(len_expr, "len_expr", int)
 
             out_empty = src.empty_data.iloc[:, 0]
             return ArrowScalarFuncExpression(

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1572,6 +1572,22 @@ def ensure_arg_is_const_expr_of_type(expr, expr_name, dtype):
 
 
 def ensure_type_of_expr(expr, expr_name, dtype):
+    def compare_types(obj_type, expected_type):
+        if expected_type is int:
+            return pd.api.types.is_integer_dtype(obj_type)
+        if expected_type is float:
+            return pd.api.types.is_float_dtype(obj_type)
+        if expected_type is str:
+            return pd.api.types.is_string_dtype(obj_type)
+        if expected_type is bool:
+            return pd.api.types.is_bool_dtype(obj_type)
+        if isinstance(expected_type, np.dtype):
+            return np.issubdtype(obj_type, expected_type)
+        # At this point we could try converting dtypes to pandas dtypes
+        if isinstance(expected_type, pd.api.extensions.ExtensionDtype):
+            return pd.api.types.is_dtype_equal(obj_type, expected_type)
+        return False
+
     # Type checker that accounts for pandas dtypes
     def instanceof(obj, dtype):
         if isinstance(obj, dtype):
@@ -1579,20 +1595,7 @@ def ensure_type_of_expr(expr, expr_name, dtype):
         obj_type = (
             type(obj) if not isinstance(obj, (pd.Series, np.ndarray)) else obj.dtype
         )
-        if dtype is int:
-            return pd.api.types.is_integer_dtype(obj_type)
-        if dtype is float:
-            return pd.api.types.is_float_dtype(obj_type)
-        if dtype is str:
-            return pd.api.types.is_string_dtype(obj_type)
-        if dtype is bool:
-            return pd.api.types.is_bool_dtype(obj_type)
-        if isinstance(dtype, np.dtype):
-            return np.issubdtype(obj_type, dtype)
-        # At this point we could try converting dtypes to pandas dtypes
-        if isinstance(dtype, pd.api.extensions.ExtensionDtype):
-            return pd.api.types.is_dtype_equal(obj_type, dtype)
-        return False
+        return compare_types(obj_type, dtype)
 
     if instanceof(expr, dtype):
         return
@@ -1608,8 +1611,8 @@ def ensure_type_of_expr(expr, expr_name, dtype):
                 return
         elif isinstance(expr.empty_data, pd.DataFrame):
             assert len(expr.empty_data.columns) == 1
-            expr_dtype = expr.empty_data.columns[0].dtype
-            if instanceof(expr.empty_data.columns[0], dtype):
+            expr_dtype = expr.empty_data.dtypes[expr.empty_data.columns[0]]
+            if compare_types(expr_dtype, dtype):
                 return
         else:
             raise ValueError(

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1020,7 +1020,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 op_exprs[0].empty_data, op_exprs, "nullif", ()
             )
 
-        if func_name in ("CHAR_LENGTH", "CHARACTER_LENGTH") and len(op_exprs) == 1:
+        if func_name == "CHAR_LENGTH" and len(op_exprs) == 1:
             src = op_exprs[0]
             ensure_type_of_expr(src, "src", str)
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
@@ -1154,7 +1154,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 "match_substring",
                 (match_expr.value,),
             )
-        elif func_name in ("LENGTH", "LEN") and len(op_exprs) == 1:
+        elif func_name == "LENGTH" and len(op_exprs) == 1:
             src = op_exprs[0]
             ensure_type_of_expr(src, "src", str)
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))

--- a/BodoSQL/bodosql/tests/test_string_ops_first_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_first_half.py
@@ -13,6 +13,7 @@ from bodosql.tests.utils import check_query
 pytestmark = pytest_slow_unless_codegen
 
 
+@pytest.mark.bodosql_cpp
 def test_like(bodosql_string_types, regex_string, like_expression, memory_leak_check):
     """
     tests that like works for a variety of different possible regex strings
@@ -26,6 +27,7 @@ def test_like(bodosql_string_types, regex_string, like_expression, memory_leak_c
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_like_ilike_non_literal_pattern(bodosql_string_types, memory_leak_check):
     """
     tests that like and ilike works for non-literal patterns
@@ -74,6 +76,7 @@ def test_like_ilike_arr_pattern(memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_like_ilike_basic_escape(memory_leak_check):
     """
     tests that like and like works for a couple different possible regex strings
@@ -99,10 +102,8 @@ def test_like_ilike_basic_escape(memory_leak_check):
     ctx = {"TABLE1": df}
     query1 = "select A from table1 where A like '%w^%%' escape '^'"
     query2 = "select A from table1 where A ilike '%w^_%' escape '^'"
-    # Spark doesn't support ilike
     query3 = "select A from table1 where A like '^%R%' escape '^'"
     query4 = "select A from table1 where A ilike '^_X%' escape '^'"
-    # Spark doesn't support ilike
 
     check_query(
         query1,
@@ -130,6 +131,7 @@ def test_like_ilike_basic_escape(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_like_ilike_non_constant_basic_escape(memory_leak_check):
     """
     tests that like and ilike works for a couple different possible regex strings
@@ -188,6 +190,7 @@ def test_like_ilike_arr_escape(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_ilike(bodosql_string_types, regex_string, memory_leak_check):
     """
     tests that ilike works for a variety of different possible regex strings
@@ -202,6 +205,7 @@ def test_ilike(bodosql_string_types, regex_string, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_like_any_all(
     bodosql_multiple_string_types,
     regex_strings,
@@ -221,6 +225,7 @@ def test_like_any_all(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_like_scalar(
     bodosql_string_types, regex_string, like_expression, memory_leak_check
 ):
@@ -238,6 +243,7 @@ def test_like_scalar(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_like_with_logical_operators(
     bodosql_string_types, regex_string, like_expression, memory_leak_check
 ):
@@ -258,6 +264,7 @@ def test_like_with_logical_operators(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_like_cols(
     basic_df, regex_string, spark_info, like_expression, memory_leak_check
 ):
@@ -271,6 +278,7 @@ def test_like_cols(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_like_constants(
     basic_df,
     regex_string,
@@ -292,12 +300,14 @@ def test_like_constants(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_nested_upper_lower(bodosql_string_types, memory_leak_check):
     """
     Tests that lower/upper calls nest properly
     """
     check_query(
         "select lower(upper(lower(upper(A)))) from table1",
+        # "select upper(A) from table1",
         bodosql_string_types,
         None,
         check_names=False,
@@ -306,6 +316,7 @@ def test_nested_upper_lower(bodosql_string_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_upper_lower_scalars(basic_df, string_constants, memory_leak_check):
     """
     Tests that lower/upper calls work on scalar values
@@ -335,6 +346,7 @@ def test_upper_lower_scalars(basic_df, string_constants, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_upper_lower_scalars_nested(basic_df, string_constants, memory_leak_check):
     """
     Tests that nested lower/upper calls work on scalar values
@@ -351,6 +363,7 @@ def test_upper_lower_scalars_nested(basic_df, string_constants, memory_leak_chec
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_upper_lower_like_constants(
     basic_df,
     regex_string,
@@ -385,6 +398,7 @@ def test_upper_lower_like_constants(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_pythonic_regex(
     bodosql_string_types,
     pythonic_regex,
@@ -403,6 +417,7 @@ def test_pythonic_regex(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_all_percent(
     bodosql_string_types,
     like_expression,
@@ -420,6 +435,7 @@ def test_all_percent(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_all_percent_scalar(
     bodosql_string_types,
     like_expression,
@@ -439,6 +455,7 @@ def test_all_percent_scalar(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_leading_percent(
     bodosql_string_types,
     like_expression,
@@ -463,6 +480,7 @@ def test_leading_percent(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_leading_percent_scalar(
     bodosql_string_types,
     like_expression,
@@ -482,6 +500,7 @@ def test_leading_percent_scalar(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_trailing_percent(
     bodosql_string_types,
     like_expression,
@@ -506,6 +525,7 @@ def test_trailing_percent(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_trailing_percent_scalar(
     bodosql_string_types,
     like_expression,
@@ -525,6 +545,7 @@ def test_trailing_percent_scalar(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_both_percent(
     bodosql_string_types,
     like_expression,
@@ -549,6 +570,7 @@ def test_both_percent(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_both_percent_scalar(
     bodosql_string_types,
     like_expression,
@@ -576,6 +598,7 @@ def test_both_percent_scalar(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_utf_scalar():
     check_query(
         "select 'ǖǘǚǜ'",

--- a/BodoSQL/bodosql/tests/test_string_ops_first_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_first_half.py
@@ -307,7 +307,6 @@ def test_nested_upper_lower(bodosql_string_types, memory_leak_check):
     """
     check_query(
         "select lower(upper(lower(upper(A)))) from table1",
-        # "select upper(A) from table1",
         bodosql_string_types,
         None,
         check_names=False,

--- a/BodoSQL/bodosql/tests/test_string_ops_second_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_second_half.py
@@ -724,7 +724,7 @@ def test_format(args, bodosql_string_fn_testing_df, memory_leak_check):
         pytest.param(
             "SELECT SUBSTRING(source, -5, 3) from table1",
             id="SUBSTRING_scalar_int_2",
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
         pytest.param(
             "SELECT SUBSTR('alphabet soup is delicious', start_pos, length) from table1",

--- a/BodoSQL/bodosql/tests/test_string_ops_second_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_second_half.py
@@ -40,6 +40,7 @@ pytestmark = pytest_slow_unless_codegen
     ],
 )
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_contains(query, memory_leak_check):
     df = pd.DataFrame(
         {
@@ -59,6 +60,7 @@ def test_contains(query, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_concat_operator_cols(bodosql_string_types, memory_leak_check):
     """Checks that the concat operator is working for columns"""
     query = "select A || B || 'scalar' || C from table1"
@@ -72,6 +74,7 @@ def test_concat_operator_cols(bodosql_string_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_concat_operator_scalars(bodosql_string_types, memory_leak_check):
     """Checks that the concat operator is working for scalar values"""
     query = (
@@ -86,6 +89,7 @@ def test_concat_operator_scalars(bodosql_string_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_concat_fn_cols(bodosql_string_types, memory_leak_check):
     """Checks that the concat function is working for columns"""
     query = "select CONCAT(A, B, 'scalar', C) from table1"
@@ -98,6 +102,7 @@ def test_concat_fn_cols(bodosql_string_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_concat_fn_single_arg(bodosql_string_types, memory_leak_check):
     """Checks that the concat function is working for a single argument"""
     query = "select CONCAT(A) from table1"
@@ -111,6 +116,7 @@ def test_concat_fn_single_arg(bodosql_string_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_concat_fn_scalars(bodosql_string_types, memory_leak_check):
     """Checks that the concat function is working for scalar values"""
     query = "select CASE WHEN A > 'A' THEN CONCAT(B, ' case1') ELSE CONCAT(C, ' case2') END from table1"
@@ -123,6 +129,7 @@ def test_concat_fn_scalars(bodosql_string_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_concat_ws_single_arg(bodosql_string_types, memory_leak_check):
     """Checks that the concat_ws function is working for a single argument"""
     query = "select CONCAT_WS('_', A) from table1"
@@ -135,6 +142,7 @@ def test_concat_ws_single_arg(bodosql_string_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_concat_ws_cols(bodosql_string_types, memory_leak_check):
     """Checks that the concat_ws function is working for columns"""
     query = "select CONCAT_WS('_', A, B, C), CONCAT_WS(A, B) from table1"
@@ -148,6 +156,7 @@ def test_concat_ws_cols(bodosql_string_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_concat_ws_scalars(bodosql_string_types, memory_leak_check):
     """Checks that the concat_ws function is working for scalar values"""
     query = "select CASE WHEN A > 'A' THEN CONCAT_WS(' case1 ', B, C, A) ELSE CONCAT_WS(A,B,C) END from table1"
@@ -214,6 +223,7 @@ def test_concat_ws_scalars_binary(bodosql_binary_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_string_fns_cols(
     bodosql_string_fn_testing_df, string_fn_info, memory_leak_check
 ):
@@ -234,6 +244,7 @@ def test_string_fns_cols(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_string_fns_scalars(
     bodosql_string_fn_testing_df, string_fn_info, memory_leak_check
 ):
@@ -723,6 +734,7 @@ def test_format(args, bodosql_string_fn_testing_df, memory_leak_check):
         pytest.param(
             "SELECT MID('alphabet soup is delicious', 9, 4) from table1",
             id="SUBSTRING_all_scalar",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "SELECT SUBSTRING_INDEX(source, delim, occur) from table1",
@@ -828,6 +840,7 @@ def test_substring_suffix(func, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_length(bodosql_string_types, memory_leak_check):
     query = "SELECT LENGTH(A) as OUT1 FROM table1"
     check_query(

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
+#include "physical/expression.h"
 
 std::variant<int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t,
              uint64_t, bool, std::string, float, double,
@@ -957,6 +958,41 @@ PyObject *duckdbFilterSetToPyicebergFilter(
     return ret;
 }
 
+std::shared_ptr<array_info> ConvertDatumToArrayInfo(arrow::Datum datum) {
+    if (datum.is_scalar()) {
+        return arrow_array_to_bodo(
+            arrow::MakeArrayFromScalar(*datum.scalar(), 1).ValueOrDie(),
+            bodo::BufferPool::DefaultPtr());
+    }
+
+    std::shared_ptr<arrow::Array> arrow_arr = datum.make_array();
+    return arrow_array_to_bodo(arrow_arr, bodo::BufferPool::DefaultPtr());
+}
+
+arrow::Datum ConvertExprResultToDatum(std::shared_ptr<ExprResult> res,
+                                      std::string res_name) {
+    // Try to convert the results of our children into array
+    // or scalar results to see which one they are.
+
+    std::shared_ptr<ArrayExprResult> res_as_array =
+        std::dynamic_pointer_cast<ArrayExprResult>(res);
+    std::shared_ptr<ScalarExprResult> res_as_scalar =
+        std::dynamic_pointer_cast<ScalarExprResult>(res);
+
+    arrow::Datum src;
+    if (res_as_array) {
+        src = arrow::Datum(prepare_arrow_compute(res_as_array->result));
+    } else if (res_as_scalar) {
+        src = arrow::MakeScalar(prepare_arrow_compute(res_as_scalar->result)
+                                    ->GetScalar(0)
+                                    .ValueOrDie());
+    } else {
+        throw std::runtime_error(res_name + " is neither array nor scalar.");
+    }
+
+    return src;
+}
+
 arrow::Datum ConvertToDatum(void *raw_ptr,
                             std::shared_ptr<arrow::DataType> type) {
     using arrow::Type;
@@ -1178,26 +1214,46 @@ duckdb::unique_ptr<duckdb::TableFilterSet> JoinFilterColStats::insert_filters(
     return filters;
 }
 
-const char *get_py_single_arg_as_cstr(PyObject *args, const char *func_name) {
-    if (!PyTuple_Check(args) || PyTuple_Size(args) != 1) {
-        throw std::runtime_error(
-            fmt::format("{} args not a 1-element tuple.", func_name));
+void assert_py_args_is_tuple(PyObject *args, const char *err_context) {
+    if (!PyTuple_Check(args)) {
+        throw std::runtime_error(fmt::format("Args for {} is not a tuple.",
+                                             std::string(err_context)));
     }
+}
 
-    // Get the first element (borrowed reference)
-    PyObject *py_str = PyTuple_GetItem(args, 0);
+int64_t get_py_object_as_int64(PyObject *py_int, const char *err_context) {
+    if (!PyLong_Check(py_int)) {
+        throw std::runtime_error("Object is not a Python int: " +
+                                 std::string(err_context));
+    }
+    return PyLong_AsLongLong(py_int);
+}
 
+const char *get_py_object_as_cstr(PyObject *py_str, const char *err_context) {
     if (!PyUnicode_Check(py_str)) {
-        throw std::runtime_error(
-            fmt::format("{} args element is not a Python string.", func_name));
+        throw std::runtime_error("Object is not a Python string: " +
+                                 std::string(err_context));
     }
-
     // Convert to UTF‑8 C string
     const char *c_str = PyUnicode_AsUTF8(py_str);
     if (!c_str) {
         throw std::runtime_error(
-            fmt::format("{} error extracting Python string.", func_name));
+            fmt::format("Error for {} extracting Python string.",
+                        std::string(err_context)));
     }
+    return c_str;
+}
+
+bool get_py_object_as_bool(PyObject *py_bool, const char *err_context) {
+    if (py_bool != Py_True && py_bool != Py_False) {
+        throw std::runtime_error("Object is not a Python bool: " +
+                                 std::string(err_context));
+    }
+    return py_bool == Py_True;
+}
+
+const char *get_py_single_arg_as_cstr(PyObject *args, const char *func_name) {
+    auto [c_str] = get_py_args_as_types(args, func_name, get_py_object_as_cstr);
     return c_str;
 }
 
@@ -1207,11 +1263,7 @@ int64_t get_py_round_arg(PyObject *args) {
         // Get the first element (borrowed reference)
         PyObject *py_digits = PyTuple_GetItem(args, 0);
 
-        if (!PyLong_Check(py_digits)) {
-            throw std::runtime_error("round args element is not a Python int.");
-        }
-
-        digits = PyLong_AsLong(py_digits);
+        digits = get_py_object_as_int64(py_digits, "round args element");
     }
     return digits;
 }

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -964,6 +964,8 @@ PyObject *duckdbFilterSetToPyicebergFilter(
 }
 
 std::shared_ptr<array_info> ConvertDatumToArrayInfo(arrow::Datum datum) {
+    // DuckDB's optimizer may evaluate expressions with scalar input, see
+    // test_tpch_q22
     if (datum.is_scalar()) {
         return arrow_array_to_bodo(
             arrow::MakeArrayFromScalar(*datum.scalar(), 1).ValueOrDie(),

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -478,15 +478,16 @@ auto _get_py_args_as_types_tuple(PyObject *args, const char *func_name,
 }
 
 /**
- * @brief Get a single argument from a Python function call
- * and convert it to a boolean.
+ * @brief Get the PyTuple of function arguments as a tuple of the arguments
+ * cast to the requested types specified by a sequence of type conversion
+ * functions.
  *
  * @param args tuple containing the function arguments
  * @param func_name Name of the function (for error messages)
  * @param converters (varargs) PyObject-to-type conversion functions to apply to
- * the respective `args` passed Number of converters must be equal to the number
- * of arguments. Example of conversion functions: get_py_object_as_cstr,
- * get_py_object_as_bool
+ * the respective `args` passed. Number of converters must be equal to the
+ * number of arguments. Example of conversion functions: get_py_object_as_cstr,
+ * get_py_object_as_bool, get_py_object_as_int64
  * @return A tuple of the passed arguments converted to the types specified by
  * the corresponding passed `converters`
  */

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -2,6 +2,7 @@
 
 #include <Python.h>
 #include <arrow/api.h>
+#include <fmt/format.h>
 #include <cstdint>
 #include <limits>
 #include <map>
@@ -332,6 +333,34 @@ std::shared_ptr<arrow::Scalar> convertDuckdbValueToArrowScalar(
 std::shared_ptr<arrow::DataType> duckdbValueToArrowType(
     const duckdb::Value &value);
 
+class ExprResult;
+class ArrayExprResult;
+class ScalarExprResult;
+
+/**
+ * @brief Convert an arrow Datum into a Bodo array_info (shared pointer)
+ *
+ * @param datum arrow Datum to convert
+ * @return std::shared_ptr<array_info>, the converted arrow::Datum
+ */
+std::shared_ptr<array_info> ConvertDatumToArrayInfo(arrow::Datum datum);
+
+inline arrow::Datum ConvertExprResultToDatum(arrow::Datum res,
+                                             const std::string &res_name) {
+    return res;
+}
+
+/**
+ * @brief Convert an ExprResult shared pointer into an Arrow
+ * Datum.
+ *
+ * @param res shared pointer to ExprResult the value to turn into Arrow::Datum
+ * @param res_name name of the ExprResult to convert (for error messages)
+ * @return arrow::Datum the converted std::shared_ptr<ExprResult>
+ */
+arrow::Datum ConvertExprResultToDatum(std::shared_ptr<ExprResult> res,
+                                      std::string res_name);
+
 /**
  * @brief Convert a raw pointer to a value of a given arrow type into an arrow
  * Datum.
@@ -397,6 +426,84 @@ class JoinFilterColStats {
         duckdb::unique_ptr<duckdb::TableFilterSet> filters,
         const std::vector<int> column_projection);
 };
+
+/**
+ * @brief Assert that the Python objects arguments is a tuple
+ *
+ * @param args Python tuple containing the function arguments
+ * @param err_context String used for error messages, often the name of the
+ * function the arguments came from
+ */
+void assert_py_args_is_tuple(PyObject *args, const char *err_context);
+
+/**
+ * @brief Get a single argument from a Python function call
+ * and convert it to an int64 (long long).
+ *
+ * @param py_int Python object
+ * @param err_context String used for error messages, often the name of the
+ * function py_int came from
+ * @return int64 representation of the Python string argument
+ */
+int64_t get_py_object_as_int64(PyObject *py_int, const char *err_context);
+
+/**
+ * @brief Get a single string argument from a Python function call
+ * and convert it to a C string.
+ *
+ * @param py_str Python object
+ * @param err_context String used for error messages, often the name of the
+ * function py_str came from
+ * @return const char* C string representation of the Python string argument
+ */
+const char *get_py_object_as_cstr(PyObject *py_str, const char *err_context);
+
+/**
+ * @brief Get a single argument from a Python function call
+ * and convert it to a boolean.
+ *
+ * @param py_bool Python object
+ * @param err_context String used for error messages, often the name of the
+ * function py_bool came from
+ * @return bool representation of the Python argument
+ */
+bool get_py_object_as_bool(PyObject *py_bool, const char *err_context);
+
+/* Implementation detail of `get_py_args_as_types()`*/
+template <typename... Converters, std::size_t... Is>
+auto _get_py_args_as_types_tuple(PyObject *args, const char *func_name,
+                                 std::index_sequence<Is...>,
+                                 Converters... converters) {
+    return std::make_tuple(converters(PyTuple_GetItem(args, Is), func_name)...);
+}
+
+/**
+ * @brief Get a single argument from a Python function call
+ * and convert it to a boolean.
+ *
+ * @param args tuple containing the function arguments
+ * @param func_name Name of the function (for error messages)
+ * @param converters (varargs) PyObject-to-type conversion functions to apply to
+ * the respective `args` passed Number of converters must be equal to the number
+ * of arguments. Example of conversion functions: get_py_object_as_cstr,
+ * get_py_object_as_bool
+ * @return A tuple of the passed arguments converted to the types specified by
+ * the corresponding passed `converters`
+ */
+template <typename... Converters>
+auto get_py_args_as_types(PyObject *args, const char *func_name,
+                          Converters... converters) {
+    assert_py_args_is_tuple(args, func_name);
+    if (PyTuple_Size(args) != sizeof...(Converters)) {
+        throw std::runtime_error(fmt::format(
+            "{} args expected to be a {}-element tuple, got {} elements.",
+            func_name, sizeof...(Converters), PyTuple_Size(args)));
+    }
+
+    return _get_py_args_as_types_tuple(args, func_name,
+                                       std::index_sequence_for<Converters...>{},
+                                       converters...);
+}
 
 /**
  * @brief Get a single string argument from a Python function call's args tuple

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -140,24 +140,9 @@ std::shared_ptr<array_info> do_arrow_compute_multi_input(
     const std::string& arrow_func_name) {
     std::vector<arrow::Datum> arg_datums;
     for (auto& expr_res : in_expr_results) {
-        std::shared_ptr<ArrayExprResult> as_array =
-            std::dynamic_pointer_cast<ArrayExprResult>(expr_res);
-        std::shared_ptr<ScalarExprResult> as_scalar =
-            std::dynamic_pointer_cast<ScalarExprResult>(expr_res);
-
-        if (as_array) {
-            arg_datums.push_back(
-                arrow::Datum(prepare_arrow_compute(as_array->result)));
-        } else if (as_scalar) {
-            arg_datums.push_back(
-                arrow::MakeScalar(prepare_arrow_compute(as_scalar->result)
-                                      ->GetScalar(0)
-                                      .ValueOrDie()));
-        } else {
-            throw std::runtime_error(
-                "do_arrow_compute_multi_input input is neither array nor "
-                "scalar.");
-        }
+        arrow::Datum arg_datum = ConvertExprResultToDatum(
+            expr_res, "do_arrow_compute_multi_input input");
+        arg_datums.push_back(arg_datum);
     }
 
     arrow::Result<arrow::Datum> func_res;
@@ -206,15 +191,7 @@ std::shared_ptr<array_info> do_arrow_compute_multi_input(
             func_res.status().message());
     }
 
-    arrow::Datum result_datum = func_res.ValueOrDie();
-    if (result_datum.is_scalar()) {
-        return arrow_array_to_bodo(
-            arrow::MakeArrayFromScalar(*result_datum.scalar(), 1).ValueOrDie(),
-            bodo::BufferPool::DefaultPtr());
-    }
-
-    return arrow_array_to_bodo(result_datum.make_array(),
-                               bodo::BufferPool::DefaultPtr());
+    return ConvertDatumToArrayInfo(func_res.ValueOrDie());
 }
 
 std::shared_ptr<array_info> do_arrow_compute_binary(
@@ -255,60 +232,18 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
 std::shared_ptr<array_info> do_arrow_compute_unary(
     std::shared_ptr<ExprResult> left_res, const std::string& comparator,
     const arrow::compute::FunctionOptions* func_options) {
-    // Try to convert the results of our children into array
-    // or scalar results to see which one they are.
-    std::shared_ptr<ArrayExprResult> left_as_array =
-        std::dynamic_pointer_cast<ArrayExprResult>(left_res);
-    std::shared_ptr<ScalarExprResult> left_as_scalar =
-        std::dynamic_pointer_cast<ScalarExprResult>(left_res);
-
-    arrow::Datum src1;
-    if (left_as_array) {
-        src1 = arrow::Datum(prepare_arrow_compute(left_as_array->result));
-    } else if (left_as_scalar) {
-        src1 = arrow::MakeScalar(prepare_arrow_compute(left_as_scalar->result)
-                                     ->GetScalar(0)
-                                     .ValueOrDie());
-    } else {
-        throw std::runtime_error(
-            "do_arrow_compute left is neither array nor scalar.");
-    }
+    arrow::Datum src1 =
+        ConvertExprResultToDatum(left_res, "do_arrow_compute left");
     arrow::Datum cmp_res =
         do_arrow_compute_unary(src1, comparator, func_options);
-
-    // DuckDB's optimizer may evaluate expressions with scalar input, see
-    // test_tpch_q22
-    if (cmp_res.is_scalar()) {
-        return arrow_array_to_bodo(
-            arrow::MakeArrayFromScalar(*cmp_res.scalar(), 1).ValueOrDie(),
-            bodo::BufferPool::DefaultPtr());
-    }
-
-    return arrow_array_to_bodo(cmp_res.make_array(),
-                               bodo::BufferPool::DefaultPtr());
+    return ConvertDatumToArrayInfo(cmp_res);
 }
 
 std::shared_ptr<array_info> do_arrow_compute_cast(
     std::shared_ptr<ExprResult> left_res,
     const duckdb::LogicalType& return_type) {
-    // Try to convert the results of our children into array
-    // or scalar results to see which one they are.
-    std::shared_ptr<ArrayExprResult> left_as_array =
-        std::dynamic_pointer_cast<ArrayExprResult>(left_res);
-    std::shared_ptr<ScalarExprResult> left_as_scalar =
-        std::dynamic_pointer_cast<ScalarExprResult>(left_res);
-
-    arrow::Datum src1;
-    if (left_as_array) {
-        src1 = arrow::Datum(prepare_arrow_compute(left_as_array->result));
-    } else if (left_as_scalar) {
-        src1 = arrow::MakeScalar(prepare_arrow_compute(left_as_scalar->result)
-                                     ->GetScalar(0)
-                                     .ValueOrDie());
-    } else {
-        throw std::runtime_error(
-            "do_arrow_compute left is neither array nor scalar.");
-    }
+    arrow::Datum src1 =
+        ConvertExprResultToDatum(left_res, "do_arrow_compute left");
 
     std::shared_ptr<arrow::DataType> arrow_ret_type =
         duckdbTypeToArrow(return_type);
@@ -320,15 +255,7 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
             cmp_res.status().message());
     }
 
-    auto res = cmp_res.ValueOrDie();
-    if (res.is_scalar()) {
-        return arrow_array_to_bodo(
-            arrow::MakeArrayFromScalar(*res.scalar(), 1).ValueOrDie(),
-            bodo::BufferPool::DefaultPtr());
-    }
-
-    return arrow_array_to_bodo(res.make_array(),
-                               bodo::BufferPool::DefaultPtr());
+    return ConvertDatumToArrayInfo(cmp_res.ValueOrDie());
 }
 
 arrow::Datum do_arrow_compute_binary(
@@ -428,21 +355,14 @@ arrow::Datum do_arrow_compute_cast(arrow::Datum left_res,
 
 std::shared_ptr<array_info> do_arrow_compute_case(
     std::shared_ptr<ExprResult> when_res, std::shared_ptr<ExprResult> then_res,
-    std::shared_ptr<ExprResult> else_res) {
+    std::shared_ptr<ExprResult> else_res,
+    const std::shared_ptr<arrow::DataType> result_type) {
     // Try to convert the results of our children into array
     // or scalar results to see which one they are.
     std::shared_ptr<ArrayExprResult> when_as_array =
         std::dynamic_pointer_cast<ArrayExprResult>(when_res);
     std::shared_ptr<ScalarExprResult> when_as_scalar =
         std::dynamic_pointer_cast<ScalarExprResult>(when_res);
-    std::shared_ptr<ArrayExprResult> then_as_array =
-        std::dynamic_pointer_cast<ArrayExprResult>(then_res);
-    std::shared_ptr<ScalarExprResult> then_as_scalar =
-        std::dynamic_pointer_cast<ScalarExprResult>(then_res);
-    std::shared_ptr<ArrayExprResult> else_as_array =
-        std::dynamic_pointer_cast<ArrayExprResult>(else_res);
-    std::shared_ptr<ScalarExprResult> else_as_scalar =
-        std::dynamic_pointer_cast<ScalarExprResult>(else_res);
 
     arrow::Datum src1;
     if (when_as_array) {
@@ -466,42 +386,36 @@ std::shared_ptr<array_info> do_arrow_compute_case(
             "do_arrow_compute when is neither array nor scalar.");
     }
 
-    arrow::Datum src2;
-    if (then_as_array) {
-        src2 = arrow::Datum(prepare_arrow_compute(then_as_array->result));
-    } else if (then_as_scalar) {
-        src2 = arrow::MakeScalar(prepare_arrow_compute(then_as_scalar->result)
-                                     ->GetScalar(0)
-                                     .ValueOrDie());
-    } else {
-        throw std::runtime_error(
-            "do_arrow_compute then is neither array nor scalar.");
-    }
-
-    arrow::Datum src3;
-    if (else_as_array) {
-        src3 = arrow::Datum(prepare_arrow_compute(else_as_array->result));
-    } else if (else_as_scalar) {
-        src3 = arrow::MakeScalar(prepare_arrow_compute(else_as_scalar->result)
-                                     ->GetScalar(0)
-                                     .ValueOrDie());
-    } else {
-        throw std::runtime_error(
-            "do_arrow_compute else is neither array nor scalar.");
-    }
+    arrow::Datum src2 =
+        ConvertExprResultToDatum(then_res, "do_arrow_compute then");
+    arrow::Datum src3 =
+        ConvertExprResultToDatum(else_res, "do_arrow_compute else");
 
     // NOTE: Arrow's "if_else" doesn't match our Python and SQL semantics since
     // it propagates nulls in the condition.
-    arrow::Result<arrow::Datum> cmp_res =
+    arrow::Result<arrow::Datum> case_res =
         arrow::compute::CallFunction("case_when", {src1, src2, src3});
-    if (!cmp_res.ok()) [[unlikely]] {
+    if (!case_res.ok()) [[unlikely]] {
         throw std::runtime_error(
             "do_array_compute_case: Error in Arrow compute: " +
-            cmp_res.status().message());
+            case_res.status().message());
     }
 
-    return arrow_array_to_bodo(cmp_res.ValueOrDie().make_array(),
-                               bodo::BufferPool::DefaultPtr());
+    arrow::Datum case_datum = case_res.ValueOrDie();
+    std::shared_ptr<arrow::DataType> case_dtype = case_datum.type();
+    if (result_type && case_dtype != result_type) {
+        // Cast to result type if available and different from current type.
+        arrow::Result<arrow::Datum> cast_res =
+            arrow::compute::Cast(case_datum, result_type);
+        if (!cast_res.ok()) [[unlikely]] {
+            throw std::runtime_error(
+                "do_arrow_compute_binary cast_res: Error in Arrow compute: " +
+                cast_res.status().message());
+        }
+        case_res = cast_res;
+    }
+
+    return ConvertDatumToArrayInfo(case_res.ValueOrDie());
 }
 
 std::shared_ptr<PhysicalExpression> buildPhysicalExprTree(

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -221,72 +221,35 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
     std::shared_ptr<ExprResult> left_res, std::shared_ptr<ExprResult> right_res,
     const std::string& comparator,
     const std::shared_ptr<arrow::DataType> result_type) {
-    // Try to convert the results of our children into array
-    // or scalar results to see which one they are.
-    std::shared_ptr<ArrayExprResult> left_as_array =
-        std::dynamic_pointer_cast<ArrayExprResult>(left_res);
-    std::shared_ptr<ScalarExprResult> left_as_scalar =
-        std::dynamic_pointer_cast<ScalarExprResult>(left_res);
-    std::shared_ptr<ArrayExprResult> right_as_array =
-        std::dynamic_pointer_cast<ArrayExprResult>(right_res);
-    std::shared_ptr<ScalarExprResult> right_as_scalar =
-        std::dynamic_pointer_cast<ScalarExprResult>(right_res);
+    arrow::Datum src1 =
+        ConvertExprResultToDatum(left_res, "do_arrow_compute left");
+    arrow::Datum src2 =
+        ConvertExprResultToDatum(right_res, "do_arrow_compute right");
+    arrow::Datum cmp_res_datum =
+        do_arrow_compute_binary(src1, src2, comparator);
+    return ConvertDatumToArrayInfo(cmp_res_datum);
+}
 
-    arrow::Datum src1;
-    if (left_as_array) {
-        src1 = arrow::Datum(prepare_arrow_compute(left_as_array->result));
-    } else if (left_as_scalar) {
-        src1 = arrow::MakeScalar(prepare_arrow_compute(left_as_scalar->result)
-                                     ->GetScalar(0)
-                                     .ValueOrDie());
-    } else {
-        throw std::runtime_error(
-            "do_arrow_compute left is neither array nor scalar.");
-    }
+std::shared_ptr<array_info> do_arrow_compute_binary(
+    arrow::Datum left_res, std::shared_ptr<ExprResult> right_res,
+    const std::string& comparator,
+    const std::shared_ptr<arrow::DataType> result_type) {
+    arrow::Datum src2 =
+        ConvertExprResultToDatum(right_res, "do_arrow_compute right");
+    arrow::Datum cmp_res_datum =
+        do_arrow_compute_binary(left_res, src2, comparator);
+    return ConvertDatumToArrayInfo(cmp_res_datum);
+}
 
-    arrow::Datum src2;
-    if (right_as_array) {
-        src2 = arrow::Datum(prepare_arrow_compute(right_as_array->result));
-    } else if (right_as_scalar) {
-        src2 = arrow::MakeScalar(prepare_arrow_compute(right_as_scalar->result)
-                                     ->GetScalar(0)
-                                     .ValueOrDie());
-    } else {
-        throw std::runtime_error(
-            "do_arrow_compute right is neither array nor scalar.");
-    }
-
-    arrow::Result<arrow::Datum> cmp_res =
-        arrow::compute::CallFunction(comparator, {src1, src2});
-    if (!cmp_res.ok()) [[unlikely]] {
-        throw std::runtime_error(
-            "do_arrow_compute_binary cmp_res: Error in Arrow compute: " +
-            cmp_res.status().message());
-    }
-
-    auto cmp_datum = cmp_res.ValueOrDie();
-    std::shared_ptr<arrow::DataType> cmp_dtype = cmp_datum.type();
-    if (result_type && cmp_dtype != result_type) {
-        // Cast to result type if available and different from current type.
-        arrow::Result<arrow::Datum> cast_res =
-            arrow::compute::Cast(cmp_datum, result_type);
-        if (!cast_res.ok()) [[unlikely]] {
-            throw std::runtime_error(
-                "do_arrow_compute_binary cast_res: Error in Arrow compute: " +
-                cast_res.status().message());
-        }
-        cmp_res = cast_res;
-    }
-
-    auto res = cmp_res.ValueOrDie();
-    if (res.is_scalar()) {
-        return arrow_array_to_bodo(
-            arrow::MakeArrayFromScalar(*res.scalar(), 1).ValueOrDie(),
-            bodo::BufferPool::DefaultPtr());
-    }
-
-    std::shared_ptr<arrow::Array> arrow_arr = cmp_res.ValueOrDie().make_array();
-    return arrow_array_to_bodo(arrow_arr, bodo::BufferPool::DefaultPtr());
+std::shared_ptr<array_info> do_arrow_compute_binary(
+    std::shared_ptr<ExprResult> left_res, arrow::Datum right_res,
+    const std::string& comparator,
+    const std::shared_ptr<arrow::DataType> result_type) {
+    arrow::Datum src1 =
+        ConvertExprResultToDatum(left_res, "do_arrow_compute left");
+    arrow::Datum cmp_res_datum =
+        do_arrow_compute_binary(src1, right_res, comparator);
+    return ConvertDatumToArrayInfo(cmp_res_datum);
 }
 
 std::shared_ptr<array_info> do_arrow_compute_unary(
@@ -368,15 +331,31 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
                                bodo::BufferPool::DefaultPtr());
 }
 
-arrow::Datum do_arrow_compute_binary(arrow::Datum left_res,
-                                     arrow::Datum right_res,
-                                     const std::string& comparator) {
+arrow::Datum do_arrow_compute_binary(
+    arrow::Datum left_res, arrow::Datum right_res,
+    const std::string& comparator,
+    const std::shared_ptr<arrow::DataType> result_type) {
     arrow::Result<arrow::Datum> cmp_res =
         arrow::compute::CallFunction(comparator, {left_res, right_res});
     if (!cmp_res.ok()) [[unlikely]] {
         throw std::runtime_error(
             "do_array_compute_binary: Error in Arrow compute: " +
             cmp_res.status().message());
+    }
+
+    arrow::Datum cmp_datum = cmp_res.ValueOrDie();
+
+    std::shared_ptr<arrow::DataType> cmp_dtype = cmp_datum.type();
+    if (result_type && cmp_dtype != result_type) {
+        // Cast to result type if available and different from current type.
+        arrow::Result<arrow::Datum> cast_res =
+            arrow::compute::Cast(cmp_datum, result_type);
+        if (!cast_res.ok()) [[unlikely]] {
+            throw std::runtime_error(
+                "do_arrow_compute_binary cast_res: Error in Arrow compute: " +
+                cast_res.status().message());
+        }
+        cmp_res = cast_res;
     }
 
     return cmp_res.ValueOrDie();
@@ -818,7 +797,8 @@ std::shared_ptr<PhysicalExpression> buildPhysicalExprTree(
                     buildPhysicalExprTree(caseCheck.then_expr, col_ref_map,
                                           no_scalars),
                     buildPhysicalExprTree(bce.else_expr, col_ref_map,
-                                          no_scalars)));
+                                          no_scalars),
+                    duckdbTypeToArrow(bce.return_type)));
         } break;  // suppress wrong fallthrough error
         default:
             throw std::runtime_error(
@@ -914,6 +894,21 @@ std::shared_ptr<ExprResult> PhysicalArrowExpression::ProcessBatch(
         result = this->do_arrow_compute(res);
         this->metrics.arrow_compute_time += end_timer(start_init_time);
     }
+
+    // Broadcast scalar result to batch size
+    if (result->length == 1 && input_batch->nrows() > 1) {
+        std::shared_ptr<arrow::Array> arrow_arr = prepare_arrow_compute(result);
+        auto scalar = arrow_arr->GetScalar(0).ValueOrDie();
+        auto broadcast =
+            arrow::MakeArrayFromScalar(*scalar, input_batch->nrows());
+        if (!broadcast.ok()) {
+            throw std::runtime_error("Failed to broadcast scalar: " +
+                                     broadcast.status().message());
+        }
+        result = arrow_array_to_bodo(broadcast.ValueOrDie(),
+                                     bodo::BufferPool::DefaultPtr());
+    }
+
     return std::make_shared<ArrayExprResult>(result, "Arrow Scalar");
 }
 

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -226,7 +226,7 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
     arrow::Datum src2 =
         ConvertExprResultToDatum(right_res, "do_arrow_compute right");
     arrow::Datum cmp_res_datum =
-        do_arrow_compute_binary(src1, src2, comparator);
+        do_arrow_compute_binary(src1, src2, comparator, result_type);
     return ConvertDatumToArrayInfo(cmp_res_datum);
 }
 
@@ -237,7 +237,7 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
     arrow::Datum src2 =
         ConvertExprResultToDatum(right_res, "do_arrow_compute right");
     arrow::Datum cmp_res_datum =
-        do_arrow_compute_binary(left_res, src2, comparator);
+        do_arrow_compute_binary(left_res, src2, comparator, result_type);
     return ConvertDatumToArrayInfo(cmp_res_datum);
 }
 
@@ -248,7 +248,7 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
     arrow::Datum src1 =
         ConvertExprResultToDatum(left_res, "do_arrow_compute left");
     arrow::Datum cmp_res_datum =
-        do_arrow_compute_binary(src1, right_res, comparator);
+        do_arrow_compute_binary(src1, right_res, comparator, result_type);
     return ConvertDatumToArrayInfo(cmp_res_datum);
 }
 

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -192,6 +192,26 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
     const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
+ * @brief Run arrow compute on the left Datum and right ExprResult after
+ * converting the ExprResult to an Arrow Datum.
+ *
+ */
+std::shared_ptr<array_info> do_arrow_compute_binary(
+    arrow::Datum left_res, std::shared_ptr<ExprResult> right_res,
+    const std::string &comparator,
+    const std::shared_ptr<arrow::DataType> result_type = nullptr);
+
+/**
+ * @brief Run arrow compute on the left ExprResult and right Datum after
+ * converting the ExprResult to an Arrow Datum.
+ *
+ */
+std::shared_ptr<array_info> do_arrow_compute_binary(
+    std::shared_ptr<ExprResult> left_res, arrow::Datum right_res,
+    const std::string &comparator,
+    const std::shared_ptr<arrow::DataType> result_type = nullptr);
+
+/**
  * @brief Convert ExprResult to arrow and cast to the requested type.
  *
  */
@@ -219,9 +239,10 @@ arrow::Datum do_arrow_compute_unary(
  * @brief Run arrow compute operation on two Datums.
  *
  */
-arrow::Datum do_arrow_compute_binary(arrow::Datum left_res,
-                                     arrow::Datum right_res,
-                                     const std::string &comparator);
+arrow::Datum do_arrow_compute_binary(
+    arrow::Datum left_res, arrow::Datum right_res,
+    const std::string &comparator,
+    const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
  * @brief Run cast on arrow Datum.
@@ -1029,8 +1050,10 @@ class PhysicalCaseExpression : public PhysicalExpression {
    public:
     PhysicalCaseExpression(std::shared_ptr<PhysicalExpression> when_expr,
                            std::shared_ptr<PhysicalExpression> then_expr,
-                           std::shared_ptr<PhysicalExpression> else_expr)
-        : PhysicalExpression(PhysicalExpressionType::CASE) {
+                           std::shared_ptr<PhysicalExpression> else_expr,
+                           std::shared_ptr<arrow::DataType> result_type)
+        : PhysicalExpression(PhysicalExpressionType::CASE),
+          result_type(std::move(result_type)) {
         children.push_back(when_expr);
         children.push_back(then_expr);
         children.push_back(else_expr);
@@ -1053,6 +1076,24 @@ class PhysicalCaseExpression : public PhysicalExpression {
             children[2]->ProcessBatch(input_batch);
 
         auto result = do_arrow_compute_case(when_res, then_res, else_res);
+
+        // Cast result to expected type if different
+        if (result_type) {
+            std::shared_ptr<arrow::Array> arrow_arr =
+                prepare_arrow_compute(result);
+            if (!arrow_arr->type()->Equals(result_type)) {
+                arrow::Result<arrow::Datum> cast_res =
+                    arrow::compute::Cast(arrow_arr, result_type);
+                if (!cast_res.ok()) [[unlikely]] {
+                    throw std::runtime_error(
+                        "PhysicalCaseExpression cast failed: " +
+                        cast_res.status().message());
+                }
+                result = arrow_array_to_bodo(cast_res.ValueOrDie().make_array(),
+                                             bodo::BufferPool::DefaultPtr());
+            }
+        }
+
         auto when_as_scalar =
             std::dynamic_pointer_cast<ScalarExprResult>(when_res);
         auto then_as_scalar =
@@ -1088,6 +1129,9 @@ class PhysicalCaseExpression : public PhysicalExpression {
         }
         return cmp_res.ValueOrDie();
     }
+
+   private:
+    const std::shared_ptr<arrow::DataType> result_type;
 };
 
 /**
@@ -1350,10 +1394,25 @@ class PhysicalArrowExpression : public PhysicalExpression {
                        "match_substring_regex_first" ||
                    scalar_func_data.arrow_func_name == "match_substring" ||
                    scalar_func_data.arrow_func_name == "starts_with" ||
-                   scalar_func_data.arrow_func_name == "ends_with") {
-            const char *c_str = get_py_single_arg_as_cstr(
-                scalar_func_data.args,
-                scalar_func_data.arrow_func_name.c_str());
+                   scalar_func_data.arrow_func_name == "ends_with" ||
+                   scalar_func_data.arrow_func_name == "find_substring") {
+            assert_py_args_is_tuple(scalar_func_data.args,
+                                    scalar_func_data.arrow_func_name.c_str());
+            size_t num_args = PyTuple_Size(scalar_func_data.args);
+            const char *c_str;
+            bool ignore_case = false;
+            if (num_args == 1) {
+                // Only string was passed
+                c_str = get_py_single_arg_as_cstr(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str());
+            } else {
+                // string and ignore_case passed
+                std::tie(c_str, ignore_case) = get_py_args_as_types(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str(),
+                    get_py_object_as_cstr, get_py_object_as_bool);
+            }
 
             std::string func_name = scalar_func_data.arrow_func_name;
             std::string pattern(c_str);
@@ -1366,7 +1425,7 @@ class PhysicalArrowExpression : public PhysicalExpression {
                 pattern = "^(" + pattern + ")";
             }
 
-            arrow::compute::MatchSubstringOptions opts(pattern);
+            arrow::compute::MatchSubstringOptions opts(pattern, ignore_case);
             result = do_arrow_compute_unary(res, func_name, &opts);
         } else if (scalar_func_data.arrow_func_name == "round") {
             int64_t digits = get_py_round_arg(scalar_func_data.args);
@@ -1396,6 +1455,54 @@ class PhysicalArrowExpression : public PhysicalExpression {
 
             arrow::compute::TrimOptions opts(c_str);
             result = do_arrow_compute_unary(res, "utf8_trim", &opts);
+        } else if (scalar_func_data.arrow_func_name == "utf8_lpad" ||
+                   scalar_func_data.arrow_func_name == "utf8_rpad") {
+            int64_t width;
+            const char *padding;
+
+            assert_py_args_is_tuple(scalar_func_data.args,
+                                    scalar_func_data.arrow_func_name.c_str());
+            if (PyTuple_Size(scalar_func_data.args) > 1) {
+                std::tie(width, padding) = get_py_args_as_types(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str(),
+                    get_py_object_as_int64, get_py_object_as_cstr);
+            } else {
+                std::tie(width) = get_py_args_as_types(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str(),
+                    get_py_object_as_int64);
+                padding = " ";
+            }
+
+            std::string padding_str(padding);
+
+            arrow::compute::PadOptions opts(width, padding_str);
+            result = do_arrow_compute_unary(
+                res, scalar_func_data.arrow_func_name, &opts);
+        } else if (scalar_func_data.arrow_func_name == "binary_repeat") {
+            assert_py_args_is_tuple(scalar_func_data.args,
+                                    scalar_func_data.arrow_func_name.c_str());
+            auto [num_repeats] = get_py_args_as_types(
+                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
+                get_py_object_as_int64);
+            arrow::Datum num_repeats_datum(
+                std::make_shared<arrow::Int64Scalar>(num_repeats));
+            result = do_arrow_compute_binary(res, num_repeats_datum,
+                                             "binary_repeat");
+        } else if (scalar_func_data.arrow_func_name == "replace_substring") {
+            assert_py_args_is_tuple(scalar_func_data.args,
+                                    scalar_func_data.arrow_func_name.c_str());
+            auto [pattern, replacement] = get_py_args_as_types(
+                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
+                get_py_object_as_cstr, get_py_object_as_cstr);
+
+            std::string pattern_str(pattern);
+            std::string replacement_str(replacement);
+
+            arrow::compute::ReplaceSubstringOptions opts(pattern, replacement);
+            result = do_arrow_compute_unary(
+                res, scalar_func_data.arrow_func_name, &opts);
         } else if (scalar_func_data.arrow_func_name == "is_in") {
             std::shared_ptr<arrow::Array> values_array =
                 get_py_isin_arg_as_arrow_array(scalar_func_data.args);

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -228,7 +228,8 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
  */
 std::shared_ptr<array_info> do_arrow_compute_case(
     std::shared_ptr<ExprResult> when_res, std::shared_ptr<ExprResult> then_res,
-    std::shared_ptr<ExprResult> else_res);
+    std::shared_ptr<ExprResult> else_res,
+    const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
  * @brief Run arrow compute operation on unary Datum.
@@ -1049,12 +1050,13 @@ class PhysicalCalendarIntervalExpression : public PhysicalExpression {
  */
 class PhysicalCaseExpression : public PhysicalExpression {
    public:
-    PhysicalCaseExpression(std::shared_ptr<PhysicalExpression> when_expr,
-                           std::shared_ptr<PhysicalExpression> then_expr,
-                           std::shared_ptr<PhysicalExpression> else_expr,
-                           std::shared_ptr<arrow::DataType> result_type)
+    PhysicalCaseExpression(
+        std::shared_ptr<PhysicalExpression> when_expr,
+        std::shared_ptr<PhysicalExpression> then_expr,
+        std::shared_ptr<PhysicalExpression> else_expr,
+        const std::shared_ptr<arrow::DataType> _result_type = nullptr)
         : PhysicalExpression(PhysicalExpressionType::CASE),
-          result_type(std::move(result_type)) {
+          result_type(_result_type) {
         children.push_back(when_expr);
         children.push_back(then_expr);
         children.push_back(else_expr);
@@ -1076,24 +1078,8 @@ class PhysicalCaseExpression : public PhysicalExpression {
         std::shared_ptr<ExprResult> else_res =
             children[2]->ProcessBatch(input_batch);
 
-        auto result = do_arrow_compute_case(when_res, then_res, else_res);
-
-        // Cast result to expected type if different
-        if (result_type) {
-            std::shared_ptr<arrow::Array> arrow_arr =
-                prepare_arrow_compute(result);
-            if (!arrow_arr->type()->Equals(result_type)) {
-                arrow::Result<arrow::Datum> cast_res =
-                    arrow::compute::Cast(arrow_arr, result_type);
-                if (!cast_res.ok()) [[unlikely]] {
-                    throw std::runtime_error(
-                        "PhysicalCaseExpression cast failed: " +
-                        cast_res.status().message());
-                }
-                result = arrow_array_to_bodo(cast_res.ValueOrDie().make_array(),
-                                             bodo::BufferPool::DefaultPtr());
-            }
-        }
+        auto result =
+            do_arrow_compute_case(when_res, then_res, else_res, result_type);
 
         auto when_as_scalar =
             std::dynamic_pointer_cast<ScalarExprResult>(when_res);


### PR DESCRIPTION
## Changes included in this PR

Added conversions to Arrow compute functions for several SQL string operations and marked the corresponding tests with `pytest.mark.bodosql_cpp`.
Added two helper functions in `plan_conversion.py`: `ensure_arg_is_const_expr_of_type` and `ensure_type_of_expr`.
Added utility function `get_py_args_as_types` to `util.h` to make it easier to grab an arbitrary number of `scalar_func_data.args` as various types.
Did some refactoring so it was cleaner to add overloads for `do_arrow_compute_binary` for the combinations of `ExprResult` and `arrow::Datum` type arguments.
Fixed an issue in the backend with scalar results and a type mismatch issue related to case expressions.

## Testing strategy

CI

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.