### PR TITLE
Improve date/time handling in C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -322,9 +322,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
         if func_name == "DATE_TRUNC" and num_operands == 2:
             # DATE_TRUNC(FLAG(DAY), timestamp) → floor_temporal(timestamp, unit)
-            unit_raw = str(java_call.getOperands()[0].toString()).upper()
-            if "(" in unit_raw:
-                unit_raw = unit_raw.split("(")[1].rstrip(")")
+            unit_raw = get_java_symbol(java_call.getOperands()[0]).upper()
             _TRUNC_UNITS = {
                 "year",
                 "quarter",
@@ -372,10 +370,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             unit_str = "MONTH"
             if num_operands == 2:
                 # EXTRACT(FLAG(MONTH), date) → month
-                unit_str = str(java_call.getOperands()[1].toString()).upper()
-                # Strip "FLAG(" / ")" from unit string
-                if "(" in unit_str:
-                    unit_str = unit_str.split("(")[1].rstrip(")")
+                unit_str = get_java_symbol(java_call.getOperands()[1]).upper()
             LAST_DAY_UNITS = {
                 "MONTH": ("month", 1, 0),
                 "QUARTER": ("quarter", 3, 0),
@@ -468,13 +463,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 # 3-operand form: DATEADD(unit, amount, date) → date + (unit * amount)
                 # First operand is a FLAG(unit) interval qualifier from the Java
                 # planner (e.g. FLAG(DAY), FLAG(MONTH)).
-                first_op_str = str(java_call.getOperands()[0].toString())
-                if not first_op_str.startswith("FLAG"):
-                    raise NotImplementedError(
-                        "DATEADD with 3 string operands not supported in "
-                        "C++ backend yet"
-                    )
-                unit_str = first_op_str.split("(")[1].rstrip(")").upper()
+                unit_str = get_java_symbol(java_call.getOperands()[0]).upper()
                 assert unit_str in INTERVAL_UNIT_MAP, (
                     f"Unsupported DATEADD interval unit: {unit_str}"
                 )
@@ -626,15 +615,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             interval_expr = java_expr_to_python_expr(
                 ctx, java_call.getOperands()[1], input_plan
             )
-            unit_str = str(java_call.getOperands()[2].toString()).upper().strip("'")
-            # Strip "FLAG(" / ")" from unit string
-            if "(" in unit_str:
-                unit_str = unit_str.split("(")[1].rstrip(")")
+            unit_str = get_java_symbol(java_call.getOperands()[2]).upper()
             start_or_end = "START"
             if num_operands == 4:
-                start_or_end = (
-                    str(java_call.getOperands()[3].toString()).upper().strip("'")
-                )
+                start_or_end = get_java_symbol(java_call.getOperands()[3]).upper()
                 assert start_or_end in ("START", "END"), (
                     f"Unsupported TIME_SLICE 4th operand: {start_or_end}"
                 )
@@ -844,11 +828,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         and len(java_call.getOperands()) == 2
     ):
         # EXTRACT(FLAG(MONTH), date) → month(date)
-        unit_str = str(java_call.getOperands()[0].toString()).upper()
+        unit_str = get_java_symbol(java_call.getOperands()[0]).upper()
         input = java_expr_to_python_expr(ctx, java_call.getOperands()[1], input_plan)
-        # Strip FLAG from unit if it's in the form FLAG(unit)
-        if "(" in unit_str:
-            unit_str = unit_str.split("(")[1].rstrip(")")
         arrow_func = _DATE_PART_ARROW_FUNCS.get(unit_str)
         if arrow_func is None:
             raise NotImplementedError(f"Unsupported EXTRACT unit: {unit_str}")
@@ -2538,6 +2519,25 @@ def java_literal_to_python_literal(ctx, java_literal, input_plan):
     raise NotImplementedError(
         f"Literal type {lit_type_name.toString()} not supported yet"
     )
+
+
+def get_java_symbol(java_symbol):
+    """Extract the value of a Java SYMBOL or CHAR literal (e.g. date/time units)."""
+    assert java_symbol.getClass().getSimpleName() == "RexLiteral", (
+        "get_java_symbol: expected RexLiteral but got "
+        + java_symbol.getClass().getSimpleName()
+    )
+    SqlTypeName = gateway.jvm.org.apache.calcite.sql.type.SqlTypeName
+
+    if java_symbol.getTypeName().equals(SqlTypeName.CHAR):
+        return java_symbol.getValue2()
+
+    assert java_symbol.getTypeName().equals(SqlTypeName.SYMBOL), (
+        "get_java_symbol: expected SYMBOL but got "
+        + java_symbol.getTypeName().toString()
+    )
+
+    return java_symbol.getValue().toString()
 
 
 def is_int_type(java_type):

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -375,7 +375,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             if num_operands == 2:
                 # EXTRACT(FLAG(MONTH), date) → month
                 unit_str = get_java_symbol(java_call.getOperands()[1])
-                unit_str = standardize_java_time_unit(func_name, unit_str)
+                unit_str = standardize_java_time_unit(func_name, unit_str).upper()
             LAST_DAY_UNITS = {
                 "MONTH": ("month", 1, 0),
                 "QUARTER": ("quarter", 3, 0),
@@ -469,7 +469,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 # First operand is a FLAG(unit) interval qualifier from the Java
                 # planner (e.g. FLAG(DAY), FLAG(MONTH)).
                 unit_str = get_java_symbol(java_call.getOperands()[0])
-                unit_str = standardize_java_time_unit(func_name, unit_str)
+                unit_str = standardize_java_time_unit(func_name, unit_str).upper()
                 assert unit_str in INTERVAL_UNIT_MAP, (
                     f"Unsupported DATEADD interval unit: {unit_str}"
                 )

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -333,6 +333,9 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 "hour",
                 "minute",
                 "second",
+                "millisecond",
+                "microsecond",
+                "nanosecond",
             }
             assert unit_raw.lower() in _TRUNC_UNITS, (
                 f"DATE_TRUNC unit has unexpected format after stripping: "

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -2530,6 +2530,11 @@ def java_literal_to_python_literal(ctx, java_literal, input_plan):
             dummy_empty_data, input_plan, java_literal.getValue2()
         )
 
+    # SYMBOL is internal Calcite enum and needs supported specifically for each case.
+    # Just avoiding errors here if input exprs are processed before the function itself.
+    if lit_type_name.equals(SqlTypeName.SYMBOL):
+        return None
+
     raise NotImplementedError(
         f"Literal type {lit_type_name.toString()} not supported yet"
     )

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -322,7 +322,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
         if func_name == "DATE_TRUNC" and num_operands == 2:
             # DATE_TRUNC(FLAG(DAY), timestamp) → floor_temporal(timestamp, unit)
-            unit_raw = get_java_symbol(java_call.getOperands()[0]).upper()
+            unit_raw = get_java_symbol(java_call.getOperands()[0])
+            unit_raw = standardize_java_time_unit(func_name, unit_raw)
             _TRUNC_UNITS = {
                 "year",
                 "quarter",
@@ -370,7 +371,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             unit_str = "MONTH"
             if num_operands == 2:
                 # EXTRACT(FLAG(MONTH), date) → month
-                unit_str = get_java_symbol(java_call.getOperands()[1]).upper()
+                unit_str = get_java_symbol(java_call.getOperands()[1])
+                unit_str = standardize_java_time_unit(func_name, unit_str)
             LAST_DAY_UNITS = {
                 "MONTH": ("month", 1, 0),
                 "QUARTER": ("quarter", 3, 0),
@@ -463,7 +465,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 # 3-operand form: DATEADD(unit, amount, date) → date + (unit * amount)
                 # First operand is a FLAG(unit) interval qualifier from the Java
                 # planner (e.g. FLAG(DAY), FLAG(MONTH)).
-                unit_str = get_java_symbol(java_call.getOperands()[0]).upper()
+                unit_str = get_java_symbol(java_call.getOperands()[0])
+                unit_str = standardize_java_time_unit(func_name, unit_str)
                 assert unit_str in INTERVAL_UNIT_MAP, (
                     f"Unsupported DATEADD interval unit: {unit_str}"
                 )
@@ -2538,6 +2541,14 @@ def get_java_symbol(java_symbol):
     )
 
     return java_symbol.getValue().toString()
+
+
+def standardize_java_time_unit(fname, time_unit):
+    """Convert time unit to a standardized form to simplify the code.
+    For example, convert yy to year.
+    """
+    standardizeTimeUnit = gateway.jvm.com.bodosql.calcite.application.BodoSQLCodeGen.DatetimeFnCodeGen.standardizeTimeUnit
+    return standardizeTimeUnit(fname, time_unit, None)
 
 
 def is_int_type(java_type):

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -943,7 +943,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
     if operator_class_name == "SqlAbstractTimeFunction":
         func_name = op.getName().upper()
         if func_name in ("LOCALTIME", "CURRENT_TIME"):
-            curr_ts = pd.Timestamp.now()
+            tz = ctx.default_tz if ctx.default_tz is not None else "UTC"
+            curr_ts = pd.Timestamp.now(tz=tz)
             curr_time = pc.cast(curr_ts, pa.time64("ns"))
             dummy_empty_data = pd.Series(
                 [curr_time], dtype=pd.ArrowDtype(pa.time64("ns"))

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -3257,6 +3257,7 @@ def test_date_trunc_time_part_handling(
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [
@@ -3281,6 +3282,7 @@ def test_date_trunc_timestamp(
     check_query(query, dt_fn_dataframe, None, expected_output=py_output)
 
 
+@pytest.mark.bodosql_cpp
 def test_date_trunc_unquoted_timeunit(dt_fn_dataframe, memory_leak_check):
     """
     Test DATE_TRUNC works for unquoted time unit input

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -689,6 +689,7 @@ def localtime_equiv_fns(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 def test_localtime_equivalents_cols(basic_df, localtime_equiv_fns, memory_leak_check):
     """Tests the group of equivalent functions which return the local time,
     without timezone info from the Snowflake Catalog.
@@ -721,6 +722,7 @@ def test_localtime_equivalents_cols(basic_df, localtime_equiv_fns, memory_leak_c
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_localtime_equivalents_case(localtime_equiv_fns, memory_leak_check):
     """Tests the group of equivalent functions which return the local time in case,
     without timezone info from the Snowflake Catalog.

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -590,6 +590,7 @@ def now_equiv_fns(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 def test_now_equivalents_cols(basic_df, now_equiv_fns, memory_leak_check):
     """Tests the group of equivalent functions which return the current timestamp,
     without timezone info from the Snowflake Catalog.
@@ -629,6 +630,7 @@ def test_now_equivalents_cols(basic_df, now_equiv_fns, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_now_equivalents_case(now_equiv_fns, memory_leak_check):
     """Tests the group of equivalent functions which return the current timestamp in case,
     without timezone info from the Snowflake Catalog.
@@ -3171,6 +3173,7 @@ def test_yearweek_scalars(dt_fn_dataframe, memory_leak_check):
 # map to the same codegen, it is believed that testing TRUNC
 # with the below two DATE_TRUNC unit tests is sufficient.
 @pytest.mark.parametrize("sql_func", ["DATE_TRUNC", "TRUNC"])
+@pytest.mark.bodosql_cpp
 def test_date_trunc_time_part(sql_func, time_df, time_part_strings, memory_leak_check):
     query = f"SELECT {sql_func}('{time_part_strings}', A) as output from table1"
     scalar_func = generate_date_trunc_time_func(time_part_strings)
@@ -3967,6 +3970,7 @@ def test_tz_aware_previous_day_case(
     check_query(query, ctx, None, expected_output=py_output, check_dtype=False)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_date_trunc_tz_aware(date_trunc_literal, memory_leak_check):
     query = f"SELECT DATE_TRUNC('{date_trunc_literal}', A) as output from table1"
@@ -3991,6 +3995,7 @@ def test_date_trunc_tz_aware(date_trunc_literal, memory_leak_check):
     check_query(query, ctx, None, expected_output=py_output)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 @pytest.mark.slow
 def test_date_trunc_tz_aware_case(date_trunc_literal, memory_leak_check):

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -3229,6 +3229,7 @@ def test_date_trunc_date(date_df, day_part_strings, use_case, memory_leak_check)
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -186,7 +186,7 @@ duckdb::unique_ptr<duckdb::Expression> make_const_date32_expr(int32_t val) {
 
 duckdb::unique_ptr<duckdb::Expression> make_const_time64_expr(int64_t val) {
     return duckdb::make_uniq<duckdb::BoundConstantExpression>(
-        duckdb::Value::TIME(duckdb::dtime_ns_t(val)));
+        duckdb::Value::TIME_NS(duckdb::dtime_ns_t(val)));
 }
 
 duckdb::unique_ptr<duckdb::Expression> make_const_string_expr(

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -184,6 +184,11 @@ duckdb::unique_ptr<duckdb::Expression> make_const_date32_expr(int32_t val) {
         duckdb::Value::DATE(duckdb::date_t(val)));
 }
 
+duckdb::unique_ptr<duckdb::Expression> make_const_time64_expr(int64_t val) {
+    return duckdb::make_uniq<duckdb::BoundConstantExpression>(
+        duckdb::Value::TIME(duckdb::dtime_ns_t(val)));
+}
+
 duckdb::unique_ptr<duckdb::Expression> make_const_string_expr(
     const std::string &val) {
     return duckdb::make_uniq<duckdb::BoundConstantExpression>(

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -376,6 +376,14 @@ duckdb::unique_ptr<duckdb::Expression> make_const_date_offset_expr(
 duckdb::unique_ptr<duckdb::Expression> make_const_date32_expr(int32_t val);
 
 /**
+ * @brief Create an expression from a constant time64 with ns resolution.
+ *
+ * @param val - the constant time for the expression in ns
+ * @return duckdb::unique_ptr<duckdb::Expression> - the const time expr
+ */
+duckdb::unique_ptr<duckdb::Expression> make_const_time64_expr(int64_t val);
+
+/**
  * @brief Create an expression that references a specified column.
  *
  * @param field_py - the data type of the specified column

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -106,6 +106,7 @@ extractValue(const duckdb::Value &value) {
             // Create a DateScalar with the date value
             return arrow::MakeScalar(date_type, extracted.days).ValueOrDie();
         } break;
+        case duckdb::LogicalTypeId::TIME:
         case duckdb::LogicalTypeId::TIME_NS: {
             // Define a time type with nanosecond precision
             auto time_type = arrow::time64(arrow::TimeUnit::NANO);
@@ -170,6 +171,7 @@ getDefaultValueForDuckdbValueType(const duckdb::Value &value) {
             // Create a DateScalar with the date value
             return arrow::MakeNullScalar(date_type);
         } break;
+        case duckdb::LogicalTypeId::TIME:
         case duckdb::LogicalTypeId::TIME_NS: {
             auto time_type = arrow::time64(arrow::TimeUnit::NANO);
             return arrow::MakeNullScalar(time_type);
@@ -517,6 +519,7 @@ std::shared_ptr<arrow::DataType> duckdbTypeToArrow(
             return arrow::timestamp(arrow::TimeUnit::NANO);
         case duckdb::LogicalTypeId::TIMESTAMP_NS:
             return arrow::timestamp(arrow::TimeUnit::NANO);
+        case duckdb::LogicalTypeId::TIME:
         case duckdb::LogicalTypeId::TIME_NS:
             return arrow::time64(arrow::TimeUnit::NANO);
         case duckdb::LogicalTypeId::BLOB:

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -106,7 +106,7 @@ extractValue(const duckdb::Value &value) {
             // Create a DateScalar with the date value
             return arrow::MakeScalar(date_type, extracted.days).ValueOrDie();
         } break;
-        case duckdb::LogicalTypeId::TIME: {
+        case duckdb::LogicalTypeId::TIME_NS: {
             // Define a time type with nanosecond precision
             auto time_type = arrow::time64(arrow::TimeUnit::NANO);
             duckdb::dtime_ns_t extracted = value.GetValue<duckdb::dtime_ns_t>();
@@ -170,7 +170,7 @@ getDefaultValueForDuckdbValueType(const duckdb::Value &value) {
             // Create a DateScalar with the date value
             return arrow::MakeNullScalar(date_type);
         } break;
-        case duckdb::LogicalTypeId::TIME: {
+        case duckdb::LogicalTypeId::TIME_NS: {
             auto time_type = arrow::time64(arrow::TimeUnit::NANO);
             return arrow::MakeNullScalar(time_type);
         } break;
@@ -517,7 +517,7 @@ std::shared_ptr<arrow::DataType> duckdbTypeToArrow(
             return arrow::timestamp(arrow::TimeUnit::NANO);
         case duckdb::LogicalTypeId::TIMESTAMP_NS:
             return arrow::timestamp(arrow::TimeUnit::NANO);
-        case duckdb::LogicalTypeId::TIME:
+        case duckdb::LogicalTypeId::TIME_NS:
             return arrow::time64(arrow::TimeUnit::NANO);
         case duckdb::LogicalTypeId::BLOB:
             return arrow::large_binary();
@@ -576,7 +576,7 @@ duckdb::LogicalType arrowTypeToDuckDB(
         case arrow::Type::LARGE_BINARY:
             return duckdb::LogicalType(duckdb::LogicalTypeId::BLOB);
         case arrow::Type::TIME64:
-            return duckdb::LogicalType(duckdb::LogicalTypeId::TIME);
+            return duckdb::LogicalType(duckdb::LogicalTypeId::TIME_NS);
         case arrow::Type::TIMESTAMP: {
             auto ts_type = std::static_pointer_cast<arrow::TimestampType>(type);
             if (!ts_type->timezone().empty()) {

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -106,6 +106,15 @@ extractValue(const duckdb::Value &value) {
             // Create a DateScalar with the date value
             return arrow::MakeScalar(date_type, extracted.days).ValueOrDie();
         } break;
+        case duckdb::LogicalTypeId::TIME: {
+            // Define a time type with nanosecond precision
+            auto time_type = arrow::time64(arrow::TimeUnit::NANO);
+            duckdb::dtime_ns_t extracted = value.GetValue<duckdb::dtime_ns_t>();
+            // Create a TimeScalar with the time value
+            // NOTE: DuckDB's dtime_ns_t is subclass of dtime_t so the field is
+            // still called micros, but it is actually nanoseconds.
+            return arrow::MakeScalar(time_type, extracted.micros).ValueOrDie();
+        } break;
         case duckdb::LogicalTypeId::INTERVAL: {
             duckdb::interval_t extracted = value.GetValue<duckdb::interval_t>();
             // Convert to nanoseconds total, dropping month/day information

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -358,6 +358,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_const_timedelta_ns_expr(int64_t val) except +
     cdef unique_ptr[CExpression] make_const_date_offset_expr(int32_t months, int32_t days, int64_t nanos) except +
     cdef unique_ptr[CExpression] make_const_date32_expr(int32_t val) except +
+    cdef unique_ptr[CExpression] make_const_time64_expr(int64_t val) except +
     cdef unique_ptr[CExpression] make_const_string_expr(c_string val) except +
     cdef unique_ptr[CExpression] make_const_bool_expr(c_bool val) except +
     cdef unique_ptr[CExpression] make_col_ref_expr(unique_ptr[CLogicalOperator] source, object field, int col_idx) except +
@@ -793,6 +794,9 @@ cdef unique_ptr[CExpression] make_const_expr(object const_schema, val):
         return move(make_const_timestamp_ns_expr(pd.Timestamp(val).value))
     elif isinstance(val, pa.Date32Scalar):
         return move(make_const_date32_expr(val.value))
+    elif isinstance(val, pa.Time64Scalar):
+        assert val.type.unit == "ns", "Only Time64 with nanosecond precision is supported as a constant"
+        return move(make_const_time64_expr(val.value))
     elif isinstance(val, bodo.pandas.scalar.BodoScalar):
         return move(make_const_expr(None, val.get_value()))
     else:


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Several fixes to improve date/time handling in the C++ backend.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
More functions work in the C++ backend.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.