### PR TITLE
Fix C++ backend string ops nightly failures

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1208,7 +1208,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
         if func_name == "CHAR_LENGTH" and len(op_exprs) == 1:
             src = op_exprs[0]
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
             return ArrowScalarFuncExpression(
                 int_empty_data,
@@ -1229,7 +1229,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
         if func_name in ("LPAD", "RPAD") and len(op_exprs) in (2, 3):
             src = op_exprs[0]
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
 
             length = op_exprs[1]
             ensure_arg_is_const_expr_of_type(length, "length", int)
@@ -1238,7 +1238,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
             if len(op_exprs) == 3:
                 pattern = op_exprs[2]
-                ensure_arg_is_const_expr_of_type(pattern, "pattern", str)
+                ensure_arg_is_const_expr_of_type(pattern, "pattern", (str, pa.binary()))
                 arrow_func_args += (pattern.value,)
 
             return ArrowScalarFuncExpression(
@@ -1252,13 +1252,15 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             search_expr = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(search_expr, "search_expr", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(
+                search_expr, "search_expr", (str, pa.binary())
+            )
 
             if len(op_exprs) == 3:
                 replacement_expr = op_exprs[2]
                 ensure_arg_is_const_expr_of_type(
-                    replacement_expr, "replacement_expr", str
+                    replacement_expr, "replacement_expr", (str, pa.binary())
                 )
                 replacement_val = replacement_expr.value
             else:
@@ -1306,8 +1308,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             regexp = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(regexp, "regexp", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(regexp, "regexp", (str, pa.binary()))
 
             if len(op_exprs) >= 3:
                 start_expr = op_exprs[2]
@@ -1672,7 +1674,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             len_expr = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
             ensure_arg_is_const_expr_of_type(len_expr, "len_expr", int)
 
             out_empty = src.empty_data.iloc[:, 0]
@@ -1684,7 +1686,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             len_expr = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
             ensure_arg_is_const_expr_of_type(len_expr, "len_expr", int)
 
             out_empty = src.empty_data.iloc[:, 0]
@@ -1695,8 +1697,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             match_expr = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(
+                match_expr, "match_expr", (str, pa.binary())
+            )
 
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return ArrowScalarFuncExpression(
@@ -1709,8 +1713,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             match_expr = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(
+                match_expr, "match_expr", (str, pa.binary())
+            )
 
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return ArrowScalarFuncExpression(
@@ -1723,8 +1729,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             match_expr = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(
+                match_expr, "match_expr", (str, pa.binary())
+            )
 
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return ArrowScalarFuncExpression(
@@ -1735,7 +1743,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
         elif func_name == "LENGTH" and len(op_exprs) == 1:
             src = op_exprs[0]
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
             return ArrowScalarFuncExpression(
                 int_empty_data,
@@ -1752,8 +1760,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 src = op_exprs[1]
                 match_expr = op_exprs[0]
 
-            ensure_type_of_expr(src, "src", str)
-            ensure_arg_is_const_expr_of_type(match_expr, "match_expr", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(
+                match_expr, "match_expr", (str, pa.binary())
+            )
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
             if len(match_expr.value) == 0:
                 return ConstantExpression(int_empty_data, input_plan, 1)
@@ -1830,7 +1840,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
         elif func_name == "CONCAT" and len(op_exprs) > 0:
             src = op_exprs[0]
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
 
             if len(op_exprs) == 1:
                 # Nothing to concatenate, just return the input string
@@ -1846,7 +1856,9 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
             if len(op_exprs) > 1:
                 for other_str_src in op_exprs[1:]:
-                    ensure_type_of_expr(other_str_src, "other_str_src", str)
+                    ensure_type_of_expr(
+                        other_str_src, "other_str_src", (str, pa.binary())
+                    )
                     input_exprs.append(other_str_src)
 
             input_exprs.append(separator)
@@ -1859,7 +1871,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
         elif func_name == "CONCAT_WS" and len(op_exprs) > 1:
             separator = op_exprs[0]
-            ensure_type_of_expr(separator, "separator", str)
+            ensure_type_of_expr(separator, "separator", (str, pa.binary()))
 
             if len(op_exprs) == 2:
                 # Nothing to concatenate, just return the input string
@@ -1867,7 +1879,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
             input_exprs = []
             for str_src in op_exprs[1:]:
-                ensure_type_of_expr(str_src, "str_src", str)
+                ensure_type_of_expr(str_src, "str_src", (str, pa.binary()))
                 input_exprs.append(str_src)
             input_exprs.append(separator)
 
@@ -1883,7 +1895,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             src = op_exprs[0]
             num_repeats_expr = op_exprs[1]
 
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
             ensure_arg_is_const_expr_of_type(num_repeats_expr, "num_repeats_expr", int)
 
             return ArrowScalarFuncExpression(
@@ -1904,7 +1916,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
         elif func_name == "REVERSE" and len(op_exprs) == 1:
             src = op_exprs[0]
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
 
             return ArrowScalarFuncExpression(src.empty_data, [src], "utf8_reverse", ())
         elif (
@@ -1944,7 +1956,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
         elif func_name == "RTRIMMED_LENGTH" and len(op_exprs) == 1:
             src = op_exprs[0]
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
             # Use utf8_rtrim instead of utf8_rtrim_whitespace so that only regular space characters are removed
             rtrimmed_expr = ArrowScalarFuncExpression(
@@ -1959,7 +1971,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             len_expr = op_exprs[2]
             inserted_str_expr = op_exprs[3]
 
-            ensure_type_of_expr(src, "src", str)
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
             ensure_arg_is_const_expr_of_type(start_expr, "start_expr", int)
             ensure_arg_is_const_expr_of_type(len_expr, "len_expr", int)
             ensure_arg_is_const_expr_of_type(
@@ -2389,7 +2401,7 @@ def java_binop_to_python_expr(ctx, kind, op_name, op_exprs):
     if kind.equals(SqlKind.OTHER):
         if op_name == "||":  # string concatenation
             for op_expr in (left, right):
-                ensure_type_of_expr(op_expr, "op_expr (|| arg)", str)
+                ensure_type_of_expr(op_expr, "op_expr (|| arg)", (str, pa.binary()))
 
             separator = bodo.pandas.plan.ConstantExpression(
                 left.empty_data,


### PR DESCRIPTION
## Changes included in this PR

The current version of `compare_types` considers `str` and `pa.binary()` as not equal, so we have to explicitly check for both possible input types to string functions.

## Testing strategy

Nightly CI

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.