### PR TITLE
Validate arguments of Series _cmp_method with scalar input.

### DIFF
--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -515,6 +515,10 @@ arrow::Datum do_arrow_compute_binary(
     arrow::Datum left_res, arrow::Datum right_res,
     const std::string& comparator,
     const std::shared_ptr<arrow::DataType> result_type) {
+    std::cout << " GOT here " << std::endl;
+    std::cout << "left type " << left_res.type()->ToString() << std::endl;
+    std::cout << "right type " << right_res.type()->ToString() << std::endl;
+    std::cout << "comparator " << comparator << std::endl;
     arrow::Result<arrow::Datum> cmp_res =
         arrow::compute::CallFunction(comparator, {left_res, right_res});
     if (!cmp_res.ok()) [[unlikely]] {

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -515,10 +515,6 @@ arrow::Datum do_arrow_compute_binary(
     arrow::Datum left_res, arrow::Datum right_res,
     const std::string& comparator,
     const std::shared_ptr<arrow::DataType> result_type) {
-    std::cout << " GOT here " << std::endl;
-    std::cout << "left type " << left_res.type()->ToString() << std::endl;
-    std::cout << "right type " << right_res.type()->ToString() << std::endl;
-    std::cout << "comparator " << comparator << std::endl;
     arrow::Result<arrow::Datum> cmp_res =
         arrow::compute::CallFunction(comparator, {left_res, right_res});
     if (!cmp_res.ok()) [[unlikely]] {

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -225,6 +225,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         assert isinstance(empty_data, pd.Series), "_cmp_method: Series expected"
 
         lhs_plan, lhs, rhs = _handle_series_binop_args(self._plan, other)
+
         # Match the source plans of lhs and rhs, if they don't match return None, None
         lhs, rhs = match_binop_expr_source_plans(lhs, rhs)
         if lhs is None and rhs is None:

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -10,7 +10,6 @@ import typing as pt
 import warnings
 from collections.abc import Callable, Hashable
 from concurrent.futures import ThreadPoolExecutor
-from decimal import Decimal
 
 import numpy
 import numpy as np
@@ -2509,9 +2508,6 @@ def representative_value_for_arrow_type(dtype: pa.DataType):
     if pa.types.is_floating(dtype):
         return 0.0
 
-    if pa.types.is_decimal(dtype):
-        return Decimal("0")
-
     if pa.types.is_string(dtype) or pa.types.is_large_string(dtype):
         return ""
 
@@ -2547,12 +2543,8 @@ def representative_value_for_arrow_type(dtype: pa.DataType):
 
 
 def _validate_series_cmp_scalar_args(empty_lhs: pd.Series, rhs, op):
-    """Validate BodoSeries comparison and raise TypeError if comparison is invalid.
-
-    This function checks whether Pandas would allow the comparison if `empty_lhs` was not
-    actually empty. Since Pandas allows comparisons between empty Series and any scalar type
-    and we generally don't know whether a Series is empty or not until we run the plan, we
-    throw an error just in case to prevent unexpected behavior.
+    """Validate BodoSeries comparison between a Series and a scalar and raise
+    an error if comparison is invalid.
     """
     assert isinstance(empty_lhs, pd.Series) and isinstance(
         empty_lhs.dtype, pd.ArrowDtype
@@ -2566,6 +2558,9 @@ def _validate_series_cmp_scalar_args(empty_lhs: pd.Series, rhs, op):
         # If we don't have a representative value, rely on empty Series behavior
         return
 
+    # Pandas allows empty Series to be compared with any scalar type, but since
+    # Bodo Series can be lazy, we also need to validate the comparison with a non-empty Series
+    # with the same dtype.
     non_empty_lhs = pd.Series([value], dtype=empty_lhs.dtype)
     non_empty_lhs._cmp_method(rhs, op)
 

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -10,6 +10,7 @@ import typing as pt
 import warnings
 from collections.abc import Callable, Hashable
 from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
 
 import numpy
 import numpy as np
@@ -216,13 +217,14 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         zero_size_other = (
             _empty_like(other) if type(other) in {BodoSeries, BodoScalar} else other
         )
+        if pd.api.types.is_scalar(other):
+            _validate_series_cmp_scalar_args(zero_size_self, zero_size_other, op)
 
         # Compute schema of new series.
         empty_data = zero_size_self._cmp_method(zero_size_other, op)
         assert isinstance(empty_data, pd.Series), "_cmp_method: Series expected"
 
         lhs_plan, lhs, rhs = _handle_series_binop_args(self._plan, other)
-
         # Match the source plans of lhs and rhs, if they don't match return None, None
         lhs, rhs = match_binop_expr_source_plans(lhs, rhs)
         if lhs is None and rhs is None:
@@ -2489,6 +2491,82 @@ def is_numeric(other):
         other, allowed_types_map["binop_dtlike"]
     )
     return is_numeric_bodoseries or is_numeric_scalar
+
+
+def representative_value_for_arrow_type(dtype: pa.DataType):
+    """
+    Return a non-null Python value that can be used to construct a one-element
+    pandas/Arrow-backed Series for dtype validation.
+    """
+
+    if pa.types.is_boolean(dtype):
+        return False
+
+    if pa.types.is_integer(dtype):
+        return 0
+
+    if pa.types.is_floating(dtype):
+        return 0.0
+
+    if pa.types.is_decimal(dtype):
+        return Decimal("0")
+
+    if pa.types.is_string(dtype) or pa.types.is_large_string(dtype):
+        return ""
+
+    if pa.types.is_binary(dtype) or pa.types.is_large_binary(dtype):
+        return b""
+
+    if pa.types.is_date32(dtype) or pa.types.is_date64(dtype):
+        return datetime.date(2000, 1, 1)
+
+    if pa.types.is_timestamp(dtype):
+        tz = dtype.tz
+        if tz is not None:
+            return pd.Timestamp("2000-01-01 00:00:00", tz=tz)
+        return pd.Timestamp("2000-01-01 00:00:00")
+
+    if pa.types.is_time32(dtype) or pa.types.is_time64(dtype):
+        return datetime.time(0, 0, 0)
+
+    if pa.types.is_duration(dtype):
+        return datetime.timedelta(0)
+
+    if pa.types.is_list(dtype) or pa.types.is_large_list(dtype):
+        return [representative_value_for_arrow_type(dtype.value_type)]
+
+    if pa.types.is_struct(dtype):
+        return {
+            field.name: representative_value_for_arrow_type(field.type)
+            for field in dtype
+        }
+
+    # TODO: add more types here as needed
+    raise NotImplementedError(f"No representative value for Arrow type: {dtype}")
+
+
+def _validate_series_cmp_scalar_args(empty_lhs: pd.Series, rhs, op):
+    """Validate BodoSeries comparison and raise TypeError if comparison is invalid.
+
+    This function checks whether Pandas would allow the type error if `empty_lhs` was not
+    actually empty. Since Pandas allows comparisons between empty Series and any scalar type
+    and we generally don't know whether a Series is empty or not until we run the plan, we
+    throw an error just in case to prevent unexpected behavior.
+    """
+    assert isinstance(empty_lhs, pd.Series) and isinstance(
+        empty_lhs.dtype, pd.ArrowDtype
+    )
+
+    pa_type = empty_lhs.dtype.pyarrow_dtype
+
+    try:
+        value = representative_value_for_arrow_type(pa_type)
+    except NotImplementedError:
+        # If we don't have a representative value, rely on empty Series behavior
+        return
+
+    non_empty_lhs = pd.Series([value], dtype=empty_lhs.dtype)
+    non_empty_lhs._cmp_method(rhs, op)
 
 
 def _handle_series_binop_args(series_plan: LazyPlan, other):

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -217,6 +217,7 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
         zero_size_other = (
             _empty_like(other) if type(other) in {BodoSeries, BodoScalar} else other
         )
+
         if pd.api.types.is_scalar(other):
             _validate_series_cmp_scalar_args(zero_size_self, zero_size_other, op)
 
@@ -2548,7 +2549,7 @@ def representative_value_for_arrow_type(dtype: pa.DataType):
 def _validate_series_cmp_scalar_args(empty_lhs: pd.Series, rhs, op):
     """Validate BodoSeries comparison and raise TypeError if comparison is invalid.
 
-    This function checks whether Pandas would allow the type error if `empty_lhs` was not
+    This function checks whether Pandas would allow the comparison if `empty_lhs` was not
     actually empty. Since Pandas allows comparisons between empty Series and any scalar type
     and we generally don't know whether a Series is empty or not until we run the plan, we
     throw an error just in case to prevent unexpected behavior.

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -434,6 +434,11 @@ def test_timestamp_now():
         pytest.param([date(1995, 1, 1)], datetime(1995, 1, 1), id="date_series"),
         pytest.param([timedelta(10)], "10", id="timedelta_series"),
         pytest.param([time(10, 0, 0)], 11, id="time_series"),
+        pytest.param(
+            [pd.Timestamp(1995, 1, 1, tz="UTC")],
+            datetime(1995, 1, 1),
+            id="timestamp_series",
+        ),
     ],
 )
 def test_series_cmp_errorchecking(data, value):

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -6,7 +6,6 @@ import warnings
 from datetime import date
 
 import pandas as pd
-import pyarrow as pa
 import pytest
 from test_end_to_end import index_val  # noqa
 
@@ -421,13 +420,18 @@ def test_timestamp_now():
         bd.Timestamp.now()
 
 
-def test_series_cmp_errorchecking():
-    """Test that invalid comparisons raise TypeErrors that match Pandas behavior."""
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(["1994-12-31"], id="string"),
+        pytest.param([{"A": 1, "B": {"A": date(1995, 1, 1)}}], id="struct"),
+        pytest.param([[1, 2, 3]], id="list"),
+    ],
+)
+def test_series_cmp_errorchecking(data):
+    """Test that invalid comparisons raise TypeErrors, matching Pandas behavior."""
 
-    pa_type = pa.large_string()
-    S = bd.Series(
-        ["1994-12-31", "1995-01-02", "1995-01-01"], dtype=pd.ArrowDtype(pa_type)
-    )
+    S = bd.Series(data)
 
     with pytest.raises(TypeError):
         S < date(1995, 1, 1)

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -3,8 +3,10 @@ Tests dataframe library frontend (no triggering of execution).
 """
 
 import warnings
+from datetime import date
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 from test_end_to_end import index_val  # noqa
 
@@ -417,3 +419,15 @@ def test_timestamp_now():
 
         # Test static methods works
         bd.Timestamp.now()
+
+
+def test_series_cmp_errorchecking():
+    """Test that invalid comparisons raise TypeErrors that match Pandas behavior."""
+
+    pa_type = pa.large_string()
+    S = bd.Series(
+        ["1994-12-31", "1995-01-02", "1995-01-01"], dtype=pd.ArrowDtype(pa_type)
+    )
+
+    with pytest.raises(TypeError):
+        S < date(1995, 1, 1)

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -3,7 +3,7 @@ Tests dataframe library frontend (no triggering of execution).
 """
 
 import warnings
-from datetime import date
+from datetime import date, datetime, time, timedelta
 
 import pandas as pd
 import pytest
@@ -421,17 +421,25 @@ def test_timestamp_now():
 
 
 @pytest.mark.parametrize(
-    "data",
+    "data, value",
     [
-        pytest.param(["1994-12-31"], id="string"),
-        pytest.param([{"A": 1, "B": {"A": date(1995, 1, 1)}}], id="struct"),
-        pytest.param([[1, 2, 3]], id="list"),
+        pytest.param(["1994-12-31"], date(1995, 1, 1), id="string_series"),
+        pytest.param(
+            [{"A": 1.1, "B": {"A": date(1995, 1, 1)}}],
+            date(1995, 1, 1),
+            id="struct_series",
+        ),
+        pytest.param([[False, True, True]], date(1995, 1, 1), id="list_series"),
+        pytest.param([datetime(1995, 1, 1)], date(1995, 1, 1), id="datetime_series"),
+        pytest.param([date(1995, 1, 1)], datetime(1995, 1, 1), id="date_series"),
+        pytest.param([timedelta(10)], "10", id="timedelta_series"),
+        pytest.param([time(10, 0, 0)], 11, id="time_series"),
     ],
 )
-def test_series_cmp_errorchecking(data):
+def test_series_cmp_errorchecking(data, value):
     """Test that invalid comparisons raise TypeErrors, matching Pandas behavior."""
 
     S = bd.Series(data)
 
     with pytest.raises(TypeError):
-        S < date(1995, 1, 1)
+        S < value

--- a/bodo/tests/test_df_lib/test_frontend.py
+++ b/bodo/tests/test_df_lib/test_frontend.py
@@ -430,6 +430,8 @@ def test_timestamp_now():
             id="struct_series",
         ),
         pytest.param([[False, True, True]], date(1995, 1, 1), id="list_series"),
+        # Pandas raises an error when comparing date with timestamp, timestamp with date,
+        # and timestamp with timezone vs timestamp without
         pytest.param([datetime(1995, 1, 1)], date(1995, 1, 1), id="datetime_series"),
         pytest.param([date(1995, 1, 1)], datetime(1995, 1, 1), id="date_series"),
         pytest.param([timedelta(10)], "10", id="timedelta_series"),


### PR DESCRIPTION
## Changes included in this PR

Pandas raises a type error for certain comparisons between Series and scalar values that we currently do not have. We either throw a runtime error or return wrong results in those cases.

Wrong result examples include string series < date scalar
While runtime (i.e. plan execution) error examples include struct series < int scalars

The issue is that Pandas allows pretty much any scalar type to be compared to an empty Series. This PR adds an extra validation check that calls _cmp_method with a representative value to handle those cases. 

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.