### PR TITLE
[GPU] GPU backend support for bodosql.

### DIFF
--- a/BodoSQL/bodosql/context.py
+++ b/BodoSQL/bodosql/context.py
@@ -723,9 +723,7 @@ class BodoSQLContext:
             # filter translation during conversion to Python plan.
             self.join_filter_info = {}
             plan = java_plan_to_python_plan(self, java_plan)
-            out = bodo.pandas.plan.execute_plan(
-                plan, optimize=False, use_sql_rules=True
-            )
+            out = bodo.pandas.plan.execute_plan(plan, optimize=True, use_sql_rules=True)
         except Exception as e:
             message = error_to_string(e)
             if bodosql.verbose_cpp_backend:

--- a/BodoSQL/bodosql/context.py
+++ b/BodoSQL/bodosql/context.py
@@ -723,7 +723,9 @@ class BodoSQLContext:
             # filter translation during conversion to Python plan.
             self.join_filter_info = {}
             plan = java_plan_to_python_plan(self, java_plan)
-            out = bodo.pandas.plan.execute_plan(plan, optimize=True, use_sql_rules=True)
+            out = bodo.pandas.plan.execute_plan(
+                plan, optimize=False, use_sql_rules=True
+            )
         except Exception as e:
             message = error_to_string(e)
             if bodosql.verbose_cpp_backend:

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -345,7 +345,6 @@ void CudaHashJoin::build_hash_table(
         this->_build_table =
             empty_table_from_arrow_schema(build_table_arrow_schema);
     }
-
     // 2. Create the hash_join object
     //    This triggers the kernel that builds the hash table on the GPU.
     //    We maintain ownership of _join_handle to reuse it for probing.
@@ -534,9 +533,37 @@ std::pair<std::unique_ptr<cudf::table>, bool> CudaHashJoin::ProbeProcessBatch(
         // ANTI joins with an empty build table (null join handle) should output
         // all probe rows, and for other join types we can just return early
         // since we know the probe rows can't match.
-        if (probe_to_select->num_rows() == 0 ||
-            (null_handle && this->join_type != duckdb::JoinType::ANTI)) {
+        if (probe_to_select->num_rows() == 0) {
             return get_empty_output_table(global_is_last, stream);
+        }
+        if (null_handle) {
+            // build table is empty
+            if (this->join_type == duckdb::JoinType::ANTI) {
+                // intentionally do nothing
+            } else if (this->join_type == duckdb::JoinType::LEFT ||
+                       this->join_type == duckdb::JoinType::OUTER) {
+                cudf::table_view probe_kept_view = probe_to_select->select(
+                    this->probe_kept_cols.begin(), this->probe_kept_cols.end());
+                cudf::table_view build_kept_view = _build_table->select(
+                    this->build_kept_cols.begin(), this->build_kept_cols.end());
+                // Create probe_idx_view to create every probe row in the
+                // output.
+                auto seq_col = cudf::sequence(probe_to_select->num_rows(),
+                                              cudf::numeric_scalar<int32_t>(0),
+                                              cudf::numeric_scalar<int32_t>(1));
+                cudf::column_view probe_idx_view = seq_col->view();
+                // Create build_idx_view to create NA build rows in the output.
+                auto neg_one_col =
+                    cudf::sequence(probe_to_select->num_rows(),
+                                   cudf::numeric_scalar<int32_t>(-1),
+                                   cudf::numeric_scalar<int32_t>(0));
+                cudf::column_view build_idx_view = neg_one_col->view();
+                return materialize_and_output(probe_kept_view, probe_idx_view,
+                                              build_kept_view, build_idx_view,
+                                              global_is_last, stream);
+            } else {
+                return get_empty_output_table(global_is_last, stream);
+            }
         }
     }
 

--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -110,6 +110,11 @@ bool is_supported_cudf_type(const duckdb::LogicalType &type) {
     return true;
 }
 
+bool bodosql_enabled() {
+    char *env_str = std::getenv("BODOSQL_CPP_BACKEND");
+    return env_str != nullptr && std::string(env_str) != "0";
+}
+
 class DevicePlanNode {
    private:
     duckdb::LogicalOperator &op;
@@ -264,23 +269,20 @@ class DevicePlanNode {
                 }
                 op.estimated_cardinality =
                     (uint64_t)(limit.limit_val.GetConstantValue());
-            } else if (op.type == duckdb::LogicalOperatorType::LOGICAL_FILTER) {
-                op.has_estimated_cardinality = true;
-                op.estimated_cardinality = rows_in;
-            } else if (op.type == duckdb::LogicalOperatorType::
-                                      LOGICAL_EXTENSION_OPERATOR) {
-                // Estimate cardinality for join filter.
-                op.has_estimated_cardinality = true;
-                op.estimated_cardinality = rows_in;
             } else {
+                if (bodosql_enabled()) {
+                    op.has_estimated_cardinality = true;
+                    op.estimated_cardinality = rows_in;
+                } else {
 #ifdef DEBUG_GPU_SELECTOR
-                std::cout
-                    << "DevicePlanNode operator didn't have cardinality.\n"
-                    << op.ToString() << std::endl;
+                    std::cout
+                        << "DevicePlanNode operator didn't have cardinality.\n"
+                        << op.ToString() << std::endl;
 #endif
-                throw std::runtime_error(
-                    "DevicePlanNode operator didn't have cardinality.\n" +
-                    op.ToString());
+                    throw std::runtime_error(
+                        "DevicePlanNode operator didn't have cardinality.\n" +
+                        op.ToString());
+                }
             }
         }
         rows_out = op.estimated_cardinality;

--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -264,7 +264,18 @@ class DevicePlanNode {
                 }
                 op.estimated_cardinality =
                     (uint64_t)(limit.limit_val.GetConstantValue());
+            } else if (op.type == duckdb::LogicalOperatorType::LOGICAL_FILTER) {
+                op.has_estimated_cardinality = true;
+                op.estimated_cardinality = rows_in;
+            } else if (op.type == duckdb::LogicalOperatorType::
+                                      LOGICAL_EXTENSION_OPERATOR) {
+                // Estimate cardinality for join filter.
+                op.has_estimated_cardinality = true;
+                op.estimated_cardinality = rows_in;
             } else {
+                op.has_estimated_cardinality = true;
+                op.estimated_cardinality = rows_in;
+#if 0
 #ifdef DEBUG_GPU_SELECTOR
                 std::cout
                     << "DevicePlanNode operator didn't have cardinality.\n"
@@ -273,6 +284,7 @@ class DevicePlanNode {
                 throw std::runtime_error(
                     "DevicePlanNode operator didn't have cardinality.\n" +
                     op.ToString());
+#endif
             }
         }
         rows_out = op.estimated_cardinality;

--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -273,9 +273,6 @@ class DevicePlanNode {
                 op.has_estimated_cardinality = true;
                 op.estimated_cardinality = rows_in;
             } else {
-                op.has_estimated_cardinality = true;
-                op.estimated_cardinality = rows_in;
-#if 0
 #ifdef DEBUG_GPU_SELECTOR
                 std::cout
                     << "DevicePlanNode operator didn't have cardinality.\n"
@@ -284,7 +281,6 @@ class DevicePlanNode {
                 throw std::runtime_error(
                     "DevicePlanNode operator didn't have cardinality.\n" +
                     op.ToString());
-#endif
             }
         }
         rows_out = op.estimated_cardinality;

--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -270,6 +270,11 @@ class DevicePlanNode {
                 op.estimated_cardinality =
                     (uint64_t)(limit.limit_val.GetConstantValue());
             } else {
+                // When BodoSQL uses the dataframe backend, it forms a duckdb
+                // plan but doesn't optimize it and it is the optimization steps
+                // that propagates cardinality estimates throughout the plan.
+                // So, when bodosql is enabled, ignore missing cardinality
+                // estimates and rely on the bodosql optimizer.
                 if (bodosql_enabled()) {
                     op.has_estimated_cardinality = true;
                     op.estimated_cardinality = rows_in;

--- a/bodo/pandas/_pipeline.cpp
+++ b/bodo/pandas/_pipeline.cpp
@@ -214,6 +214,9 @@ std::string getGPUStats() {
                 if constexpr (std::is_same_v<T,                                \
                                              std::shared_ptr<table_info>>) {   \
                     DEBUG_PrintTable(out, x, true);                            \
+                } else {                                                       \
+                    auto ctable = convertGPUToTable(x);                        \
+                    DEBUG_PrintTable(out, ctable, true);                       \
                 }                                                              \
             },                                                                 \
             batch);                                                            \

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1517,10 +1517,10 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
             }
 
             case arrow::Type::DATE64: {
-                using rep = cudf::timestamp_ms::rep;
+                using rep = cudf::timestamp_D::rep;
                 return std::make_unique<
-                    cudf::timestamp_scalar<cudf::timestamp_ms>>(rep{0}, false,
-                                                                stream, mr);
+                    cudf::timestamp_scalar<cudf::timestamp_D>>(rep{0}, false,
+                                                               stream, mr);
             }
 
             case arrow::Type::TIMESTAMP: {
@@ -1622,7 +1622,7 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
 
         case arrow::Type::DATE64: {
             auto ds = std::static_pointer_cast<arrow::Date64Scalar>(s);
-            return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_ms>>(
+            return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_D>>(
                 ds->value, true);
         }
 

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1616,16 +1616,14 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
 
         case arrow::Type::DATE32: {
             auto ds = std::static_pointer_cast<arrow::Date32Scalar>(s);
-            // arrow::Date32Scalar::value is days since epoch (int32_t)
-            return std::make_unique<cudf::numeric_scalar<int32_t>>(
-                static_cast<int32_t>(ds->value), true);
+            return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_D>>(
+                ds->value, true);
         }
 
         case arrow::Type::DATE64: {
             auto ds = std::static_pointer_cast<arrow::Date64Scalar>(s);
-            // arrow::Date64Scalar::value is milliseconds since epoch (int64_t)
-            return std::make_unique<cudf::numeric_scalar<int64_t>>(
-                static_cast<int64_t>(ds->value), true);
+            return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_ms>>(
+                ds->value, true);
         }
 
         // ---------------- TIMESTAMPS ----------------

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1550,7 +1550,7 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
 
             default:
                 throw std::runtime_error(
-                    "Unsupported Arrow type for null scalar");
+                    "Unsupported Arrow type for null scalar " + t->ToString());
         }
     }
 
@@ -1614,6 +1614,20 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
                                                          true);
         }
 
+        case arrow::Type::DATE32: {
+            auto ds = std::static_pointer_cast<arrow::Date32Scalar>(s);
+            // arrow::Date32Scalar::value is days since epoch (int32_t)
+            return std::make_unique<cudf::numeric_scalar<int32_t>>(
+                static_cast<int32_t>(ds->value), true);
+        }
+
+        case arrow::Type::DATE64: {
+            auto ds = std::static_pointer_cast<arrow::Date64Scalar>(s);
+            // arrow::Date64Scalar::value is milliseconds since epoch (int64_t)
+            return std::make_unique<cudf::numeric_scalar<int64_t>>(
+                static_cast<int64_t>(ds->value), true);
+        }
+
         // ---------------- TIMESTAMPS ----------------
         case arrow::Type::TIMESTAMP: {
             auto ts = std::static_pointer_cast<arrow::TimestampScalar>(s);
@@ -1644,7 +1658,8 @@ std::unique_ptr<cudf::scalar> arrow_scalar_to_cudf(
         }
 
         default:
-            throw std::runtime_error("Unsupported Arrow scalar type");
+            throw std::runtime_error("Unsupported Arrow scalar type " +
+                                     s->type->ToString());
     }
 }
 

--- a/bodo/pandas/physical/gpu_aggregate.h
+++ b/bodo/pandas/physical/gpu_aggregate.h
@@ -147,8 +147,6 @@ class PhysicalGPUAggregate : public PhysicalGPUSource, public PhysicalGPUSink {
                      ++col_idx) {
                     bool found = false;
                     for (unsigned i = 0; i < keys.size(); ++i) {
-                        std::cout << "testing " << col_idx << " " << keys[i]
-                                  << std::endl;
                         if (col_idx == keys[i]) {
                             found = true;
                         }

--- a/bodo/pandas/physical/gpu_aggregate.h
+++ b/bodo/pandas/physical/gpu_aggregate.h
@@ -56,6 +56,10 @@ inline bool gpu_capable(duckdb::LogicalAggregate& logical_aggregate) {
             return false;
         }
 
+        if (agg_expr.function.name == "size" && agg_expr.children.size() == 0) {
+            continue;
+        }
+
         // Check input types of the aggregate function
         auto& child_expr = agg_expr.children[0];
         if (child_expr->type != duckdb::ExpressionType::BOUND_COLUMN_REF) {
@@ -135,28 +139,56 @@ class PhysicalGPUAggregate : public PhysicalGPUSource, public PhysicalGPUSink {
                     agg_expr.function.name);
             }
 
-            if (agg_expr.children.size() != 1) {
-                throw std::runtime_error(
-                    "Aggregate expression for builtin funcs must have exactly "
-                    "one child expression" +
-                    expr->ToString());
-            }
+            uint64_t col_idx;
+            if (agg_expr.function.name == "size" &&
+                agg_expr.children.size() == 0) {
+                for (col_idx = 0;
+                     col_idx < in_table_schema->column_types.size();
+                     ++col_idx) {
+                    bool found = false;
+                    for (unsigned i = 0; i < keys.size(); ++i) {
+                        std::cout << "testing " << col_idx << " " << keys[i]
+                                  << std::endl;
+                        if (col_idx == keys[i]) {
+                            found = true;
+                        }
+                    }
+                    if (!found) {
+                        break;
+                    }
+                }
+                if (col_idx == in_table_schema->column_types.size()) {
+                    throw std::runtime_error(
+                        "Didn't find non-key column to use for size "
+                        "aggregated");
+                }
+                std::cout << "Found non-key column " << col_idx << std::endl;
+            } else {
+                if (agg_expr.children.size() != 1) {
+                    throw std::runtime_error(
+                        "Aggregate expression for builtin funcs must have "
+                        "exactly "
+                        "one child expression" +
+                        expr->ToString());
+                }
 
-            auto& child_expr = agg_expr.children[0];
-            if (child_expr->type != duckdb::ExpressionType::BOUND_COLUMN_REF) {
-                throw std::runtime_error(
-                    "Aggregate expression must have only col ref "
-                    "expression children" +
-                    expr->ToString());
+                auto& child_expr = agg_expr.children[0];
+                if (child_expr->type !=
+                    duckdb::ExpressionType::BOUND_COLUMN_REF) {
+                    throw std::runtime_error(
+                        "Aggregate expression must have only col ref "
+                        "expression children" +
+                        expr->ToString());
+                }
+                auto& colref =
+                    child_expr->Cast<duckdb::BoundColumnRefExpression>();
+
+                col_idx = col_ref_map.at(
+                    {colref.binding.table_index, colref.binding.column_index});
             }
-            auto& colref = child_expr->Cast<duckdb::BoundColumnRefExpression>();
             // Extract bind_info
             BodoAggFunctionData& bind_info =
                 agg_expr.bind_info->Cast<BodoAggFunctionData>();
-            std::unique_ptr<bodo::DataType> out_arr_type;
-
-            uint64_t col_idx = col_ref_map.at(
-                {colref.binding.table_index, colref.binding.column_index});
 
             auto ftype = function_to_ftype.at(agg_expr.function.name);
             column_agg_funcs.push_back({col_idx, ftype});
@@ -166,9 +198,10 @@ class PhysicalGPUAggregate : public PhysicalGPUSource, public PhysicalGPUSink {
                     in_table_schema->column_types[col_idx]->c_type);
             std::string timezone =
                 in_table_schema->column_types[col_idx]->timezone;
-            out_arr_type = std::make_unique<bodo::DataType>(
-                std::get<0>(output_dtype), std::get<1>(output_dtype), -1, -1,
-                timezone);
+            std::unique_ptr<bodo::DataType> out_arr_type =
+                std::make_unique<bodo::DataType>(std::get<0>(output_dtype),
+                                                 std::get<1>(output_dtype), -1,
+                                                 -1, timezone);
 
             this->output_schema->append_column(std::move(out_arr_type));
             this->output_schema->column_names.push_back(agg_expr.function.name);

--- a/bodo/pandas/physical/gpu_aggregate.h
+++ b/bodo/pandas/physical/gpu_aggregate.h
@@ -142,25 +142,7 @@ class PhysicalGPUAggregate : public PhysicalGPUSource, public PhysicalGPUSink {
             uint64_t col_idx;
             if (agg_expr.function.name == "size" &&
                 agg_expr.children.size() == 0) {
-                for (col_idx = 0;
-                     col_idx < in_table_schema->column_types.size();
-                     ++col_idx) {
-                    bool found = false;
-                    for (unsigned i = 0; i < keys.size(); ++i) {
-                        if (col_idx == keys[i]) {
-                            found = true;
-                        }
-                    }
-                    if (!found) {
-                        break;
-                    }
-                }
-                if (col_idx == in_table_schema->column_types.size()) {
-                    throw std::runtime_error(
-                        "Didn't find non-key column to use for size "
-                        "aggregated");
-                }
-                std::cout << "Found non-key column " << col_idx << std::endl;
+                col_idx = keys[0];
             } else {
                 if (agg_expr.children.size() != 1) {
                     throw std::runtime_error(

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -622,6 +622,13 @@ class PhysicalGPUCastExpression : public PhysicalGPUExpression {
     cudf::data_type return_type;
 };
 
+enum GPU_UNARY_MODE {
+    CUDF_UNARY = 0,
+    IS_NOT_NULL = 1,
+    IS_NULL = 2,
+    IS_TRUE = 3
+};
+
 /**
  * @brief Physical expression tree node type for unary of array.
  *
@@ -639,7 +646,19 @@ class PhysicalGPUUnaryExpression : public PhysicalGPUExpression {
                 // Will do separate is_null and then apply NOT.
                 // Will not show up as right column name.
                 comparator = cudf::unary_operator::NOT;
-                is_not_null = true;
+                mode = GPU_UNARY_MODE::IS_NOT_NULL;
+                break;
+            case duckdb::ExpressionType::OPERATOR_IS_NULL:
+                // Will not show up as right column name.
+                comparator = cudf::unary_operator::NOT;  // unused
+                mode = GPU_UNARY_MODE::IS_NULL;
+                break;
+            case duckdb::ExpressionType::OPERATOR_IS_TRUE:
+                comparator = cudf::unary_operator::NOT;  // unused
+                mode = GPU_UNARY_MODE::IS_TRUE;
+                break;
+            case duckdb::ExpressionType::OPERATOR_NEG:
+                comparator = cudf::unary_operator::NEGATE;
                 break;
             default:
                 throw std::runtime_error("Unhandled unary op expression type.");
@@ -668,7 +687,7 @@ class PhysicalGPUUnaryExpression : public PhysicalGPUExpression {
         std::shared_ptr<ExprGPUResult> left_res =
             children[0]->ProcessBatch(input_batch, se);
         std::variant<GPU_COLUMN, GPU_SCALAR> op_res;
-        if (is_not_null) {
+        if (mode == GPU_UNARY_MODE::IS_NOT_NULL) {
             std::shared_ptr<ArrayExprGPUResult> left_as_array =
                 std::dynamic_pointer_cast<ArrayExprGPUResult>(left_res);
             if (left_as_array) {
@@ -677,6 +696,53 @@ class PhysicalGPUUnaryExpression : public PhysicalGPUExpression {
                                                se->stream);
             } else {
                 throw std::runtime_error("Left must be array for is_not_null.");
+            }
+        } else if (mode == GPU_UNARY_MODE::IS_NULL) {
+            std::shared_ptr<ArrayExprGPUResult> left_as_array =
+                std::dynamic_pointer_cast<ArrayExprGPUResult>(left_res);
+            if (left_as_array) {
+                op_res = cudf::is_null(left_as_array->result->view());
+            } else {
+                throw std::runtime_error("Left must be array for is_null.");
+            }
+        } else if (mode == GPU_UNARY_MODE::IS_TRUE) {
+            std::shared_ptr<ArrayExprGPUResult> left_as_array =
+                std::dynamic_pointer_cast<ArrayExprGPUResult>(left_res);
+            if (left_as_array) {
+                // Cast to boolean column if necessary.
+                std::unique_ptr<cudf::column> bool_col_ptr;
+                if (left_as_array->result->type().id() !=
+                    cudf::type_id::BOOL8) {
+                    // Cast to boolean (this will produce a new column)
+                    bool_col_ptr = cudf::cast(
+                        left_as_array->result->view(),
+                        cudf::data_type{cudf::type_id::BOOL8}, se->stream);
+                    if (!bool_col_ptr) {
+                        throw std::runtime_error("cast to BOOL8 failed");
+                    }
+                }
+
+                cudf::column_view bool_view =
+                    bool_col_ptr ? bool_col_ptr->view()
+                                 : left_as_array->result->view();
+
+                // Create a boolean scalar 'false' to replace nulls
+                std::unique_ptr<cudf::scalar> false_scalar =
+                    cudf::make_numeric_scalar(
+                        cudf::data_type{cudf::type_id::BOOL8});
+                // set the scalar value to false
+                static_cast<cudf::numeric_scalar<bool> *>(false_scalar.get())
+                    ->set_value(false);
+
+                // Replace nulls with false.
+                std::unique_ptr<cudf::column> result =
+                    cudf::replace_nulls(bool_view, *false_scalar, se->stream);
+                if (!result) {
+                    throw std::runtime_error("fill_nulls failed");
+                }
+                op_res = std::move(result);
+            } else {
+                throw std::runtime_error("Left must be array for is_true.");
             }
         } else {
             op_res = do_cudf_compute_unary(left_res, comparator, se);
@@ -711,7 +777,7 @@ class PhysicalGPUUnaryExpression : public PhysicalGPUExpression {
 
    protected:
     cudf::unary_operator comparator;
-    bool is_not_null = false;
+    GPU_UNARY_MODE mode = GPU_UNARY_MODE::CUDF_UNARY;
 };
 
 /**

--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -62,7 +62,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
         duckdb::LogicalOperator& probeSide = *join.children[0];
 
         // If we have no equality conditions we have to do
-        //  a broadcast join.
+        // a broadcast join.
         bool no_equality = true;
         for (const duckdb::JoinCondition& cond : join.conditions) {
             if (cond.IsComparison() &&

--- a/bodo/pandas/physical/gpu_join_filter.h
+++ b/bodo/pandas/physical/gpu_join_filter.h
@@ -109,7 +109,11 @@ class PhysicalGPUJoinFilter : public PhysicalGPUProcessBatch {
                 continue;
             }
 
-            join_state_t join_state_ = (*join_filter_states)[filter_id];
+            auto join_filter_iter = join_filter_states->find(filter_id);
+            if (join_filter_iter == join_filter_states->end()) {
+                continue;
+            }
+            join_state_t join_state_ = join_filter_iter->second;
             std::visit(
                 [&](const auto& join_state) {
                     if constexpr (std::is_same_v<


### PR DESCRIPTION
## Changes included in this PR

1. Support size with no column in gpu_aggregate.
2. Support is_null and is_true in gpu_expression.
3. Ignore join filters for join that have been converted to cross-products.
4. Support date32 and date64 conversion from arrow scalar to cudf for non-null scalars.
5. Fix left join problem when build table is empty.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.