### PR TITLE
[BSE-5453] Reenable skipped Iceberg dict encoded tests

### DIFF
--- a/.github/workflows/_test_nightly_python_source.yml
+++ b/.github/workflows/_test_nightly_python_source.yml
@@ -1,3 +1,4 @@
+name: Run Python Nightly Tests
 on:
   workflow_call:
     inputs:

--- a/BodoSQL/bodosql/tests/test_types/test_table_path_iceberg.py
+++ b/BodoSQL/bodosql/tests/test_types/test_table_path_iceberg.py
@@ -105,9 +105,6 @@ def test_simple_table_read(
     )
 
 
-@pytest.mark.skip(
-    reason="BSE-5453: Fix issue with iceberg dictionary encoding and reenable tests."
-)
 @pytest.mark.slow
 def test_column_pruning(memory_leak_check, iceberg_database, iceberg_table_conn):
     """
@@ -149,7 +146,13 @@ def test_column_pruning(memory_leak_check, iceberg_database, iceberg_table_conn)
         )
 
     py_out = sync_dtypes(py_out, res.dtypes.values.tolist())
-    check_func(impl, (table_name, conn, db_schema, bodo_read_as_dict), py_output=py_out)
+    check_func(
+        impl,
+        (table_name, conn, db_schema, bodo_read_as_dict),
+        py_output=py_out,
+        sort_output=True,
+        reset_index=True,
+    )
 
 
 @pytest.mark.skipif(
@@ -190,9 +193,6 @@ def test_zero_columns_pruning(memory_leak_check, iceberg_database, iceberg_table
     )
 
 
-@pytest.mark.skip(
-    reason="BSE-5453: Fix issue with iceberg dictionary encoding and reenable tests."
-)
 @pytest.mark.slow
 def test_explicit_dict_encoding(
     memory_leak_check, iceberg_database, iceberg_table_conn
@@ -236,7 +236,13 @@ def test_explicit_dict_encoding(
         )
 
     py_out = sync_dtypes(py_out, res.dtypes.values.tolist())
-    check_func(impl, (table_name, conn, db_schema, bodo_read_as_dict), py_output=py_out)
+    check_func(
+        impl,
+        (table_name, conn, db_schema, bodo_read_as_dict),
+        py_output=py_out,
+        sort_output=True,
+        reset_index=True,
+    )
 
 
 @pytest.mark.slow

--- a/bodo/tests/test_iceberg/test_read.py
+++ b/bodo/tests/test_iceberg/test_read.py
@@ -338,9 +338,6 @@ def test_column_pruning(iceberg_database, iceberg_table_conn, memory_leak_check)
 
 
 @pytest.mark.slow
-@pytest.mark.skip(
-    reason="BSE-5453: Fix issue with iceberg dictionary encoding and reenable tests."
-)
 @pytest.mark.parametrize(
     "dict_encode_in_bodo",
     [
@@ -406,7 +403,13 @@ def test_dict_encoded_string_arrays(
         )
         return df
 
-    check_func(impl1, (table_name, conn, db_schema), py_output=df)
+    check_func(
+        impl1,
+        (table_name, conn, db_schema),
+        py_output=df,
+        sort_output=True,
+        reset_index=True,
+    )
 
     stream = io.StringIO()
     logger = create_string_io_logger(stream)
@@ -421,7 +424,13 @@ def test_dict_encoded_string_arrays(
         )
         return df[["B", "D"]]
 
-    check_func(impl2, (table_name, conn, db_schema), py_output=df[["B", "D"]])
+    check_func(
+        impl2,
+        (table_name, conn, db_schema),
+        py_output=df[["B", "D"]],
+        sort_output=True,
+        reset_index=True,
+    )
 
     stream = io.StringIO()
     logger = create_string_io_logger(stream)
@@ -440,7 +449,13 @@ def test_dict_encoded_string_arrays(
         )  # type: ignore
         return df[["B", "C", "D", "E"]]
 
-    check_func(impl3, (table_name, conn, db_schema), py_output=df[["B", "C", "D", "E"]])
+    check_func(
+        impl3,
+        (table_name, conn, db_schema),
+        py_output=df[["B", "C", "D", "E"]],
+        sort_output=True,
+        reset_index=True,
+    )
 
     stream = io.StringIO()
     logger = create_string_io_logger(stream)
@@ -554,7 +569,13 @@ def test_dict_encoded_string_arrays(
         df = df[df.F >= 10000]
         return df
 
-    check_func(impl7, (table_name, conn, db_schema), py_output=df)
+    check_func(
+        impl7,
+        (table_name, conn, db_schema),
+        py_output=df,
+        sort_output=True,
+        reset_index=True,
+    )
 
 
 @pytest.mark.parametrize("dict_encode_in_bodo", [True, False])


### PR DESCRIPTION
## Changes included in this PR

Add sort/drop index to iceberg dict encoded tests to fix output out of order. 

## Testing strategy

Ran tests locally with `BODO_SPAWN_MODE=0 mpiexec -n 2 ...` confirmed they pass with sort/reset index

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.