### PR TITLE
Make DATEDIFF fall back for TZ-aware input

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -640,6 +640,15 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             date1_pa_type = date_expr1.empty_data.iloc[:, 0].dtype.pyarrow_dtype
             date2_pa_type = date_expr2.empty_data.iloc[:, 0].dtype.pyarrow_dtype
 
+            if (
+                pa.types.is_timestamp(date1_pa_type) and date1_pa_type.tz is not None
+            ) or (
+                pa.types.is_timestamp(date2_pa_type) and date2_pa_type.tz is not None
+            ):
+                raise ValueError(
+                    "TZ-aware input not currently supported in DATEDIFF (C++ backend)"
+                )
+
             # Only mixing DATE and TIMESTAMP is allowed
             if pa.types.is_time(date1_pa_type) or pa.types.is_time(date2_pa_type):
                 if unit_str in ("YEAR", "QUARTER", "MONTH", "WEEK", "DAY"):

--- a/BodoSQL/bodosql/tests/test_datetime_difference_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_difference_fns.py
@@ -556,7 +556,7 @@ def timestampdiff_data():
     [
         pytest.param(False, False, id="no_tz-no_case"),
         pytest.param(False, True, id="no_tz-with_case", marks=pytest.mark.slow),
-        pytest.param(False, False, id="with_tz-no_case", marks=pytest.mark.slow),
+        pytest.param(True, False, id="with_tz-no_case", marks=pytest.mark.slow),
         pytest.param(True, True, id="with_tz-with_case"),
     ],
 )


### PR DESCRIPTION
## Changes included in this PR

Throw an error in DATEDIFF for TZ-aware timestamps for now until we can confidently implement the right solution.
Also fixes a typo in the parameterization of `test_timestamp_diff_cols`.

## Testing strategy

Nightly CI

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.