### PR TITLE
BSE-5478 [GPU]: Fix tpch q15 sql gpu

### DIFF
--- a/BodoSQL/bodosql/tests/test_tpch_second_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_second_half.py
@@ -218,6 +218,7 @@ def test_tpch_q14(tpch_data, memory_leak_check):
 
 @pytest.mark.slow
 @pytest.mark.bodosql_cpp
+@pytest.mark.gpu
 def test_tpch_q15_blazingsql(tpch_data, memory_leak_check):
     DATE = "1996-01-01"
     # This query is modified because we don't support DDL properly.

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -740,6 +740,19 @@ CudaNonEquiJoin::CudaNonEquiJoin(
                std::move(non_equi_expression), true) {}
 
 void CudaNonEquiJoin::FinalizeBuild() {
+    // Drain any pending broadcasts from GPU ranks.
+    //  Must be done before clearing _build_chunks since the broadcast may
+    //  arrive
+    // during this call.
+    if (is_broadcast_join) {
+        std::vector<std::shared_ptr<cudf::table>> received_chunks =
+            build_broadcast_manager->progress(true);
+        for (auto& chunk : received_chunks) {
+            this->_build_chunks.emplace_back(std::move(chunk));
+        }
+        build_broadcast_manager->sync_is_last(true);
+    }
+
     if (is_gpu_rank()) {
         std::vector<cudf::table_view> build_views;
         for (const auto& chunk : this->_build_chunks) {

--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -403,6 +403,9 @@ void CudaHashJoin::runtime_filter(
     std::vector<cudf::size_type> const& probe_key_indices,
     std::unique_ptr<cudf::column>& prev_mask, rmm::cuda_stream_view stream) {
     if (_build_bloom_filter) {
+        if (build_se) {
+            build_se->event.wait(stream);
+        }
         filter_table_with_bloom(probe_table, probe_key_indices,
                                 *_build_bloom_filter, prev_mask, stream);
     }
@@ -740,19 +743,6 @@ CudaNonEquiJoin::CudaNonEquiJoin(
                std::move(non_equi_expression), true) {}
 
 void CudaNonEquiJoin::FinalizeBuild() {
-    // Drain any pending broadcasts from GPU ranks.
-    //  Must be done before clearing _build_chunks since the broadcast may
-    //  arrive
-    // during this call.
-    if (is_broadcast_join) {
-        std::vector<std::shared_ptr<cudf::table>> received_chunks =
-            build_broadcast_manager->progress(true);
-        for (auto& chunk : received_chunks) {
-            this->_build_chunks.emplace_back(std::move(chunk));
-        }
-        build_broadcast_manager->sync_is_last(true);
-    }
-
     if (is_gpu_rank()) {
         std::vector<cudf::table_view> build_views;
         for (const auto& chunk : this->_build_chunks) {

--- a/bodo/pandas/_executor.cpp
+++ b/bodo/pandas/_executor.cpp
@@ -112,7 +112,7 @@ bool is_supported_cudf_type(const duckdb::LogicalType &type) {
 
 bool bodosql_enabled() {
     char *env_str = std::getenv("BODOSQL_CPP_BACKEND");
-    return env_str != nullptr && std::string(env_str) != "0";
+    return env_str == nullptr || std::string(env_str) != "0";
 }
 
 class DevicePlanNode {

--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -847,7 +847,9 @@ void PhysicalPlanBuilder::Visit(bodo::LogicalJoinFilter& op) {
     // join filter run before this pipeline.
     for (int filter_id : op.filter_ids) {
 #ifdef USE_CUDF
-        if ((*join_on_gpu)[filter_id] != run_on_gpu) {
+        auto join_gpu_iter = join_on_gpu->find(filter_id);
+        if (join_gpu_iter == join_on_gpu->end() ||
+            join_gpu_iter->second != run_on_gpu) {
             continue;
         }
         found_join_on_same_device = true;


### PR DESCRIPTION
## Changes included in this PR
Fixes a bug where searching for a filter default initialized it to not run on the GPU.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Locally q15/PR CI
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.