### PR TITLE
Complete SEARCH handling and enable test_in.py on BodoSQL C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1999,32 +1999,68 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 # T        T        F              T
                 # T        T        F              F
 
-                # Also, the case of having lower and upper bound and both being
-                # inclusive can be divided up into two cases, where lower and
-                # upper are equal and where they are not equal.
+                # The lower and upper bounds being equal is a special case that does not
+                # involve less-than or greater-than comparison. It can be subdivided
+                # based on whether the lower and upper bounds are inclusive or not.
+                # The typical case is that they will be inclusive, which we can simplify
+                # to an equality check.
                 if (
                     lower_lit is not None
                     and upper_lit is not None
-                    and lower_inclusive
-                    and upper_inclusive
                     and lower_lit == upper_lit
                 ):
-                    # The exception case where we have lower and upper bounds and they are both
-                    # inclusive and the same we can simplify as equality check.
+                    if lower_inclusive and upper_inclusive:
+                        # Range of the form [a..a] - reduce to equality check
+                        const_empty_data = arrow_to_empty_df(
+                            pa.schema([pa.field("equal", pa.scalar(lower_lit).type)])
+                        )
+
+                        return ComparisonOpExpression(
+                            bool_empty_data,
+                            src,
+                            ConstantExpression(const_empty_data, input_plan, lower_lit),
+                            operator.eq,
+                        )
+                    elif lower_inclusive or upper_inclusive:
+                        # Range of the form [a..a) or (a..a] - interpret as empty
+                        return ConstantExpression(bool_empty_data, input_plan, False)
+                    else:
+                        raise ValueError("SEARCH option range form (a..a) is invalid.")
+
+                # Address the standard continuous range case, e.g. BETWEEN
+                if lower_lit is not None:
                     const_empty_data = arrow_to_empty_df(
                         pa.schema([pa.field("equal", pa.scalar(lower_lit).type)])
                     )
-
-                    return ComparisonOpExpression(
+                    src_greater = ComparisonOpExpression(
                         bool_empty_data,
                         src,
                         ConstantExpression(const_empty_data, input_plan, lower_lit),
-                        operator.eq,
+                        operator.ge if lower_inclusive else operator.gt,
                     )
+                    in_range = src_greater
+                if upper_lit is not None:
+                    const_empty_data = arrow_to_empty_df(
+                        pa.schema([pa.field("equal", pa.scalar(upper_lit).type)])
+                    )
+                    src_less = ComparisonOpExpression(
+                        bool_empty_data,
+                        src,
+                        ConstantExpression(const_empty_data, input_plan, upper_lit),
+                        operator.le if upper_inclusive else operator.lt,
+                    )
+                    in_range = src_less
 
-                raise NotImplementedError(
-                    f"SEARCH operator case of hasLower {lower_lit is not None}, hasUpper {upper_lit is not None}, lowerInclusive {lower_inclusive}, upperInclusive {upper_inclusive} not supported yet."
-                )
+                if lower_lit is not None and upper_lit is not None:
+                    # Assure input is within both bounds
+                    in_range = ConjunctionOpExpression(
+                        bool_empty_data, src_greater, src_less, "__and__"
+                    )
+                elif lower_lit is None and upper_lit is None:
+                    # No bounds specified, inputs must be in infinite range
+                    in_range = ConstantExpression(bool_empty_data, input_plan, True)
+
+                return in_range
 
             out_expr = process_one_search_option(search_options[0])
             # The definition of search is that the value is one of the

--- a/BodoSQL/bodosql/tests/test_in.py
+++ b/BodoSQL/bodosql/tests/test_in.py
@@ -5,7 +5,10 @@ Tests correctness of the In and Not In operations in BodoSQL
 import pandas as pd
 import pytest
 
+import bodosql
 from bodosql.tests.utils import check_query
+
+pytestmark = pytest.mark.bodosql_cpp
 
 
 def check_codegen_uses_optimized_is_in(codegen):
@@ -75,10 +78,11 @@ def test_in_scalar_literals(basic_df, memory_leak_check):
         None,
         check_names=False,
         check_dtype=False,
-        return_codegen=True,
+        return_codegen=not bodosql.use_cpp_backend,
         use_duckdb=True,
     )
-    assert check_codegen_uses_optimized_is_in(output["pandas_code"])
+    if not bodosql.use_cpp_backend:
+        assert check_codegen_uses_optimized_is_in(output["pandas_code"])
 
 
 def test_string_in_scalar_literals():
@@ -94,10 +98,11 @@ def test_string_in_scalar_literals():
         None,
         check_names=False,
         check_dtype=False,
-        return_codegen=True,
+        return_codegen=not bodosql.use_cpp_backend,
         use_duckdb=True,
     )
-    assert check_codegen_uses_optimized_is_in(output["pandas_code"])
+    if not bodosql.use_cpp_backend:
+        assert check_codegen_uses_optimized_is_in(output["pandas_code"])
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Changes included in this PR

Finish the unhandled cases for SEARCH plan conversion. This is mainly for completeness because, as far as I've found, there aren't any tests that actually rely on SEARCH for ranges wider than a single value.
Enable `test_in.py` on C++ backend. (IN was the one case where SEARCH is sometimes needed, but our previous SEARCH code already dealt with that).

## Testing strategy

CI

## User facing changes

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.