### PR TITLE
[GPU] Use new 26.06 memory resource API

### DIFF
--- a/bodo/libs/gpu_utils.cpp
+++ b/bodo/libs/gpu_utils.cpp
@@ -711,16 +711,24 @@ bool is_gpu_rank() {
     return is_gpu_rank;
 }
 
-rmm::device_async_resource_ref get_gpu_async_memory_resource() {
+// Static GPU async memory resource — shared by both the ref and pool handle
+// queries
+static rmm::mr::cuda_async_memory_resource& get_gpu_async_mr_inst() {
     static rmm::mr::cuda_async_memory_resource mr;
-    static rmm::device_async_resource_ref mr_ref{&mr};
-    return mr_ref;
+    return mr;
+}
+
+rmm::device_async_resource_ref get_gpu_async_memory_resource() {
+    return rmm::device_async_resource_ref{get_gpu_async_mr_inst()};
+}
+
+cudaMemPool_t get_gpu_async_pool_handle() {
+    return get_gpu_async_mr_inst().pool_handle();
 }
 
 rmm::device_async_resource_ref get_cuda_memory_resource_ref() {
     static rmm::mr::cuda_memory_resource mr;
-    static rmm::device_async_resource_ref mr_ref{&mr};
-    return mr_ref;
+    return rmm::device_async_resource_ref{mr};
 }
 
 #endif  // USE_CUDF

--- a/bodo/libs/gpu_utils.cpp
+++ b/bodo/libs/gpu_utils.cpp
@@ -711,9 +711,10 @@ bool is_gpu_rank() {
     return is_gpu_rank;
 }
 
-std::shared_ptr<rmm::mr::device_memory_resource>
-get_gpu_async_memory_resource() {
-    return std::make_shared<rmm::mr::cuda_async_memory_resource>();
+rmm::device_async_resource_ref get_gpu_async_memory_resource() {
+    static rmm::mr::cuda_async_memory_resource mr;
+    static rmm::device_async_resource_ref mr_ref{&mr};
+    return mr_ref;
 }
 
 rmm::device_async_resource_ref get_cuda_memory_resource_ref() {

--- a/bodo/libs/gpu_utils.h
+++ b/bodo/libs/gpu_utils.h
@@ -7,6 +7,7 @@ extern bool g_use_async;
 #include <mpi.h>
 #include <cudf/contiguous_split.hpp>
 #include <cudf/table/table.hpp>
+#include <rmm/resource_ref.hpp>
 #include <unordered_set>
 
 #define CHECK_CUDA(call)                                                    \
@@ -577,10 +578,9 @@ void cudf_set_bools_from_indices(cudf::mutable_column_view target_bools,
  *
  * @note This function must be called after a rank's device id is set.
  *
- * @return std::shared_ptr<rmm::mr::device_memory_resource>
+ * @return rmm::device_async_resource_ref
  */
-std::shared_ptr<rmm::mr::device_memory_resource>
-get_gpu_async_memory_resource();
+rmm::device_async_resource_ref get_gpu_async_memory_resource();
 
 /**
  * @brief Get a static Cuda memory resource reference for allocating buffers for

--- a/bodo/libs/gpu_utils.h
+++ b/bodo/libs/gpu_utils.h
@@ -583,6 +583,13 @@ void cudf_set_bools_from_indices(cudf::mutable_column_view target_bools,
 rmm::device_async_resource_ref get_gpu_async_memory_resource();
 
 /**
+ * @brief Get the pool handle of the GPU async memory resource.
+ *
+ * @return cudaMemPool_t pool handle
+ */
+cudaMemPool_t get_gpu_async_pool_handle();
+
+/**
  * @brief Get a static Cuda memory resource reference for allocating buffers for
  * MPI to enable GPU Direct paths.
  *

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -357,10 +357,8 @@ void CudaHashJoin::build_hash_table(
         if (this->join_type == duckdb::JoinType::MARK ||
             this->join_type == duckdb::JoinType::ANTI) {
             this->_join_handle = std::make_unique<cudf::filtered_join>(
-                selected_build_view, this->null_equality,
-                /* default args otherwise the compiler can't figure out which
-                   constructor to call */
-                cudf::set_as_build_table::RIGHT, 0.5, build_se->stream);
+                selected_build_view, this->null_equality, 0.5,
+                build_se->stream);
         } else {
             this->_join_handle = std::make_unique<cudf::hash_join>(
                 selected_build_view, this->null_equality, build_se->stream);

--- a/bodo/pandas/_pipeline.cpp
+++ b/bodo/pandas/_pipeline.cpp
@@ -4,7 +4,6 @@
 #ifdef USE_CUDF
 #include <cudf/copying.hpp>
 #include <cudf/table/table_view.hpp>
-#include <rmm/mr/cuda_async_memory_resource.hpp>
 #endif  // USE_CUDF
 #include "physical/operator.h"
 #include "physical/result_collector.h"
@@ -26,13 +25,7 @@ std::string getGPUStats() {
     free_bytes /= 1024 * 1024 * 1024;
     total_bytes /= 1024 * 1024 * 1024;
 
-    auto *mr = dynamic_cast<rmm::mr::cuda_async_memory_resource *>(
-        rmm::mr::get_current_device_resource());
-    if (!mr) {
-        throw std::runtime_error(
-            "Current RMM resource is not cuda_async_memory_resource");
-    }
-    cudaMemPool_t pool = mr->pool_handle();
+    cudaMemPool_t pool = get_gpu_async_pool_handle();
 
     size_t reserved_current = 0;
     size_t reserved_peak = 0;

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -50,7 +50,7 @@
 
 #ifdef USE_CUDF
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
 #include "cuda_runtime_api.h"
 #endif
 
@@ -1360,15 +1360,15 @@ std::pair<int64_t, PyObject *> execute_plan(
     // Assign ranks to cuda devices
     rmm::cuda_device_id gpu_id = get_gpu_id();
     std::optional<rmm::cuda_set_device_raii> device_guard;
-    std::shared_ptr<rmm::mr::device_memory_resource> mr = nullptr;
-    rmm::mr::device_memory_resource *prev_mr = nullptr;
+    auto prev_mr = cuda::mr::any_resource<cuda::mr::device_accessible>{};
     if (gpu_id.value() != -1) {
         // Set device (resets to previous device when device_guard goes out of
         // scope)
         device_guard.emplace(gpu_id);
 
-        mr = get_gpu_async_memory_resource();
-        prev_mr = cudf::set_current_device_resource(mr.get());
+        prev_mr = cudf::set_current_device_resource(
+            cuda::mr::any_resource<cuda::mr::device_accessible>{
+                get_gpu_async_memory_resource()});
     }
 #endif
 
@@ -1385,7 +1385,7 @@ std::pair<int64_t, PyObject *> execute_plan(
 #ifdef USE_CUDF
     if (prev_mr) {
         // Reset device resource for GPU ranks.
-        cudf::set_current_device_resource(prev_mr);
+        cudf::set_current_device_resource(std::move(prev_mr));
     }
 #endif
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1383,10 +1383,8 @@ std::pair<int64_t, PyObject *> execute_plan(
     }
 
 #ifdef USE_CUDF
-    if (prev_mr) {
-        // Reset device resource for GPU ranks.
-        cudf::set_current_device_resource(std::move(prev_mr));
-    }
+    // Reset device resource for GPU ranks.
+    cudf::set_current_device_resource(std::move(prev_mr));
 #endif
 
     // Iceberg write returns a PyObject* with file information

--- a/buildscripts/bodo/conda-recipe/meta.yaml
+++ b/buildscripts/bodo/conda-recipe/meta.yaml
@@ -81,11 +81,10 @@ requirements:
     - {{mpi_build_pkg}}
 
     # GPU dependencies
-    # This pin is necessary to avoid compatibility issues with 26.02
-    # and newer versions.
-    - cudf =26.04                  # [gpu]
-    - rmm =26.04                   # [gpu]
-    - librmm =26.04                # [gpu]
+    # This pin is necessary to avoid compatibility issues
+    - cudf =26.06                  # [gpu]
+    - rmm =26.06                   # [gpu]
+    - librmm =26.06                # [gpu]
     - cuda-version 13.*            # [gpu]
     - cuda-nvml-dev                # [gpu]
 


### PR DESCRIPTION
## Changes included in this PR
As title, the memory resource API changed in rmm 26.06.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
PR CI
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
N/A
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.