### PR TITLE
BSE-5477: Broader Iceberg filter expression support

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -174,52 +174,14 @@ def java_plan_to_python_plan(ctx, java_plan):
                 f"Table type {type(table)} not supported in C++ backend yet"
             )
 
-    # Iceberg plan nodes: each handler sets up its own contribution to
-    # IcebergReadInfo and recurses into children via visit_iceberg_node
+    # Traverse Iceberg plan nodes to extract read information similar to BodoSQL
     # (see flattenIcebergTree in BodoSQL Java code)
-
     if java_class_name == "IcebergToBodoPhysicalConverter":
-        return java_plan_to_python_plan(ctx, java_plan.getInput())
-
-    if java_class_name == "IcebergTableScan":
-        read_info = IcebergReadInfo()
-        read_info.scan_node = java_plan
-        read_info.colmap = list(range(java_plan.getRowType().getFieldCount()))
-        return generate_iceberg_read(read_info)
-
-    if java_class_name == "IcebergFilter":
-        read_info = IcebergReadInfo()
         input = java_plan.getInput()
-        read_info.colmap = list(range(input.getRowType().getFieldCount()))
-        read_info.filters = [java_plan.getCondition()]
-        visit_iceberg_node(ctx, input, read_info)
-        return generate_iceberg_read(read_info)
-
-    if java_class_name == "IcebergProject":
         read_info = IcebergReadInfo()
-        read_info.colmap = list(range(java_plan.getRowType().getFieldCount()))
-        _apply_iceberg_project(read_info, java_plan)
-        visit_iceberg_node(ctx, java_plan.getInput(), read_info)
-        return generate_iceberg_read(read_info)
-
-    if java_class_name == "IcebergSort":
-        read_info = IcebergReadInfo()
-        input = java_plan.getInput()
+        # Initialize all columns to be in the original location (updated top-down based
+        # on IcebergProject nodes)
         read_info.colmap = list(range(input.getRowType().getFieldCount()))
-        limit = java_plan.getFetch()
-        if limit is not None:
-            assert limit.getClass().getSimpleName() == "RexLiteral", (
-                "Only literal LIMITs are supported in IcebergSort"
-            )
-            read_info.limit = java_expr_to_pyiceberg_expr(limit, [])
-        visit_iceberg_node(ctx, input, read_info)
-        return generate_iceberg_read(read_info)
-
-    if java_class_name == "IcebergRuntimeJoinFilter":
-        read_info = IcebergReadInfo()
-        input = java_plan.getInput()
-        read_info.colmap = list(range(input.getRowType().getFieldCount()))
-        read_info.join_filter_info = java_rtjf_to_join_info(ctx, java_plan)
         visit_iceberg_node(ctx, input, read_info)
         return generate_iceberg_read(read_info)
 
@@ -3600,24 +3562,6 @@ def sql_type_to_pa_type(ctx, sql_type_name):
     raise NotImplementedError(f"SQL type {sql_type_name.toString()} not supported yet")
 
 
-def _apply_iceberg_project(read_info, java_plan):
-    """Apply IcebergProject column reordering to read_info.colmap.
-
-    Updates read_info.colmap in-place to map output positions to input
-    column indices based on the project expressions.
-    """
-    new_colmap = []
-    projs = java_plan.getProjects()
-    for ind in read_info.colmap:
-        proj = projs[ind]
-        if proj.getClass().getSimpleName() != "RexInputRef":
-            raise NotImplementedError(
-                "IcebergProject with expressions not supported yet"
-            )
-        new_colmap.append(proj.getIndex())
-    read_info.colmap = new_colmap
-
-
 def visit_iceberg_node(ctx, java_plan, read_info: IcebergReadInfo):
     """Visit Iceberg-related plan nodes to extract read information like filters.
     For example:
@@ -3643,7 +3587,17 @@ def visit_iceberg_node(ctx, java_plan, read_info: IcebergReadInfo):
     if java_class_name == "IcebergProject":
         # Projects may reorder columns, so we need to update the column mapping.
         # See IcebergToBodoPhysicalConverter.kt
-        _apply_iceberg_project(read_info, java_plan)
+        new_colmap = []
+        projs = java_plan.getProjects()
+        for ind in read_info.colmap:
+            proj = projs[ind]
+            if proj.getClass().getSimpleName() != "RexInputRef":
+                raise NotImplementedError(
+                    "IcebergProject with expressions not supported yet"
+                )
+            new_colmap.append(proj.getIndex())
+
+        read_info.colmap = new_colmap
         input = java_plan.getInput()
         visit_iceberg_node(ctx, input, read_info)
         return

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -5,7 +5,7 @@ import operator
 import re
 import zoneinfo
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import numpy as np
 import pandas as pd
@@ -174,14 +174,44 @@ def java_plan_to_python_plan(ctx, java_plan):
                 f"Table type {type(table)} not supported in C++ backend yet"
             )
 
-    # Traverse Iceberg plan nodes to extract read information similar to BodoSQL
+    # Iceberg plan nodes: each handler sets up its own contribution to
+    # IcebergReadInfo and recurses into children via visit_iceberg_node
     # (see flattenIcebergTree in BodoSQL Java code)
+
     if java_class_name == "IcebergToBodoPhysicalConverter":
-        input = java_plan.getInput()
+        return java_plan_to_python_plan(ctx, java_plan.getInput())
+
+    if java_class_name == "IcebergTableScan":
         read_info = IcebergReadInfo()
-        # Initialize all columns to be in the original location (updated top-down based
-        # on IcebergProject nodes)
+        read_info.scan_node = java_plan
+        read_info.colmap = list(range(java_plan.getRowType().getFieldCount()))
+        return generate_iceberg_read(read_info)
+
+    if java_class_name == "IcebergFilter":
+        read_info = IcebergReadInfo()
+        input = java_plan.getInput()
         read_info.colmap = list(range(input.getRowType().getFieldCount()))
+        read_info.filters = [java_plan.getCondition()]
+        visit_iceberg_node(ctx, input, read_info)
+        return generate_iceberg_read(read_info)
+
+    if java_class_name == "IcebergProject":
+        read_info = IcebergReadInfo()
+        read_info.colmap = list(range(java_plan.getRowType().getFieldCount()))
+        _apply_iceberg_project(read_info, java_plan)
+        visit_iceberg_node(ctx, java_plan.getInput(), read_info)
+        return generate_iceberg_read(read_info)
+
+    if java_class_name == "IcebergSort":
+        read_info = IcebergReadInfo()
+        input = java_plan.getInput()
+        read_info.colmap = list(range(input.getRowType().getFieldCount()))
+        limit = java_plan.getFetch()
+        if limit is not None:
+            assert limit.getClass().getSimpleName() == "RexLiteral", (
+                "Only literal LIMITs are supported in IcebergSort"
+            )
+            read_info.limit = java_expr_to_pyiceberg_expr(limit, [])
         visit_iceberg_node(ctx, input, read_info)
         return generate_iceberg_read(read_info)
 
@@ -2299,134 +2329,81 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             # search_expr is a ConstantExpression with org.apache.calcite.util.Sarg value
             search_expr = op_exprs[1]
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
-            # sarg is an org.apache.calcite.util.Sarg
             sarg = search_expr.value
-            assert sarg.getClass().getSimpleName() == "Sarg"
-            nullAs = sarg.getClass().getDeclaredField("nullAs").get(sarg).toString()
-            # sarg_rangeSet is a com.google.common.collect.ImmutableRangeSet
-            sarg_rangeSet = sarg.getClass().getDeclaredField("rangeSet").get(sarg)
-            assert sarg_rangeSet.getClass().getSimpleName() == "ImmutableRangeSet"
-            # ranges_collection is a com.google.common.collect.RegularImmutableSortedSet
-            ranges_collection = sarg_rangeSet.asRanges()
-            assert (
-                ranges_collection.getClass().getSimpleName()
-                == "RegularImmutableSortedSet"
-            )
-            search_options = []
-            it = ranges_collection.iterator()
-            while it.hasNext():
-                # r is a com.google.common.collect.Range
-                r = it.next()
-                assert r.getClass().getSimpleName() == "Range"
-                search_options.append(r)
+            nullAs = _get_sarg_null_as(sarg)
 
-            def range_type_to_python(x):
-                if isinstance(x, py4j.java_gateway.JavaObject):
-                    return x.getValue()
-                elif isinstance(x, decimal.Decimal):
-                    return float(x)
-                else:
-                    return x
-
-            def process_one_search_option(so):
+            def process_one_search_option(lower, lower_incl, upper, upper_incl):
                 """Generate an expression to check if src satisfies this
                 current possibility from the range set."""
-                # Get and convert the lower range endpoint if it has one else None.
-                lower_lit = (
-                    range_type_to_python(so.lowerEndpoint())
-                    if so.hasLowerBound()
-                    else None
-                )
-                # Get and convert the upper range endpoint if it has one else None.
-                upper_lit = (
-                    range_type_to_python(so.upperEndpoint())
-                    if so.hasUpperBound()
-                    else None
-                )
-                lower_inclusive = so.lowerBoundType().toString() == "CLOSED"
-                upper_inclusive = so.upperBoundType().toString() == "CLOSED"
-                # There are 9 possibilities here.  NA=Not applicable
-                # HasLower HasUpper LowerInclusive UpperInclusive
-                # F        F        NA             NA
-                # T        F        T              NA
-                # T        F        F              NA
-                # F        T        NA             T
-                # F        T        NA             F
-                # T        T        T              T
-                # T        T        T              F
-                # T        T        F              T
-                # T        T        F              F
-
                 # The lower and upper bounds being equal is a special case that does not
                 # involve less-than or greater-than comparison. It can be subdivided
                 # based on whether the lower and upper bounds are inclusive or not.
                 # The typical case is that they will be inclusive, which we can simplify
                 # to an equality check.
-                if (
-                    lower_lit is not None
-                    and upper_lit is not None
-                    and lower_lit == upper_lit
-                ):
-                    if lower_inclusive and upper_inclusive:
+                if lower is not None and upper is not None and lower == upper:
+                    if lower_incl and upper_incl:
                         # Range of the form [a..a] - reduce to equality check
                         const_empty_data = arrow_to_empty_df(
-                            pa.schema([pa.field("equal", pa.scalar(lower_lit).type)])
+                            pa.schema([pa.field("equal", pa.scalar(lower).type)])
                         )
-
                         return ComparisonOpExpression(
                             bool_empty_data,
                             src,
-                            ConstantExpression(const_empty_data, input_plan, lower_lit),
+                            ConstantExpression(const_empty_data, input_plan, lower),
                             operator.eq,
                         )
-                    elif lower_inclusive or upper_inclusive:
+                    elif lower_incl or upper_incl:
                         # Range of the form [a..a) or (a..a] - interpret as empty
                         return ConstantExpression(bool_empty_data, input_plan, False)
                     else:
                         raise ValueError("SEARCH option range form (a..a) is invalid.")
 
                 # Address the standard continuous range case, e.g. BETWEEN
-                if lower_lit is not None:
+                in_range = None
+                src_greater = None
+                src_less = None
+                if lower is not None:
                     const_empty_data = arrow_to_empty_df(
-                        pa.schema([pa.field("equal", pa.scalar(lower_lit).type)])
+                        pa.schema([pa.field("equal", pa.scalar(lower).type)])
                     )
                     src_greater = ComparisonOpExpression(
                         bool_empty_data,
                         src,
-                        ConstantExpression(const_empty_data, input_plan, lower_lit),
-                        operator.ge if lower_inclusive else operator.gt,
+                        ConstantExpression(const_empty_data, input_plan, lower),
+                        operator.ge if lower_incl else operator.gt,
                     )
                     in_range = src_greater
-                if upper_lit is not None:
+                if upper is not None:
                     const_empty_data = arrow_to_empty_df(
-                        pa.schema([pa.field("equal", pa.scalar(upper_lit).type)])
+                        pa.schema([pa.field("equal", pa.scalar(upper).type)])
                     )
                     src_less = ComparisonOpExpression(
                         bool_empty_data,
                         src,
-                        ConstantExpression(const_empty_data, input_plan, upper_lit),
-                        operator.le if upper_inclusive else operator.lt,
+                        ConstantExpression(const_empty_data, input_plan, upper),
+                        operator.le if upper_incl else operator.lt,
                     )
                     in_range = src_less
 
-                if lower_lit is not None and upper_lit is not None:
+                if lower is not None and upper is not None:
                     # Assure input is within both bounds
                     in_range = ConjunctionOpExpression(
                         bool_empty_data, src_greater, src_less, "__and__"
                     )
-                elif lower_lit is None and upper_lit is None:
+                elif lower is None and upper is None:
                     # No bounds specified, inputs must be in infinite range
                     in_range = ConstantExpression(bool_empty_data, input_plan, True)
 
                 return in_range
 
-            out_expr = process_one_search_option(search_options[0])
+            search_options = list(iter_sarg_ranges(sarg))
+            out_expr = process_one_search_option(*search_options[0])
             # The definition of search is that the value is one of the
             # possibilities in the range set.  so, "or" in the other
             # possibilities below.
             for so in search_options[1:]:
                 out_expr = ConjunctionOpExpression(
-                    bool_empty_data, out_expr, process_one_search_option(so), "__or__"
+                    bool_empty_data, out_expr, process_one_search_option(*so), "__or__"
                 )
 
             if nullAs != "UNKNOWN":
@@ -3602,6 +3579,24 @@ def sql_type_to_pa_type(ctx, sql_type_name):
     raise NotImplementedError(f"SQL type {sql_type_name.toString()} not supported yet")
 
 
+def _apply_iceberg_project(read_info, java_plan):
+    """Apply IcebergProject column reordering to read_info.colmap.
+
+    Updates read_info.colmap in-place to map output positions to input
+    column indices based on the project expressions.
+    """
+    new_colmap = []
+    projs = java_plan.getProjects()
+    for ind in read_info.colmap:
+        proj = projs[ind]
+        if proj.getClass().getSimpleName() != "RexInputRef":
+            raise NotImplementedError(
+                "IcebergProject with expressions not supported yet"
+            )
+        new_colmap.append(proj.getIndex())
+    read_info.colmap = new_colmap
+
+
 def visit_iceberg_node(ctx, java_plan, read_info: IcebergReadInfo):
     """Visit Iceberg-related plan nodes to extract read information like filters.
     For example:
@@ -3627,17 +3622,7 @@ def visit_iceberg_node(ctx, java_plan, read_info: IcebergReadInfo):
     if java_class_name == "IcebergProject":
         # Projects may reorder columns, so we need to update the column mapping.
         # See IcebergToBodoPhysicalConverter.kt
-        new_colmap = []
-        projs = java_plan.getProjects()
-        for ind in read_info.colmap:
-            proj = projs[ind]
-            if proj.getClass().getSimpleName() != "RexInputRef":
-                raise NotImplementedError(
-                    "IcebergProject with expressions not supported yet"
-                )
-            new_colmap.append(proj.getIndex())
-
-        read_info.colmap = new_colmap
+        _apply_iceberg_project(read_info, java_plan)
         input = java_plan.getInput()
         visit_iceberg_node(ctx, input, read_info)
         return
@@ -3796,10 +3781,178 @@ def java_call_to_pyiceberg_call(java_call, field_names):
         if kind.equals(SqlKind.IS_NULL):
             return pie.IsNull(input)
 
+        if kind.equals(SqlKind.IS_TRUE):
+            return pie.EqualTo(input, True)
+
+        if kind.equals(SqlKind.IS_FALSE):
+            return pie.EqualTo(input, False)
+
+    if operator_class_name == "SqlPrefixOperator" and len(java_call.getOperands()) == 1:
+        kind = op.getKind()
+        SqlKind = gateway.jvm.org.apache.calcite.sql.SqlKind
+        if kind.equals(SqlKind.NOT):
+            operand = java_expr_to_pyiceberg_expr(
+                java_call.getOperands()[0], field_names
+            )
+            return pie.Not(operand)
+
+    if operator_class_name == "SqlSearchOperator":
+        return java_search_to_pyiceberg_expr(java_call, field_names)
+
+    if operator_class_name == "SqlNullPolicyFunction":
+        func_name = op.getName().upper()
+        if func_name == "STARTSWITH" and len(java_call.getOperands()) == 2:
+            operands = java_call.getOperands()
+            ref = java_expr_to_pyiceberg_expr(operands[0], field_names)
+            prefix = java_expr_to_pyiceberg_expr(operands[1], field_names)
+            return pie.StartsWith(ref, prefix)
+
     raise NotImplementedError(
         f"Call operator {operator_class_name} for pyiceberg not supported yet: "
         + java_call.toString()
     )
+
+
+def java_search_to_pyiceberg_expr(java_call, field_names):
+    """Convert a Calcite SEARCH call (e.g. IN/BETWEEN expressed as
+    SEARCH($col, Sarg[...])) to a PyIceberg expression.
+
+    Calcite represents IN predicates as SEARCH against a Sarg of discrete
+    points, and NOT IN as SEARCH against the complement. Range-based
+    predicates (e.g. BETWEEN) become a Sarg with non-point ranges.
+    """
+    import pyiceberg.expressions as pie
+
+    operands = java_call.getOperands()
+    ref = java_expr_to_pyiceberg_expr(operands[0], field_names)
+    sarg = operands[1].getValue()
+    null_as = _get_sarg_null_as(sarg)
+
+    # Collect each range as a Python value (point) or a comparison pair (range).
+    points = []
+    range_exprs = []
+    for lower, lower_incl, upper, upper_incl in iter_sarg_ranges(sarg):
+        if (
+            lower is not None
+            and upper is not None
+            and lower == upper
+            and lower_incl
+            and upper_incl
+        ):
+            points.append(lower)
+        elif (
+            lower is not None
+            and upper is not None
+            and lower == upper
+            and lower_incl != upper_incl
+        ):
+            # [a..a) or (a..a] is an empty range.
+            range_exprs.append(pie.AlwaysFalse())
+        else:
+            range_exprs.append(
+                _sarg_range_to_pyiceberg_expr(ref, lower, lower_incl, upper, upper_incl)
+            )
+
+    if sarg.isPoints() and points:
+        expr = pie.In(ref, set(points))
+    elif sarg.isComplementedPoints() and points:
+        expr = pie.NotIn(ref, set(points))
+    elif range_exprs:
+        expr = range_exprs[0]
+        for re_ in range_exprs[1:]:
+            expr = pie.Or(expr, re_)
+    elif points:
+        # Mixed points and ranges (shouldn't happen for isPoints/isComplementedPoints,
+        # but handle defensively): OR together In and range expressions.
+        expr = pie.In(ref, set(points))
+        for re_ in range_exprs:
+            expr = pie.Or(expr, re_)
+    else:
+        raise NotImplementedError(
+            "SEARCH with empty Sarg not supported yet: " + java_call.toString()
+        )
+
+    if null_as == "FALSE":
+        return pie.And(expr, pie.NotNull(ref))
+    if null_as == "TRUE":
+        return pie.Or(expr, pie.IsNull(ref))
+    return expr
+
+
+def _sarg_endpoint_to_python(endpoint):
+    """Convert a Java Sarg range endpoint (e.g. NlsString, BigDecimal) to a
+    Python value."""
+    if isinstance(endpoint, py4j.java_gateway.JavaObject):
+        # NlsString and other Calcite literal wrappers expose getValue()
+        return endpoint.getValue()
+    if isinstance(endpoint, decimal.Decimal):
+        return float(endpoint)
+    return endpoint
+
+
+def _get_sarg_null_as(sarg):
+    """Read the nullAs field of a Java Sarg as a string ('UNKNOWN', 'TRUE', or 'FALSE')."""
+    return sarg.getClass().getDeclaredField("nullAs").get(sarg).toString()
+
+
+def iter_sarg_ranges(sarg):
+    """Iterate over the ranges in a Calcite Sarg's range set, yielding
+    ``(lower, lower_inclusive, upper, upper_inclusive)`` tuples with
+    Python-typed endpoints.
+
+    A ``None`` bound means unbounded on that side. Calcite represents IN
+    predicates as a Sarg of discrete points (each a degenerate [a..a]
+    range), NOT IN as the complement, and range-based predicates (e.g.
+    BETWEEN) as non-degenerate ranges.
+    """
+    range_set = sarg.getClass().getDeclaredField("rangeSet").get(sarg)
+    it = range_set.asRanges().iterator()
+    while it.hasNext():
+        r = it.next()
+        has_lower = r.hasLowerBound()
+        has_upper = r.hasUpperBound()
+        yield (
+            _sarg_endpoint_to_python(r.lowerEndpoint()) if has_lower else None,
+            r.lowerBoundType().toString() == "CLOSED" if has_lower else False,
+            _sarg_endpoint_to_python(r.upperEndpoint()) if has_upper else None,
+            r.upperBoundType().toString() == "CLOSED" if has_upper else False,
+        )
+
+
+def _sarg_range_to_pyiceberg_expr(ref, lower, lower_inclusive, upper, upper_inclusive):
+    """Convert a single non-point Sarg range to a PyIceberg comparison
+    expression against the given reference."""
+    import pyiceberg.expressions as pie
+
+    has_lower = lower is not None
+    has_upper = upper is not None
+
+    if has_lower and has_upper:
+        left = (
+            pie.GreaterThanOrEqual(ref, lower)
+            if lower_inclusive
+            else pie.GreaterThan(ref, lower)
+        )
+        right = (
+            pie.LessThanOrEqual(ref, upper)
+            if upper_inclusive
+            else pie.LessThan(ref, upper)
+        )
+        return pie.And(left, right)
+    if has_lower:
+        return (
+            pie.GreaterThanOrEqual(ref, lower)
+            if lower_inclusive
+            else pie.GreaterThan(ref, lower)
+        )
+    if has_upper:
+        return (
+            pie.LessThanOrEqual(ref, upper)
+            if upper_inclusive
+            else pie.LessThan(ref, upper)
+        )
+    # No bounds => infinite range, always true.
+    return pie.AlwaysTrue()
 
 
 def java_binop_to_pyiceberg_expr(kind, op_exprs):
@@ -3845,6 +3998,23 @@ def java_binop_to_pyiceberg_expr(kind, op_exprs):
         right = _ensure_pyiceberg_non_ref_expr(right)
         return pie.Or(left, right)
 
+    if kind.equals(SqlKind.IS_DISTINCT_FROM):
+        # Null-safe "not equal": A != B AND (A IS NOT NULL OR B IS NOT NULL).
+        # pyiceberg's NotEqualTo follows SQL semantics (null if either is
+        # null), so the additional IS_NOT_NULL clause distinguishes the
+        # "one is null" case from the "both null" case.
+        left_nn = pie.NotNull(left)
+        right_nn = pie.NotNull(right)
+        return pie.And(pie.NotEqualTo(left, right), pie.Or(left_nn, right_nn))
+
+    if kind.equals(SqlKind.IS_NOT_DISTINCT_FROM):
+        # Null-safe "equal": A == B OR (A IS NULL AND B IS NULL).
+        # pyiceberg's EqualTo follows SQL semantics (null if either is null),
+        # so the additional IS_NULL clause covers the "both null" case.
+        left_null = pie.IsNull(left)
+        right_null = pie.IsNull(right)
+        return pie.Or(pie.EqualTo(left, right), pie.And(left_null, right_null))
+
     raise NotImplementedError(
         f"Binary operator {kind.toString()} not supported yet in java_binop_to_pyiceberg_expr"
     )
@@ -3872,8 +4042,6 @@ def java_literal_to_pyiceberg_literal(java_literal):
     lit_type_name = java_literal.getTypeName()
     lit_type = java_literal.getType()
 
-    # TODO[BSE-5156]: support all Calcite literal types
-
     if lit_type_name.equals(SqlTypeName.DECIMAL):
         lit_type_scale = lit_type.getScale()
         val = java_literal.getValue()
@@ -3885,13 +4053,35 @@ def java_literal_to_pyiceberg_literal(java_literal):
     if lit_type_name.equals(SqlTypeName.DOUBLE):
         return java_literal.getValue()
 
+    if lit_type_name.equals(SqlTypeName.FLOAT):
+        return float(java_literal.getValue())
+
+    if (
+        lit_type_name.equals(SqlTypeName.TINYINT)
+        or lit_type_name.equals(SqlTypeName.SMALLINT)
+        or lit_type_name.equals(SqlTypeName.INTEGER)
+        or lit_type_name.equals(SqlTypeName.BIGINT)
+    ):
+        return int(java_literal.getValue2())
+
+    if lit_type_name.equals(SqlTypeName.BOOLEAN):
+        return bool(java_literal.getValue())
+
     if lit_type_name.equals(SqlTypeName.CHAR):
+        return java_literal.getValue2()
+
+    if lit_type_name.equals(SqlTypeName.VARCHAR):
         return java_literal.getValue2()
 
     if lit_type_name.equals(SqlTypeName.DATE):
         # getValue2() returns an integer representing days since epoch
-        val = pa.scalar(java_literal.getValue2(), pa.date32())
-        return val
+        return date(1970, 1, 1) + timedelta(days=java_literal.getValue2())
+
+    if lit_type_name.equals(SqlTypeName.TIMESTAMP):
+        # getValue2() returns an integer representing milliseconds since epoch
+        return datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(
+            milliseconds=java_literal.getValue2()
+        )
 
     raise NotImplementedError(
         f"Literal type {lit_type_name.toString()} not supported yet in java_literal_to_pyiceberg_literal"

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -215,6 +215,14 @@ def java_plan_to_python_plan(ctx, java_plan):
         visit_iceberg_node(ctx, input, read_info)
         return generate_iceberg_read(read_info)
 
+    if java_class_name == "IcebergRuntimeJoinFilter":
+        read_info = IcebergReadInfo()
+        input = java_plan.getInput()
+        read_info.colmap = list(range(input.getRowType().getFieldCount()))
+        read_info.join_filter_info = java_rtjf_to_join_info(ctx, java_plan)
+        visit_iceberg_node(ctx, input, read_info)
+        return generate_iceberg_read(read_info)
+
     if java_class_name in ("PandasProject", "BodoPhysicalProject"):
         input_plan = java_plan_to_python_plan(ctx, java_plan.getInput())
         exprs = [

--- a/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog.py
+++ b/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog.py
@@ -258,3 +258,22 @@ def test_basic_iceberg_read(iceberg_database):
     query = f'SELECT B, C FROM "{db_schema}"."{table_name}" limit 2'
     out = bc1.sql(query)
     assert len(out) == 2, "Expected only 2 rows from limit 2"
+
+    # Exercise a broad set of filter types supported by the Java→pyiceberg
+    # converter in a single pushed-down IcebergFilter: comparison operators
+    # (>, >=, <, <=, =, <>), AND/OR/NOT, IN (via SEARCH/Sarg), STARTSWITH
+    # (via LIKE 'prefix%'), and IS NOT DISTINCT FROM (column vs literal).
+    query = (
+        f'SELECT A, B, C FROM "{db_schema}"."{table_name}" WHERE '
+        f"A IN (1, 3, 5, 7) "
+        f"AND A <> 5 "
+        f"AND A >= 1 AND A <= 7 "
+        f"AND NOT (A = 1) "
+        f"AND C LIKE 'a%' "
+        f"AND A IS NOT DISTINCT FROM 3"
+    )
+    out = bc1.sql(query)
+    expected = input_df[(input_df.A == 3) & (input_df.C.str.startswith("a"))][
+        ["A", "B", "C"]
+    ].reset_index(drop=True)
+    _check_query_equal(out, expected)


### PR DESCRIPTION
## Changes included in this PR
As title, supports all IcebergFilters generated by calcite
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
Existing and new tests/pr ci
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
More iceberg queries won't fallback
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.