### PR TITLE
Filter ID not found.

### DIFF
--- a/BodoSQL/bodosql/tests/conftest.py
+++ b/BodoSQL/bodosql/tests/conftest.py
@@ -1253,7 +1253,6 @@ def tpch_data_helper(datapath):
     return dataframe_dict
 
 
-@bodo.jit(returns_maybe_distributed=False, cache=True)
 def load_tpch_data(dir_name):
     """Load the necessary TPCH DataFrames given a root directory.
     We use bodo.jit so we can read easily from a directory.

--- a/BodoSQL/bodosql/tests/test_tpch_first_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_first_half.py
@@ -872,6 +872,7 @@ def test_tpch_q10(tpch_data, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q11(tpch_data, memory_leak_check):
     NATION = "GERMANY"
     FRACTION = 0.0001

--- a/BodoSQL/bodosql/tests/test_tpch_second_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_second_half.py
@@ -547,6 +547,7 @@ def test_tpch_q20(tpch_data, memory_leak_check):
 
 @pytest.mark.timeout(900)
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q21(tpch_data, memory_leak_check):
     NATION = "SAUDI ARABIA"
     tpch_query = f"""select
@@ -613,6 +614,7 @@ def test_tpch_q21(tpch_data, memory_leak_check):
 
 @pytest.mark.timeout(600)
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q22(tpch_data, memory_leak_check):
     I1 = 13
     I2 = 31

--- a/BodoSQL/bodosql/tests/test_tpch_second_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_second_half.py
@@ -16,6 +16,7 @@ from bodosql.tests.utils import check_query, shrink_data
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q12(tpch_data, memory_leak_check):
     SHIPMODE1 = "MAIL"
     SHIPMODE2 = "SHIP"
@@ -426,6 +427,7 @@ def test_tpch_q18(tpch_data, memory_leak_check):
 
 @pytest.mark.timeout(600)
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_tpch_q19(tpch_data, memory_leak_check):
     QUANTITY1 = 1
     QUANTITY2 = 10

--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -839,6 +839,9 @@ void PhysicalPlanBuilder::Visit(bodo::LogicalJoinFilter& op) {
 #endif  // USE_CUDF
 
     bool found_join_on_same_device = false;
+    // If might be the case that all the join filters
+    // don't exist and if so then we don't need this node.
+    bool node_needed = false;
 
     // Make sure all filter generators used by this
     // join filter run before this pipeline.
@@ -849,13 +852,23 @@ void PhysicalPlanBuilder::Visit(bodo::LogicalJoinFilter& op) {
         }
         found_join_on_same_device = true;
 #endif  // USE_CUDF
-        std::shared_ptr<Pipeline> filter_pipeline =
-            (*join_filter_pipelines)[filter_id];
-        if (!filter_pipeline) {
-            throw std::runtime_error(
-                "Pipeline for given filter id not found in "
-                "join_filter_states.");
+        auto join_filter_iter = join_filter_pipelines->find(filter_id);
+        std::shared_ptr<Pipeline> filter_pipeline;
+        if (join_filter_iter == join_filter_pipelines->end()) {
+            // If we convert a join into a cross-product/filter
+            // then there will be no join node to generate a bloom filter
+            // and the join_id will be missing in join_filter_pipelines.
+            // Since no bloom filter we can ignore these cases.
+            continue;
+        } else {
+            filter_pipeline = join_filter_iter->second;
+            if (!filter_pipeline) {
+                throw std::runtime_error(
+                    "Pipeline for given filter id is null in "
+                    "join_filter_states.");
+            }
         }
+        node_needed = true;
         // Make sure generator of the filter runs before
         // this consumer of the filter.
         this->active_pipeline->addRunBefore(filter_pipeline);
@@ -864,7 +877,7 @@ void PhysicalPlanBuilder::Visit(bodo::LogicalJoinFilter& op) {
     // the same device type.  We could change this later but it is much
     // more complicated and involves transferring and transforming the
     // bloom filters.
-    if (!found_join_on_same_device) {
+    if (!found_join_on_same_device || !node_needed) {
         return;
     }
 

--- a/bodo/pandas/physical/join_filter.h
+++ b/bodo/pandas/physical/join_filter.h
@@ -132,7 +132,11 @@ class PhysicalJoinFilter : public PhysicalProcessBatch {
                 continue;
             }
 
-            join_state_t join_state_ = (*join_filter_states)[filter_id];
+            auto join_filter_iter = join_filter_states->find(filter_id);
+            if (join_filter_iter == join_filter_states->end()) {
+                continue;
+            }
+            join_state_t join_state_ = join_filter_iter->second;
             // GPU Joins don't create bloom filters so only run against
             // CPU JoinStates
             std::visit(

--- a/bodo/pandas/physical/join_filter.h
+++ b/bodo/pandas/physical/join_filter.h
@@ -134,6 +134,13 @@ class PhysicalJoinFilter : public PhysicalProcessBatch {
 
             auto join_filter_iter = join_filter_states->find(filter_id);
             if (join_filter_iter == join_filter_states->end()) {
+                // Various stages of plan conversion and optimizations
+                // can convert a join to a cross-product/filter after
+                // join filter nodes are added.  In that case there is no
+                // node to generate a join filter state for this join
+                // filter to examine.  It is safe to just skip filter
+                // related to that join which is what the above check is
+                // detecting.
                 continue;
             }
             join_state_t join_state_ = join_filter_iter->second;


### PR DESCRIPTION
## Changes included in this PR

plan_conversion.py can convert join to cross product.  The join filter for the original join will be unfound after that because no join node creates it.  Allow this case and just skip join filters if there isn't a corresponding join node.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.