### PR TITLE
Limit ucx to tcp and shared memory in Github actions

### DIFF
--- a/.github/workflows/_test_nightly_python_source.yml
+++ b/.github/workflows/_test_nightly_python_source.yml
@@ -279,6 +279,8 @@ jobs:
           AZURE_CLIENT_ID:  ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: "ac373ae0-dc77-4cbb-bbb7-deddcf6133b3"
+          # Don't let UCX try to use RDMA, sometimes it fails to initialize because of this
+          UCX_TLS: "tcp,self,sm"
 
       - name: Upload JUnit Reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -219,6 +219,8 @@ jobs:
             AZURE_CLIENT_ID:  ${{ secrets.AZURE_CLIENT_ID }}
             AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
             AZURE_TENANT_ID: "ac373ae0-dc77-4cbb-bbb7-deddcf6133b3"
+            # Don't let UCX try to use RDMA, sometimes it fails to initialize because of this
+            UCX_TLS: "tcp,self,sm"
 
         # Upload
         - name: Prepare Outputs


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
We randomly see a UCX init failure trying to setup Azure's RDMA, we don't test multiple instances so this doesn't matter.

## Testing strategy
PR CI
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
N/A
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.