### PR TITLE
Fix bug in Iceberg to Arrow String Filter Conversion

### DIFF
--- a/bodo/io/iceberg/filter_conversion.py
+++ b/bodo/io/iceberg/filter_conversion.py
@@ -46,8 +46,9 @@ class _ConvertToArrowExpressionStringAndScalar(
             (right_rename_map[name], value) for name, value in right_child[1]
         ]
         # Rename the right child names in the expression string
+        # Matches whole words that are not inside {} and are in the right_rename_map
         pattern = re.compile(
-            r"\b(" + "|".join(map(re.escape, right_rename_map)) + r")\b"
+            r"(?<!\{)\b(" + "|".join(map(re.escape, right_rename_map)) + r")\b(?!\})"
         )
         right_child_expr = pattern.sub(
             lambda m: right_rename_map[m.group(0)],

--- a/bodo/io/iceberg/filter_conversion.py
+++ b/bodo/io/iceberg/filter_conversion.py
@@ -1,6 +1,7 @@
 """Convert Iceberg expressions to PyArrow expressions and scalars for filtering.
 This module imports pyicberg so it shouldn't be imported unless PyIceberg is installed."""
 
+import re
 from typing import Any
 
 import pyarrow as pa
@@ -45,9 +46,13 @@ class _ConvertToArrowExpressionStringAndScalar(
             (right_rename_map[name], value) for name, value in right_child[1]
         ]
         # Rename the right child names in the expression string
-        right_child_expr = right_child[0]
-        for old_name, new_name in right_rename_map.items():
-            right_child_expr = right_child_expr.replace(old_name, new_name)
+        pattern = re.compile(
+            r"\b(" + "|".join(map(re.escape, right_rename_map)) + r")\b"
+        )
+        right_child_expr = pattern.sub(
+            lambda m: right_rename_map[m.group(0)],
+            right_child[0],
+        )
         right_child = (right_child_expr, right_child_scalars)
 
         return left_child, right_child

--- a/bodo/io/iceberg/filter_conversion.py
+++ b/bodo/io/iceberg/filter_conversion.py
@@ -46,7 +46,11 @@ class _ConvertToArrowExpressionStringAndScalar(
             (right_rename_map[name], value) for name, value in right_child[1]
         ]
         # Rename the right child names in the expression string
-        # Matches whole words that are not inside {} and are in the right_rename_map
+        # Use a regex to replace all old names at once to avoid replacing names that
+        # have already been replaced. This regex also includes word boundaries to avoid
+        # replacing names that are substrings of other names, and skips names that are
+        # preceded or followed by a '{' or '}' to avoid replacing names inside the
+        # field references.
         pattern = re.compile(
             r"(?<!\{)\b(" + "|".join(map(re.escape, right_rename_map)) + r")\b(?!\})"
         )

--- a/bodo/tests/test_iceberg/test_filter_conversion.py
+++ b/bodo/tests/test_iceberg/test_filter_conversion.py
@@ -1,0 +1,68 @@
+import pyarrow as pa
+import pyiceberg.expressions as pie
+import pytest
+from pyiceberg.schema import DoubleType, LongType, NestedField, Schema
+from pyiceberg.types import DoubleType, LongType, NestedField
+
+from bodo.tests.utils import pytest_mark_one_rank
+
+
+@pytest_mark_one_rank
+@pytest.mark.parametrize(
+    "filter_expr, expected_output",
+    [
+        (
+            pie.And(
+                left=pie.LessThan(
+                    term=pie.Reference(name="L_QUANTITY"),
+                    literal=24,
+                ),
+                right=pie.And(
+                    left=pie.GreaterThanOrEqual(
+                        term=pie.Reference(name="L_DISCOUNT"),
+                        literal=0.05,
+                    ),
+                    right=pie.LessThanOrEqual(
+                        term=pie.Reference(name="L_DISCOUNT"),
+                        literal=0.07,
+                    ),
+                ),
+            ),
+            (
+                "(pc.field('{L_QUANTITY}') < f0) & ((pc.field('{L_DISCOUNT}') >= f1) & (pc.field('{L_DISCOUNT}') <= f2))",
+                [
+                    ("f0", pa.scalar(24, type=pa.int64())),
+                    ("f1", pa.scalar(0.05, type=pa.float64())),
+                    ("f2", pa.scalar(0.07, type=pa.float64())),
+                ],
+            ),
+        ),
+    ],
+)
+def test_pyiceberg_filter_to_pyarrow_format_str(filter_expr, expected_output):
+    """Test the conversion of PyIceberg filter expressions to PyArrow format strings and scalars."""
+    from bodo.io.iceberg.common import (
+        pyiceberg_filter_to_pyarrow_format_str_and_scalars,
+    )
+
+    schema = Schema(
+        NestedField(
+            field_id=1,
+            name="L_QUANTITY",
+            field_type=LongType(),
+            required=False,
+        ),
+        NestedField(
+            field_id=2,
+            name="L_DISCOUNT",
+            field_type=DoubleType(),
+            required=False,
+        ),
+    )
+
+    expr, scalars = pyiceberg_filter_to_pyarrow_format_str_and_scalars(
+        filter_expr, schema, True
+    )
+
+    assert expr == expected_output[0]
+    assert scalars == expected_output[1]


### PR DESCRIPTION
## Changes included in this PR

There was a bug in make unique where it would replace the name of a variable multiple times.

For example if your string was "f0 f1" and your new names are {f0: f1, f1: f2}, it would first replace f0 with f1, making the string "f1 f1" then it would replace f1 with f2 making it "f2 f2". 

This bug was exposed because previously our iceberg filters were left-heavy but after switching to the dataframe library they became right-heavy. For some reason.

So for example 

AND(AND(x,y),z) is now AND(x, AND(y,z)).

## Testing strategy

New test added for this case

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.