### PR TITLE
Support more date/time functions in BodoSQL C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -577,26 +577,25 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     nano_scale_expr = ConstantExpression(
                         int_empty, input_plan, 86_400_000_000_000
                     )
+
+                    return ArrowScalarFuncExpression(
+                        out_empty,
+                        [
+                            date_expr,
+                            amount_expr,
+                            ConstantExpression(int_empty, input_plan, 0),
+                            nano_scale_expr,
+                        ],
+                        "bodo_dateadd",
+                        (),
+                    )
                 else:
                     # Assume we have an interval type (e.g. a MonthDayNanoInterval tuple or duration type).
-                    # Get nanoseconds from interval literal by casting to int64.
-                    amount_expr = CastExpression(
-                        pd.Series(dtype=pd.ArrowDtype(pa.int64())), amount_expr
+                    # Add the interval via ArithOpExpression, which should use DuckDB's calendar-aware
+                    # interval arithmetic as long as amount_expr is a ConstantExpression.
+                    return ArithOpExpression(
+                        out_empty, date_expr, amount_expr, "__add__"
                     )
-                    # nano_scale is 1 since we are already in units of nanoseconds
-                    nano_scale_expr = ConstantExpression(int_empty, input_plan, 1)
-
-                return ArrowScalarFuncExpression(
-                    out_empty,
-                    [
-                        date_expr,
-                        amount_expr,
-                        ConstantExpression(int_empty, input_plan, 0),
-                        nano_scale_expr,
-                    ],
-                    "bodo_dateadd",
-                    (),
-                )
             elif num_operands == 3:
                 # 3-operand form: DATEADD(unit, amount, date) → date + (unit * amount)
                 # First operand is a FLAG(unit) interval qualifier from the Java

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -421,6 +421,91 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
             return last_day
 
+        if func_name in ("NEXT_DAY", "PREVIOUS_DAY") and num_operands == 2:
+            date_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+            dow_string_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[1], input_plan
+            )
+            ensure_type_of_expr(dow_string_expr, "dow_string_expr", str)
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+
+            # 0-6 integer matching order of Arrow's day_of_week
+            target_dow_expr = ArrowScalarFuncExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.int32())),
+                [dow_string_expr],
+                "day_of_week_num",
+                (),
+            )
+            # Returns day of week between 0 and 6
+            cur_dow_expr = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr], "day_of_week", ()
+            )
+
+            if func_name == "NEXT_DAY":
+                # ((target_dow - cur_dow - 1) + 7) % 7 + 1 to get a day offset between 1 and 7
+                diff_expr = ArithOpExpression(
+                    int_empty_data, target_dow_expr, cur_dow_expr, "__sub__"
+                )
+            else:
+                # ((cur_dow - target_dow - 1) + 7) % 7 + 1 to get a day offset between 1 and 7
+                diff_expr = ArithOpExpression(
+                    int_empty_data, cur_dow_expr, target_dow_expr, "__sub__"
+                )
+            diff_expr = ArithOpExpression(
+                int_empty_data,
+                diff_expr,
+                ConstantExpression(int_empty_data, input_plan, 6),
+                "__add__",
+            )
+            diff_mod_expr = ArithOpExpression(
+                int_empty_data,
+                diff_expr,
+                ConstantExpression(int_empty_data, input_plan, 7),
+                "__mod__",
+            )
+            days_to_offset_expr = ArithOpExpression(
+                int_empty_data,
+                diff_mod_expr,
+                ConstantExpression(int_empty_data, input_plan, 1),
+                "__add__",
+            )
+
+            # Get the number of seconds to add to or subtract from the input timestamp.
+            # Arrow's duration type is the easiest way to add/subtract time, but it only accepts seconds and smaller units.
+            seconds_in_day = ConstantExpression(int_empty_data, input_plan, 86400)
+            seconds_to_offset_expr = ArithOpExpression(
+                int_empty_data, days_to_offset_expr, seconds_in_day, "__mul__"
+            )
+            duration_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.duration("s")))
+            one_duration_expr = ConstantExpression(duration_empty_data, input_plan, 1)
+            seconds_to_offset_duration_expr = ArithOpExpression(
+                duration_empty_data,
+                seconds_to_offset_expr,
+                one_duration_expr,
+                "__mul__",
+            )
+
+            date_pa_type = date_expr.empty_data.iloc[:, 0].dtype.pyarrow_dtype
+            if pa.types.is_date(date_pa_type):
+                timestamp_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.timestamp("s")))
+            else:
+                # Otherwise, must be a timestamp
+                timestamp_empty_data = date_expr.empty_data
+
+            # Add or subtract the seconds offset to get the requested day
+            next_day_timestamp_expr = ArithOpExpression(
+                timestamp_empty_data,
+                date_expr,
+                seconds_to_offset_duration_expr,
+                "__add__" if func_name == "NEXT_DAY" else "__sub__",
+            )
+            # According to Snowflake, we should always cast result to a date
+            date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
+            return CastExpression(date_empty_data, next_day_timestamp_expr)
+
         # ADD_MONTHS(date, months) -> date + months * INTERVAL '1' MONTH
         if func_name == "ADD_MONTHS" and num_operands == 2:
             date_expr = java_expr_to_python_expr(

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -61,7 +61,10 @@ _DATE_PART_ARROW_FUNCS = {
     "WEEKISO": "iso_week",
     "DAYOFYEAR": "day_of_year",
     "DAYOFWEEK": "day_of_week",
+    "DAYOFWEEKISO": "day_of_week",
     "WEEKDAY": "day_of_week",
+    "YEAROFWEEK": "iso_year",
+    "YEAROFWEEKISO": "iso_year",
     "MICROSECOND": "microsecond",
     "NANOSECOND": "nanosecond",
     "DOW": "day_of_week",
@@ -258,8 +261,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
     SqlKind = gateway.jvm.org.apache.calcite.sql.SqlKind
 
-    _DOW_NAMES = {"DAYOFWEEK", "DOW"}
-
     if operator_class_name == "SqlNullPolicyFunction":
         func_name = op.getName().upper()
         num_operands = len(java_call.getOperands())
@@ -271,14 +272,15 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
             arrow_func = _DATE_PART_ARROW_FUNCS[func_name]
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            raw_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
             if func_name in ("DAYOFWEEK", "DOW"):
-                # PyArrow default: 0=Monday, 6=Sunday.
-                # Bodo/Snowflake DAYOFWEEK: 1=Monday, 0=Sunday → (dow+1)%7
-                one = ConstantExpression(empty_data, input_plan, 1)
-                seven = ConstantExpression(empty_data, input_plan, 7)
-                raw_expr = ArithOpExpression(empty_data, raw_expr, one, "__add__")
-                raw_expr = ArithOpExpression(empty_data, raw_expr, seven, "__mod__")
+                # Default DAYOFWEEK for Bodo/Snowflake is Sunday=0, Monday=1, ..., Saturday=6.
+                raw_expr = ArrowScalarFuncExpression(
+                    empty_data, [input], arrow_func, (True, 7)
+                )
+            else:
+                raw_expr = ArrowScalarFuncExpression(
+                    empty_data, [input], arrow_func, ()
+                )
             # For WEEKDAY, PyArrow default (0=Monday..6=Sunday) exactly matches
             # Spark/Snowflake WEEKDAY, so no transformation is needed.
             return raw_expr
@@ -309,6 +311,25 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             return ArrowScalarFuncExpression(
                 empty_data, [input], "strftime", (arrow_fmt,)
             )
+
+        if func_name == "STR_TO_DATE" and num_operands == 2:
+            input = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+            mysql_fmt = str(java_call.getOperands()[1].toString())
+            if mysql_fmt.startswith("'") and mysql_fmt.endswith("'"):
+                mysql_fmt = mysql_fmt[1:-1]
+            arrow_fmt = _mysql_date_format_to_arrow_format(mysql_fmt)
+
+            timestamp_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns")))
+            timestamp_expr = ArrowScalarFuncExpression(
+                timestamp_empty_data, [input], "strptime", (arrow_fmt, "ns")
+            )
+
+            # Cast to date at the end no matter what.
+            # We need to truncate timestamps to be consistent with the JIT implementation.
+            date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
+            return CastExpression(date_empty_data, timestamp_expr)
 
         if func_name == "MAKEDATE" and num_operands == 2:
             # MAKEDATE(year, dayofyear) → Jan 1 of year + (doy-1) days
@@ -535,8 +556,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             if num_operands == 2:
                 # 2-operand form: DATEADD(date, interval) → date + interval
                 # This path handles Snowflake-style DATEADD with a date/timestamp
-                # and an interval literal. Default to DAY-based units
-                # (86_400_000_000_000 nanos per day) for the scalar fallback.
+                # and an interval literal.
                 date_expr = java_expr_to_python_expr(
                     ctx, java_call.getOperands()[0], input_plan
                 )
@@ -545,13 +565,30 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 )
                 int_empty = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
                 out_empty = pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns")))
+
+                amount_expr_dtype = get_expr_dtype(amount_expr, "DATEADD amount_expr")
+                if compare_types(amount_expr_dtype, (int, float)):
+                    # For the scalar fallback, default to DAY-based units
+                    # (86_400_000_000_000 nanos per day)
+                    nano_scale_expr = ConstantExpression(
+                        int_empty, input_plan, 86_400_000_000_000
+                    )
+                else:
+                    # Assume we have an interval type (e.g. a MonthDayNanoInterval tuple or duration type).
+                    # Get nanoseconds from interval literal by casting to int64.
+                    amount_expr = CastExpression(
+                        pd.Series(dtype=pd.ArrowDtype(pa.int64())), amount_expr
+                    )
+                    # nano_scale is 1 since we are already in units of nanoseconds
+                    nano_scale_expr = ConstantExpression(int_empty, input_plan, 1)
+
                 return ArrowScalarFuncExpression(
                     out_empty,
                     [
                         date_expr,
                         amount_expr,
                         ConstantExpression(int_empty, input_plan, 0),
-                        ConstantExpression(int_empty, input_plan, 86_400_000_000_000),
+                        nano_scale_expr,
                     ],
                     "bodo_dateadd",
                     (),
@@ -850,6 +887,31 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 "__add__",
             )
 
+        if func_name == "YEARWEEK" and num_operands == 1:
+            date_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            year_part = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr], "iso_year", ()
+            )
+            week_part = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr], "iso_week", ()
+            )
+
+            # Concatenate the year and the week parts in integer form
+            year_part_shifted = ArithOpExpression(
+                int_empty_data,
+                year_part,
+                ConstantExpression(int_empty_data, input_plan, 100),
+                "__mul__",
+            )
+            week_part_appended = ArithOpExpression(
+                int_empty_data, year_part_shifted, week_part, "__add__"
+            )
+            return week_part_appended
+
     if operator_class_name in (
         "SqlMonotonicBinaryOperator",
         "SqlBinaryOperator",
@@ -896,6 +958,16 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         empty_data = pd.Series(
             dtype=pd.ArrowDtype(sql_type_to_pa_type(ctx, target_type.getSqlTypeName()))
         )
+
+        if operand_type.getSqlTypeName().equals(
+            SqlTypeName.VARCHAR
+        ) and target_type.getSqlTypeName().equals(SqlTypeName.DATE):
+            # Cast to a timestamp first so we can parse string timestamps
+            # before truncating to a date at the end.
+            in_expr = CastExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns"))),
+                in_expr,
+            )
 
         # TO_TIMESTAMP/TO_TIMESTAMP_NTZ remove the timezone which is same as
         # local_timestamp() function of Arrow (not cast)
@@ -1030,14 +1102,14 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         if arrow_func is None:
             raise NotImplementedError(f"Unsupported EXTRACT unit: {unit_str}")
         empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-        raw_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
+
         if unit_str in ("DAYOFWEEK", "DOW"):
-            # PyArrow default: 0=Monday, 6=Sunday.
-            # Bodo/Snowflake DAYOFWEEK: 1=Monday, 0=Sunday → (dow+1)%7
-            one = ConstantExpression(empty_data, input_plan, 1)
-            seven = ConstantExpression(empty_data, input_plan, 7)
-            raw_expr = ArithOpExpression(empty_data, raw_expr, one, "__add__")
-            raw_expr = ArithOpExpression(empty_data, raw_expr, seven, "__mod__")
+            # Default DAYOFWEEK for Bodo/Snowflake is Sunday=0, Monday=1, ..., Saturday=6.
+            raw_expr = ArrowScalarFuncExpression(
+                empty_data, [input], arrow_func, (True, 7)
+            )
+        else:
+            raw_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
         # For WEEKDAY, PyArrow default (0=Monday..6=Sunday) exactly matches
         # Spark/Snowflake WEEKDAY, so no transformation is needed.
         return raw_expr
@@ -1058,9 +1130,12 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             "DAY",
             "DAYOFMONTH",
             "DAYOFYEAR",
+            "WEEKDAY",
             "WEEK",
             "WEEKOFYEAR",
-            "WEEKISOHOUR",
+            "WEEKISO",
+            "YEAROFWEEK",
+            "YEAROFWEEKISO",
             "HOUR",
             "MINUTE",
             "SECOND",
@@ -1068,28 +1143,23 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             "MICROSECOND",
             "NANOSECOND",
         ):
+            # TODO: Properly differentiate between the ISO and non-ISO versions.
+            # Currently we resort to Arrow's ISO versions for the variants aside from regular DAYOFWEEK.
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
             return ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
 
-        if func_name in ("WEEK", "WEEKOFYEAR", "WEEKISO", "DAYOFYEAR"):
+        if func_name == "DAYOFWEEKISO":
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            return ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
+            # Set count_from_zero=False and week_start=1 which corresponds to Monday.
+            # Therefore we get Monday=1, Tuesday=2, ..., Sunday=7.
+            return ArrowScalarFuncExpression(
+                empty_data, [input], arrow_func, (False, 1)
+            )
 
         if func_name in ("DAYOFWEEK", "DOW"):
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            dow_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
-            # PyArrow default: 0=Monday, 6=Sunday.
-            # Bodo/Snowflake DAYOFWEEK: 1=Monday, 0=Sunday → (dow+1)%7
-            one_const = ConstantExpression(empty_data, input_plan, 1)
-            seven_const = ConstantExpression(empty_data, input_plan, 7)
-            plus_one = ArithOpExpression(empty_data, dow_expr, one_const, "__add__")
-            return ArithOpExpression(empty_data, plus_one, seven_const, "__mod__")
-
-        if func_name == "WEEKDAY":
-            empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            # PyArrow default (0=Monday..6=Sunday) exactly matches
-            # Spark/Snowflake WEEKDAY, so no transformation is needed.
-            return ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
+            # Pass week_start = 7 which corresponds to Sunday, so we have Sunday=0, Monday=1, ..., Saturday=6.
+            return ArrowScalarFuncExpression(empty_data, [input], arrow_func, (True, 7))
 
     if operator_class_name == "SqlCoalesceFunction":
         operands = java_call.getOperands()

--- a/BodoSQL/bodosql/tests/test_date.py
+++ b/BodoSQL/bodosql/tests/test_date.py
@@ -501,6 +501,7 @@ def test_datediff_upcasting(func, unit, answer, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "func_name",
     [
@@ -580,6 +581,7 @@ def test_min_date_group_by(date_df, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_str_to_date_literals(basic_df, memory_leak_check):
     """
     Checks that calling STR_TO_DATE on literals behaves as expected
@@ -594,6 +596,7 @@ def test_str_to_date_literals(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_str_to_date_columns(memory_leak_check):
     """
     Checks that calling STR_TO_DATE on columns behaves as expected
@@ -612,6 +615,7 @@ def test_str_to_date_columns(memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_str_to_date_columns_format(memory_leak_check):
     """
     Checks that calling STR_TO_DATE on columns behaves as expected when

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -399,6 +399,7 @@ def test_dt_fns_cols(spark_info, dt_fn_info, dt_fn_dataframe, memory_leak_check)
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_dt_fns_scalars(spark_info, dt_fn_info, dt_fn_dataframe, memory_leak_check):
     """tests that the specified string functions work on Scalars"""
     bodo_fn_name = dt_fn_info[0]
@@ -2873,6 +2874,7 @@ def test_date_add_sub_interval_with_date_input(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_subdate_cols_int_arg1(
     subdate_equiv_fns,
     dt_fn_dataframe,
@@ -2930,6 +2932,7 @@ def test_subdate_scalar_int_arg1(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_subdate_cols_td_arg1(
     subdate_equiv_fns,
     dt_fn_dataframe,
@@ -3105,6 +3108,7 @@ def test_tz_aware_subdate(use_case, interval_amt, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_yearweek(dt_fn_dataframe, memory_leak_check):
     """Test for YEARWEEK, which returns a 6-character string
     with the date's year and week (1-53) concatenated together"""
@@ -3124,9 +3128,11 @@ def test_yearweek(dt_fn_dataframe, memory_leak_check):
         check_dtype=False,
         only_python=True,
         expected_output=expected_output,
+        use_duckdb=True,
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_yearweek(tz_aware_df, memory_leak_check):
     """Test for YEARWEEK on timezone aware data.
@@ -3134,40 +3140,26 @@ def test_tz_aware_yearweek(tz_aware_df, memory_leak_check):
     and week (1-53) concatenated together"""
 
     query = "SELECT YEARWEEK(A) AS OUTPUT from table1"
-
-    expected_output = pd.DataFrame(
-        {
-            "OUTPUT": tz_aware_df["TABLE1"]["A"].dt.year * 100
-            + tz_aware_df["TABLE1"]["A"].dt.isocalendar().week
-        }
-    )
     check_query(
         query,
         tz_aware_df,
         spark=None,
         check_dtype=False,
         only_python=True,
-        expected_output=expected_output,
+        use_duckdb=True,
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_yearweek_scalars(dt_fn_dataframe, memory_leak_check):
     query = "SELECT CASE WHEN YEARWEEK(timestamps) = 0 THEN -1 ELSE YEARWEEK(timestamps) END AS OUTPUT from table1"
-
-    expected_output = pd.DataFrame(
-        {
-            "OUTPUT": dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.year * 100
-            + dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.isocalendar().week
-        }
-    )
-
     check_query(
         query,
         dt_fn_dataframe,
         None,
         check_dtype=False,
         only_python=True,
-        expected_output=expected_output,
+        use_duckdb=True,
     )
 
 
@@ -3189,6 +3181,7 @@ def test_date_trunc_time_part(sql_func, time_df, time_part_strings, memory_leak_
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize("sql_func", ["DATE_TRUNC", "TRUNC"])
 def test_date_trunc_day_part_handling(
     sql_func, time_df, day_part_strings, memory_leak_check
@@ -3317,23 +3310,7 @@ def test_date_trunc_unquoted_timeunit(dt_fn_dataframe, memory_leak_check):
     )
 
 
-@pytest.mark.tz_aware
-def test_tz_aware_yearofweekiso(tz_aware_df, memory_leak_check):
-    """
-    Test Snowflake's yearofweekiso function on columns.
-    """
-    query = "SELECT YEAROFWEEKISO(A) as A from table1"
-    # Use expected output because this function isn't in SparkSQL
-    expected_output = pd.DataFrame({"A": tz_aware_df["TABLE1"]["A"].dt.year})
-    check_query(
-        query,
-        tz_aware_df,
-        None,
-        expected_output=expected_output,
-        check_dtype=False,
-    )
-
-
+@pytest.mark.bodosql_cpp
 def test_yearofweekiso(dt_fn_dataframe, memory_leak_check):
     """
     Test Snowflake's yearofweekiso function on columns.
@@ -3352,6 +3329,7 @@ def test_yearofweekiso(dt_fn_dataframe, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_yearofweekiso(tz_aware_df, memory_leak_check):
     """
@@ -3371,6 +3349,7 @@ def test_tz_aware_yearofweekiso(tz_aware_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_yearofweekiso_scalar(dt_fn_dataframe, memory_leak_check):
     """
     Test Snowflake's yearofweekiso function on scalars.
@@ -3393,6 +3372,7 @@ def test_yearofweekiso_scalar(dt_fn_dataframe, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_yearofweekiso_scalar(tz_aware_df, memory_leak_check):
     """
@@ -3453,6 +3433,7 @@ def test_weekiso_scalar(dt_fn_dataframe, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_weekiso(tz_aware_df, memory_leak_check):
     """simplest weekiso test on timezone aware data"""
@@ -3470,6 +3451,7 @@ def test_tz_aware_weekiso(tz_aware_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_weekiso_case(tz_aware_df, memory_leak_check):
     """weekiso test in case statement on timezone aware data"""
@@ -3491,6 +3473,7 @@ def test_tz_aware_weekiso_case(tz_aware_df, memory_leak_check):
 dm = {"mo": 0, "tu": 1, "we": 2, "th": 3, "fr": 4, "sa": 5, "su": 6}
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize("next_or_prev", ["NEXT", "PREVIOUS"])
 @pytest.mark.parametrize("dow_str", ["days_of_week", "su"])
 def test_next_previous_day_cols(
@@ -3535,6 +3518,7 @@ def test_next_previous_day_cols(
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize("next_or_prev", ["NEXT", "PREVIOUS"])
 @pytest.mark.parametrize("dow_str", ["days_of_week", "su"])
 def test_next_previous_day_scalars(
@@ -3763,6 +3747,7 @@ def test_tz_aware_week_quarter_dayname(large_tz_df, case, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 @pytest.mark.parametrize(
     "case",

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -3113,21 +3113,12 @@ def test_yearweek(dt_fn_dataframe, memory_leak_check):
     """Test for YEARWEEK, which returns a 6-character string
     with the date's year and week (1-53) concatenated together"""
     query = "SELECT YEARWEEK(timestamps) AS OUTPUT from table1"
-
-    expected_output = pd.DataFrame(
-        {
-            "OUTPUT": dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.year * 100
-            + dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.isocalendar().week
-        }
-    )
-
     check_query(
         query,
         dt_fn_dataframe,
         None,
         check_dtype=False,
         only_python=True,
-        expected_output=expected_output,
         use_duckdb=True,
     )
 

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -327,6 +327,32 @@ duckdb::Value ArrowScalarToDuckDBValue(
             break;
         }
 
+        case arrow::Type::DURATION: {
+            auto dur_scalar =
+                std::static_pointer_cast<arrow::DurationScalar>(scalar);
+            auto dur_type =
+                std::static_pointer_cast<arrow::DurationType>(scalar->type);
+
+            // DuckDB INTERVAL uses microseconds. If Arrow is not micro,
+            // we must scale.
+            int64_t val = dur_scalar->value;
+            switch (dur_type->unit()) {
+                case arrow::TimeUnit::SECOND:
+                    val *= 1000000;
+                    break;
+                case arrow::TimeUnit::MILLI:
+                    val *= 1000;
+                    break;
+                case arrow::TimeUnit::MICRO:
+                    break;  // No change
+                case arrow::TimeUnit::NANO:
+                    val /= 1000;
+                    break;
+            }
+
+            return duckdb::Value::INTERVAL(duckdb::Interval::FromMicro(val));
+        }
+
         default:
             throw std::runtime_error(
                 "ArrowScalarToDuckDBValue unhandled type: " +

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1588,6 +1588,23 @@ class PhysicalArrowExpression : public PhysicalExpression {
             // year_month_day, which returns a struct. To match the output dtype
             // of Pandas, we Cast to Date32 instead.
             result = do_arrow_compute_cast(res, duckdb::LogicalType::DATE);
+        } else if (scalar_func_data.arrow_func_name == "day_of_week") {
+            assert_py_args_is_tuple(scalar_func_data.args,
+                                    scalar_func_data.arrow_func_name.c_str());
+            size_t num_args = PyTuple_Size(scalar_func_data.args);
+            if (num_args == 2) {
+                auto [count_from_zero, week_start] = get_py_args_as_types(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str(),
+                    get_py_object_as_bool, get_py_object_as_int64);
+
+                arrow::compute::DayOfWeekOptions opts(count_from_zero,
+                                                      week_start);
+                result = do_arrow_compute_unary(res, "day_of_week", &opts);
+            } else {
+                // Only support 0 or 2 optional parameters for now
+                result = do_arrow_compute_unary(res, "day_of_week");
+            }
         } else if (scalar_func_data.arrow_func_name == "day_of_week_num") {
             // day_of_week_num is a made up function representing the
             // number representing a day of week string.
@@ -1796,6 +1813,26 @@ class PhysicalArrowExpression : public PhysicalExpression {
                 scalar_func_data.arrow_func_name.c_str());
             arrow::compute::StrftimeOptions opts(fmt_str);
             result = do_arrow_compute_unary(res, "strftime", &opts);
+        } else if (scalar_func_data.arrow_func_name == "strptime") {
+            auto [fmt_str, unit_cstr] = get_py_args_as_types(
+                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
+                get_py_object_as_cstr, get_py_object_as_cstr);
+            std::string unit_str(unit_cstr);
+            arrow::TimeUnit::type time_unit;
+            if (unit_str == "s") {
+                time_unit = arrow::TimeUnit::SECOND;
+            } else if (unit_str == "ms") {
+                time_unit = arrow::TimeUnit::MILLI;
+            } else if (unit_str == "us") {
+                time_unit = arrow::TimeUnit::MICRO;
+            } else if (unit_str == "ns") {
+                time_unit = arrow::TimeUnit::NANO;
+            } else {
+                throw std::invalid_argument(
+                    "strptime: Invalid time unit string: " + unit_str);
+            }
+            arrow::compute::StrptimeOptions opts(fmt_str, time_unit, false);
+            result = do_arrow_compute_unary(res, "strptime", &opts);
         } else if (scalar_func_data.arrow_func_name == "floor_temporal" ||
                    scalar_func_data.arrow_func_name == "ceil_temporal" ||
                    scalar_func_data.arrow_func_name == "round_temporal") {

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1391,6 +1391,11 @@ class PhysicalArrowExpression : public PhysicalExpression {
     PhysicalArrowExpressionMetrics metrics;
 
     template <typename T>
+    using compute_return_t =
+        std::conditional_t<std::is_same_v<T, std::shared_ptr<ExprResult>>,
+                           std::shared_ptr<array_info>, T>;
+
+    template <typename T>
     arrow::Datum do_arrow_compute_regexp_substr(T res, std::string pattern_str,
                                                 std::string regex_params_str,
                                                 int64_t group_to_extract) {
@@ -1515,9 +1520,44 @@ class PhysicalArrowExpression : public PhysicalExpression {
     }
 
     template <typename T>
-    using compute_return_t =
-        std::conditional_t<std::is_same_v<T, std::shared_ptr<ExprResult>>,
-                           std::shared_ptr<array_info>, T>;
+    arrow::Datum do_arrow_compute_dow_num(T res) {
+        // We strip off the leading spaces and only look at the first two
+        // characters of the input string in accordance with Snowflake (e.g.
+        // NEXT_DAY/PREVIOUS_DAY)
+
+        // Create Arrow array containing the days of the week. The order (index)
+        // determines the result DoW number.
+        arrow::StringBuilder builder;
+        arrow::Status status =
+            builder.AppendValues({"mo", "tu", "we", "th", "fr", "sa", "su"});
+        if (!status.ok()) {
+            throw std::runtime_error(
+                "do_arrow_compute_dow_num: Failed to append values to "
+                "StringBuilder");
+        }
+        std::shared_ptr<arrow::Array> dow_array = builder.Finish().ValueOrDie();
+
+        arrow::Datum res_datum =
+            ConvertExprResultToDatum(res, "day_of_week_num input");
+
+        // Normalize string to two lowercase characters representing the day of
+        // the week
+        arrow::Datum trimmed_dow_string =
+            do_arrow_compute_unary(res_datum, "utf8_ltrim_whitespace");
+        arrow::compute::SliceOptions slice_opts(0, 2, 1);
+        arrow::Datum sliced_dow_string = do_arrow_compute_unary(
+            trimmed_dow_string, "utf8_slice_codeunits", &slice_opts);
+        arrow::Datum lowered_dow_string =
+            do_arrow_compute_unary(sliced_dow_string, "utf8_lower");
+
+        // Get index of string into DoW array, which equals the DoW number
+        arrow::compute::SetLookupOptions set_lookup_opts(dow_array);
+        arrow::Datum dow_num = do_arrow_compute_unary(
+            lowered_dow_string, "index_in", &set_lookup_opts);
+
+        return dow_num;
+    }
+
     template <typename T>
     compute_return_t<T> do_arrow_compute(T res) {
         compute_return_t<T> result;
@@ -1548,6 +1588,18 @@ class PhysicalArrowExpression : public PhysicalExpression {
             // year_month_day, which returns a struct. To match the output dtype
             // of Pandas, we Cast to Date32 instead.
             result = do_arrow_compute_cast(res, duckdb::LogicalType::DATE);
+        } else if (scalar_func_data.arrow_func_name == "day_of_week_num") {
+            // day_of_week_num is a made up function representing the
+            // number representing a day of week string.
+            // Monday = 0, ..., Sunday = 6
+            arrow::Datum dow_num_datum = do_arrow_compute_dow_num(res);
+
+            // Convert DoW number and assign to result based on input type
+            if constexpr (std::is_same_v<T, arrow::Datum>) {
+                result = dow_num_datum;
+            } else {
+                result = ConvertDatumToArrayInfo(dow_num_datum);
+            }
         } else if (scalar_func_data.arrow_func_name ==
                        "match_substring_regex" ||
                    scalar_func_data.arrow_func_name ==


### PR DESCRIPTION
## Changes included in this PR

More date/time functions are supported in the C++ backend, including `NEXT_DAY`/`PREVIOUS_DAY`, `DAYOFWEEKISO`, `YEAROFWEEK`, `YEAROFWEEKISO`, `YEARWEEK`, `STR_TO_DATE`.
This also fixes the 2-argument form of DATEADD when the input is an interval type.

## Testing strategy

PR CI and Nightly

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.