### PR TITLE
Support more conditional functions in BodoSQL C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1332,7 +1332,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             select_expr = op_exprs[0]
 
             # Get unified result type between all result expressions to avoid overflow
-            # breakpoint()
             common_result_type, results_need_cast = get_common_int_type_list(
                 [op_exprs[i] for i in range(2, len(op_exprs), 2)]
             )

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -2731,9 +2731,11 @@ def make_unified_case_expression(empty_data, when_expr, then_expr, else_expr):
 
     unified_then_expr = then_expr
     unified_else_expr = else_expr
-    unified_empty_data = (
-        empty_data if empty_data not in (None, "common") else then_expr.empty_data
-    )
+    if isinstance(empty_data, (pd.Series, pd.DataFrame)):
+        unified_empty_data = empty_data
+    else:
+        assert empty_data in (None, "common")
+        unified_empty_data = then_expr.empty_data
 
     common_arrow_type, then_needs_cast, else_needs_cast = get_common_int_type(
         then_expr, else_expr
@@ -2758,10 +2760,12 @@ def make_unified_case_expression(empty_data, when_expr, then_expr, else_expr):
     # and our unification ended up casting one away from the intended result type.
     # We do this with a CastExpression instead of via CaseExpression empty_data
     # (which attempts to cast safely in _arrow_array_to_pd) so that integer overflow is allowed.
-    if empty_data not in (None, "common") and (then_needs_cast or else_needs_cast):
-        return CastExpression(empty_data, case_expr)
+    if isinstance(empty_data, (pd.Series, pd.DataFrame)):
+        if then_needs_cast or else_needs_cast:
+            return CastExpression(empty_data, case_expr)
     else:
-        return case_expr
+        assert empty_data in (None, "common")
+    return case_expr
 
 
 def java_case_to_python_case(ctx, operands, input_plan):

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1329,14 +1329,30 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         if func_name == "DECODE" and len(op_exprs) >= 3:
             select_expr = op_exprs[0]
 
+            result_exprs = [op_exprs[i] for i in range(2, len(op_exprs), 2)]
+            # Ensure result expression datatypes are compatible. Currently we
+            # only try to unify integer datatypes.
+            result_expr_dtypes = [
+                get_expr_dtype(result_expr) for result_expr in result_exprs
+            ]
+            if not all(
+                pd.api.types.is_integer_dtype(dtype) for dtype in result_expr_dtypes
+            ):
+                result_type = result_expr_dtypes[0]
+                for result_expr_dtype in result_expr_dtypes[1:]:
+                    if not compare_types(result_expr_dtype, result_type):
+                        raise ValueError(
+                            f"Incompatible DECODE result expression dtypes: {result_expr_dtype} and {result_type}"
+                        )
+
             # Get unified result type between all result expressions to avoid overflow
             common_result_type, results_need_cast = get_common_int_type_list(
-                [op_exprs[i] for i in range(2, len(op_exprs), 2)]
+                result_exprs
             )
             if common_result_type is not None:
                 empty_data = pd.Series(dtype=pd.ArrowDtype(common_result_type))
             else:
-                empty_data = op_exprs[2].empty_data
+                empty_data = result_exprs[0].empty_data
 
             if len(op_exprs) % 2 == 0:
                 # Default specified

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1295,9 +1295,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             expr1_is_null = UnaryOpExpression(bool_empty_data, expr1, "isnull")
-            return make_unified_case_expression(
-                expr2.empty_data, expr1_is_null, expr3, expr2
-            )
+            return make_unified_case_expression("common", expr1_is_null, expr3, expr2)
 
         if func_name == "ZEROIFNULL" and len(op_exprs) == 1:
             expr = op_exprs[0]
@@ -2720,6 +2718,10 @@ def make_unified_case_expression(empty_data, when_expr, then_expr, else_expr):
     to Arrow's case_when. Note that the output type (from `empty_data`) is
     retained. If `then_expr` or `else_expr` is not an integer expression,
     this is equivalent to directly constructing a CaseExpression.
+
+    If `empty_data` is None or `"common"`, the output type will be the same as
+    the common type of the inputs. If `then_expr` and `else_expr` have no
+    common type, `empty_data` will default to `then_expr.empty_data`.
     """
     # then_expr and else_expr could have different types, e.g. int64 and uint64
 
@@ -2729,7 +2731,9 @@ def make_unified_case_expression(empty_data, when_expr, then_expr, else_expr):
 
     unified_then_expr = then_expr
     unified_else_expr = else_expr
-    unified_empty_data = empty_data
+    unified_empty_data = (
+        empty_data if empty_data not in (None, "common") else then_expr.empty_data
+    )
 
     common_arrow_type, then_needs_cast, else_needs_cast = get_common_int_type(
         then_expr, else_expr
@@ -2754,7 +2758,7 @@ def make_unified_case_expression(empty_data, when_expr, then_expr, else_expr):
     # and our unification ended up casting one away from the intended result type.
     # We do this with a CastExpression instead of via CaseExpression empty_data
     # (which attempts to cast safely in _arrow_array_to_pd) so that integer overflow is allowed.
-    if then_needs_cast or else_needs_cast:
+    if empty_data not in (None, "common") and (then_needs_cast or else_needs_cast):
         return CastExpression(empty_data, case_expr)
     else:
         return case_expr

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1259,10 +1259,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 bool_empty_data, expr_rounded, zero_expr, operator.eq
             )
 
-        if func_name == "EQUAL_NULL" and len(op_exprs) == 2:
-            left_expr = op_exprs[0]
-            right_expr = op_exprs[1]
-
+        def equal_null(left_expr, right_expr):
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             values_equal = ComparisonOpExpression(
                 bool_empty_data, left_expr, right_expr, operator.eq
@@ -1279,6 +1276,9 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             true_expr = ConstantExpression(bool_empty_data, input_plan, True)
             return CaseExpression(bool_empty_data, values_equal, true_expr, both_null)
 
+        if func_name == "EQUAL_NULL" and len(op_exprs) == 2:
+            return equal_null(op_exprs[0], op_exprs[1])
+
         if func_name == "IFF" and len(op_exprs) == 3:
             # IFF is equivalent to CASE with single WHEN
             return java_case_to_python_case(ctx, operands, input_plan)
@@ -1287,6 +1287,92 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             return ArrowScalarFuncExpression(
                 op_exprs[0].empty_data, op_exprs, "nullif", ()
             )
+
+        if func_name == "NVL2" and len(op_exprs) == 3:
+            expr1 = op_exprs[0]
+            expr2 = op_exprs[1]
+            expr3 = op_exprs[2]
+
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            expr1_is_null = UnaryOpExpression(bool_empty_data, expr1, "isnull")
+            return make_unified_case_expression(
+                expr2.empty_data, expr1_is_null, expr3, expr2
+            )
+
+        if func_name == "ZEROIFNULL" and len(op_exprs) == 1:
+            expr = op_exprs[0]
+            ensure_type_of_expr(expr, "ZEROIFNULL expr", (int, float))
+
+            zero_expr = ConstantExpression(expr.empty_data, input_plan, 0)
+            return ArrowScalarFuncExpression(
+                expr.empty_data, [expr, zero_expr], "coalesce", ()
+            )
+
+        if func_name == "REGR_VALX" and len(op_exprs) == 2:
+            y_expr = op_exprs[0]
+            x_expr = op_exprs[1]
+
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            y_is_null = UnaryOpExpression(bool_empty_data, y_expr, "isnull")
+            return make_unified_case_expression(
+                x_expr.empty_data, y_is_null, y_expr, x_expr
+            )
+
+        if func_name == "REGR_VALY" and len(op_exprs) == 2:
+            y_expr = op_exprs[0]
+            x_expr = op_exprs[1]
+
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            x_is_null = UnaryOpExpression(bool_empty_data, x_expr, "isnull")
+            return make_unified_case_expression(
+                y_expr.empty_data, x_is_null, x_expr, y_expr
+            )
+
+        if func_name == "DECODE" and len(op_exprs) >= 3:
+            select_expr = op_exprs[0]
+
+            # Get unified result type between all result expressions to avoid overflow
+            # breakpoint()
+            common_result_type, results_need_cast = get_common_int_type_list(
+                [op_exprs[i] for i in range(2, len(op_exprs), 2)]
+            )
+            if common_result_type is not None:
+                empty_data = pd.Series(dtype=pd.ArrowDtype(common_result_type))
+            else:
+                empty_data = op_exprs[2].empty_data
+
+            if len(op_exprs) % 2 == 0:
+                # Default specified
+                default_expr = op_exprs[-1]
+            else:
+                # No default specified - NULL should be returned when there is no match
+                default_expr = NullExpression(empty_data, input_plan, 0)
+
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+
+            # Recursively create CaseExpressions for the remaining search expression and result expression pairs
+            # There is guaranteed to be at least one pair
+            def make_ternary_expression(search_result_pair_index):
+                pair_start_index = 1 + 2 * search_result_pair_index
+                search_expr = op_exprs[pair_start_index]
+                result_expr = op_exprs[pair_start_index + 1]
+                if results_need_cast[search_result_pair_index]:
+                    result_expr = CastExpression(empty_data, result_expr)
+
+                # Use equal_null for comparison since nulls should match nulls
+                search_expr_match = equal_null(select_expr, search_expr)
+                # Get the result expression if select_expr does not match search_expr
+                if len(op_exprs) - pair_start_index > 3:
+                    else_ternary_expr = make_ternary_expression(
+                        search_result_pair_index + 1
+                    )
+                else:
+                    else_ternary_expr = default_expr  # Use the default expression if we have run out of pairs
+                return CaseExpression(
+                    empty_data, search_expr_match, result_expr, else_ternary_expr
+                )
+
+            return make_ternary_expression(0)
 
         if func_name == "CHAR_LENGTH" and len(op_exprs) == 1:
             src = op_exprs[0]
@@ -2536,17 +2622,20 @@ def java_binop_to_python_expr(ctx, kind, op_name, op_exprs):
     raise NotImplementedError(f"Binary operator {kind.toString()} not supported yet")
 
 
-def get_common_int_type(left_expr, right_expr):
-    """Find a common integer type for two expressions with integer dtypes.
+def get_common_int_type_list(exprs):
+    """Find a common integer type for a list of expressions with integer dtypes.
 
     The bit width of the common type will be the maximum of the bit widths of the input types.
-    If `left_expr` and `right_expr` have the same signedness, the signedness does not change.
-    If `left_expr` and `right_expr` have different signedness, the common type will be
-    unsigned unless the unsigned input has a shorter bit width than the signed input.
+    If all expressions have the same signedness, the signedness does not change.
+    If expressions have different signedness, the common type will be unsigned unless
+    the unsigned inputs have shorter bit widths than the signed inputs.
 
-    Returns a tuple: (common_arrow_type, left_cast_needed, right_cast_needed)
-    (None, False, False) is returned if `left_expr` or `right_expr` does not have integer dtype.
+    Returns a tuple: (common_arrow_type, cast_needed_list) where each element in cast_needed_list
+    is a boolean representing if the corresponding expr needs to be casted to match the common type.
+    (None, [False] * len(exprs)) is returned if any of the input exprs does not have integer dtype.
     """
+    if not exprs:
+        return None, []
 
     def get_as_pyarrow_dtype(dtype):
         if isinstance(dtype, pd.ArrowDtype):
@@ -2567,63 +2656,73 @@ def get_common_int_type(left_expr, right_expr):
 
         return pa.from_numpy_dtype(dtype)
 
-    left_type = get_expr_dtype(left_expr)
-    right_type = get_expr_dtype(right_expr)
+    types = []
+    for expr in exprs:
+        dtype = get_expr_dtype(expr)
+        if not compare_types(dtype, int):
+            return None, [False] * len(exprs)
+        types.append(get_as_pyarrow_dtype(dtype))
 
-    if not (compare_types(left_type, int) and compare_types(right_type, int)):
-        return None, False, False
+    common_type = types[0]
 
-    left_type = get_as_pyarrow_dtype(left_type)
-    right_type = get_as_pyarrow_dtype(right_type)
+    for dtype in types[1:]:
+        if common_type.equals(dtype):
+            continue
 
-    # If types are identical, no cast needed
-    if left_type.equals(right_type):
-        return left_type, False, False
+        common_is_signed = pa.types.is_signed_integer(common_type)
+        expr_is_signed = pa.types.is_signed_integer(dtype)
+        common_width = common_type.bit_width
+        expr_width = dtype.bit_width
 
-    left_is_signed = pa.types.is_signed_integer(left_type)
-    right_is_signed = pa.types.is_signed_integer(right_type)
-    left_width = left_type.bit_width
-    right_width = right_type.bit_width
-
-    # Use wider type if inputs have same signedness
-    if left_is_signed == right_is_signed:
-        if left_width >= right_width:
-            return left_type, False, True
+        if common_is_signed == expr_is_signed:
+            # Use wider type if inputs have same signedness
+            if expr_width > common_width:
+                common_type = dtype
         else:
-            return right_type, True, False
+            # For mixed signedness, use the wider bit width of the two.
+            # The common type is signed only if the max value of the unsigned input can fit in the signed int
+            common_type_width = max(common_width, expr_width)
+            common_type_signed = (common_is_signed and common_width > expr_width) or (
+                expr_is_signed and expr_width > common_width
+            )
+            common_type = eval(
+                f"pa.{'' if common_type_signed else 'u'}int{common_type_width}()"
+            )
 
-    # For mixed signedness, use the wider bit width of the two.
-    # The common type is signed only if the max value of the unsigned input can fit in the signed int
-    common_type_width = max(left_width, right_width)
-    common_type_signed = (left_is_signed and left_width > right_width) or (
-        right_is_signed and right_width > left_width
-    )
-    common_type = eval(
-        f"pa.{'' if common_type_signed else 'u'}int{common_type_width}()"
-    )
+    cast_needed_list = [not expr_type.equals(common_type) for expr_type in types]
 
+    return common_type, cast_needed_list
+
+
+def get_common_int_type(left_expr, right_expr):
+    """Find a common integer type for two expressions with integer dtypes.
+
+    The bit width of the common type will be the maximum of the bit widths of the input types.
+    If `left_expr` and `right_expr` have the same signedness, the signedness does not change.
+    If `left_expr` and `right_expr` have different signedness, the common type will be
+    unsigned unless the unsigned input has a shorter bit width than the signed input.
+
+    Returns a tuple: (common_arrow_type, left_cast_needed, right_cast_needed)
+    (None, False, False) is returned if `left_expr` or `right_expr` does not have integer dtype.
+    """
+
+    common_type, casts_needed = get_common_int_type_list([left_expr, right_expr])
     return (
         common_type,
-        not left_type.equals(common_type),
-        not right_type.equals(common_type),
+        casts_needed[0],
+        casts_needed[1],
     )
 
 
-def java_case_to_python_case(ctx, operands, input_plan):
-    """Convert a BodoSQL Java CASE operator call to a DataFrame library CaseExpression.
-    operands has the form [when1, then1, when2, then2, ..., else].
+def make_unified_case_expression(empty_data, when_expr, then_expr, else_expr):
     """
-    assert len(operands) >= 3, "CASE operator should have at least 3 operands"
-    assert len(operands) % 2 == 1, "CASE operator should have an odd number of operands"
-    when_expr = java_expr_to_python_expr(ctx, operands[0], input_plan)
-    then_expr = java_expr_to_python_expr(ctx, operands[1], input_plan)
-
-    if len(operands) > 3:
-        else_expr = java_case_to_python_case(ctx, operands[2:], input_plan)
-    else:
-        else_expr = java_expr_to_python_expr(ctx, operands[2], input_plan)
-
-    # then_expr and else_expr could have different types here, e.g. int64 and uint64
+    Make a DataFrame library CaseExpression with logic (`get_common_int_type`)
+    to unify the integer types of `then_expr` and `else_expr` before passing
+    to Arrow's case_when. Note that the output type (from `empty_data`) is
+    retained. If `then_expr` or `else_expr` is not an integer expression,
+    this is equivalent to directly constructing a CaseExpression.
+    """
+    # then_expr and else_expr could have different types, e.g. int64 and uint64
 
     # Here we explicitly unify integer types to prevent Arrow's case_when
     # from attempting its own overflow-free unification which can fail in some cases,
@@ -2631,7 +2730,7 @@ def java_case_to_python_case(ctx, operands, input_plan):
 
     unified_then_expr = then_expr
     unified_else_expr = else_expr
-    unified_empty_data = then_expr.empty_data
+    unified_empty_data = empty_data
 
     common_arrow_type, then_needs_cast, else_needs_cast = get_common_int_type(
         then_expr, else_expr
@@ -2652,13 +2751,34 @@ def java_case_to_python_case(ctx, operands, input_plan):
     case_expr = CaseExpression(
         unified_empty_data, when_expr, unified_then_expr, unified_else_expr
     )
-    # Restore the original return type if the types of then_expr and else_expr were different and our unification ended up casting one away from the intended result type.
-    # We do this with a CastExpression instead of via CaseExpression empty_data (which attempts to cast safely in _arrow_array_to_pd) so that integer overflow is allowed.
-    # At the moment we choose then_expr to be the result type - is there a better way to decide?
-    if then_needs_cast:
-        return CastExpression(then_expr.empty_data, case_expr)
+    # Restore the original return type if the types of then_expr and else_expr were different
+    # and our unification ended up casting one away from the intended result type.
+    # We do this with a CastExpression instead of via CaseExpression empty_data
+    # (which attempts to cast safely in _arrow_array_to_pd) so that integer overflow is allowed.
+    if then_needs_cast or else_needs_cast:
+        return CastExpression(empty_data, case_expr)
     else:
         return case_expr
+
+
+def java_case_to_python_case(ctx, operands, input_plan):
+    """Convert a BodoSQL Java CASE operator call to a DataFrame library CaseExpression.
+    operands has the form [when1, then1, when2, then2, ..., else].
+    """
+    assert len(operands) >= 3, "CASE operator should have at least 3 operands"
+    assert len(operands) % 2 == 1, "CASE operator should have an odd number of operands"
+    when_expr = java_expr_to_python_expr(ctx, operands[0], input_plan)
+    then_expr = java_expr_to_python_expr(ctx, operands[1], input_plan)
+
+    if len(operands) > 3:
+        else_expr = java_case_to_python_case(ctx, operands[2:], input_plan)
+    else:
+        else_expr = java_expr_to_python_expr(ctx, operands[2], input_plan)
+
+    # At the moment we choose then_expr to be the result type - is there a better way to decide?
+    return make_unified_case_expression(
+        then_expr.empty_data, when_expr, then_expr, else_expr
+    )
 
 
 def java_join_to_python_join(ctx, java_join):

--- a/BodoSQL/bodosql/tests/test_cond.py
+++ b/BodoSQL/bodosql/tests/test_cond.py
@@ -384,6 +384,7 @@ def test_coalesce_variable_type_scalars(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_nvl2(memory_leak_check):
     """Tests NVL2 (equivalent to IF(A IS NOT NULL, B, C)"""
     query = "SELECT NVL2(A+B, B+C, C+A) from table1"
@@ -406,6 +407,7 @@ def test_nvl2(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_zeroifnull(memory_leak_check):
     """Tests ZEROIFNULL (same as COALESCE(X, 0))"""
     query = "SELECT ZEROIFNULL(A) from table1"
@@ -458,6 +460,7 @@ def test_zeroifnull(memory_leak_check):
         ),
     ],
 )
+@pytest.mark.bodosql_cpp
 def test_regr_valx_regr_valy(query, memory_leak_check):
     ctx = {
         "TABLE1": pd.DataFrame(
@@ -509,6 +512,7 @@ def test_if_scalar(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_if_dt(memory_leak_check):
     """Checks if function with datetime values"""
     query = "Select IF(YEAR(A) < 2010, makedate(2010, 1), A) FROM table1"
@@ -998,6 +1002,7 @@ def test_nullifzero_cols(memory_leak_check):
         ),
     ],
 )
+@pytest.mark.bodosql_cpp
 def test_decode(args, memory_leak_check):
     """Checks if function with all column values"""
     ctx = {
@@ -1031,6 +1036,7 @@ def test_decode(args, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_decode_time(bodosql_time_types, memory_leak_check):
     """Test DECODE with time columns"""
     query = "SELECT DECODE(A, TO_TIME('14:28:57'), 1, NULL, 2, 0) from table1"

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -185,6 +185,9 @@ getDefaultValueForDuckdbValueType(const duckdb::Value &value) {
                 arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
             return arrow::MakeNullScalar(timestamp_type);
         } break;
+        case duckdb::LogicalTypeId::SQLNULL: {
+            return arrow::MakeNullScalar(arrow::null());
+        } break;
         default:
             throw std::runtime_error(
                 "getDefaultValueForDuckdbValueType unhandled type." +


### PR DESCRIPTION
## Changes included in this PR

Support more conditional functions in C++ backend: `NVL2`, `ZEROIFNULL`, `REGR_VALX`/`REGR_VALY`, and `DECODE`.
Now all tests in `test_cond.py` pass on the C++ backend except for `test_hash`. I don't know why that test is in this file.
Also a small amount of refactoring is in this PR.

## Testing strategy

CI

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.