### PR TITLE
Support more date/time functions in BodoSQL C++ backend (part 2)

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -577,26 +577,25 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     nano_scale_expr = ConstantExpression(
                         int_empty, input_plan, 86_400_000_000_000
                     )
+
+                    return ArrowScalarFuncExpression(
+                        out_empty,
+                        [
+                            date_expr,
+                            amount_expr,
+                            ConstantExpression(int_empty, input_plan, 0),
+                            nano_scale_expr,
+                        ],
+                        "bodo_dateadd",
+                        (),
+                    )
                 else:
                     # Assume we have an interval type (e.g. a MonthDayNanoInterval tuple or duration type).
-                    # Get nanoseconds from interval literal by casting to int64.
-                    amount_expr = CastExpression(
-                        pd.Series(dtype=pd.ArrowDtype(pa.int64())), amount_expr
+                    # Add the interval via ArithOpExpression, which should use DuckDB's calendar-aware
+                    # interval arithmetic as long as amount_expr is a ConstantExpression.
+                    return ArithOpExpression(
+                        out_empty, date_expr, amount_expr, "__add__"
                     )
-                    # nano_scale is 1 since we are already in units of nanoseconds
-                    nano_scale_expr = ConstantExpression(int_empty, input_plan, 1)
-
-                return ArrowScalarFuncExpression(
-                    out_empty,
-                    [
-                        date_expr,
-                        amount_expr,
-                        ConstantExpression(int_empty, input_plan, 0),
-                        nano_scale_expr,
-                    ],
-                    "bodo_dateadd",
-                    (),
-                )
             elif num_operands == 3:
                 # 3-operand form: DATEADD(unit, amount, date) → date + (unit * amount)
                 # First operand is a FLAG(unit) interval qualifier from the Java

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -335,6 +335,429 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
             return CastExpression(date_empty_data, timestamp_expr)
 
+        def timestamp_from_parts(
+            year_expr,
+            month_expr,
+            day_expr,
+            hour_expr=None,
+            minute_expr=None,
+            second_expr=None,
+            nanosecond_expr=None,
+        ):
+            # Arrow currently lacks a function to make a date or timestamp from parts:
+            # https://github.com/apache/arrow/issues/49514.
+            # There is some possibility of it being added in the future,
+            # so we can revisit this strptime approach then.
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            float_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.float64()))
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            string_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.string()))
+
+            max_int64 = ConstantExpression(
+                int_empty_data, input_plan, np.iinfo(np.int64).max
+            )
+            min_int64 = ConstantExpression(
+                int_empty_data, input_plan, np.iinfo(np.int64).min
+            )
+
+            # If any of the inputs are floats, we will round to the nearest integer.
+            # This is what the JIT implementation seems to do, even though float input isn't explicitly allowed in Snowflake.
+            def int_part_expr(part_expr, part_expr_name):
+                ensure_type_of_expr(part_expr, part_expr_name, (int, float))
+                part_expr_dtype = get_expr_dtype(part_expr, part_expr_name)
+                if compare_types(part_expr_dtype, float):
+                    part_expr = ArrowScalarFuncExpression(
+                        float_empty_data,
+                        [part_expr],
+                        "round",
+                        (0, "half_towards_infinity"),
+                    )
+
+                    # The BodoSQL docs say we should return NULL when any input cannot be converted to int64
+                    part_too_large = ComparisonOpExpression(
+                        bool_empty_data, part_expr, max_int64, operator.gt
+                    )
+                    part_too_small = ComparisonOpExpression(
+                        bool_empty_data, part_expr, min_int64, operator.lt
+                    )
+                    part_out_of_bounds = ConjunctionOpExpression(
+                        bool_empty_data, part_too_large, part_too_small, "__or__"
+                    )
+                    part_expr = CaseExpression(
+                        float_empty_data,
+                        part_out_of_bounds,
+                        NullExpression(float_empty_data, input_plan, 0),
+                        part_expr,
+                    )
+
+                    part_expr = CastExpression(int_empty_data, part_expr)
+                return part_expr
+
+            year_expr = int_part_expr(year_expr, "year_expr")
+            month_expr = int_part_expr(month_expr, "month_expr")
+            day_expr = int_part_expr(day_expr, "day_expr")
+
+            if hour_expr:
+                hour_expr = int_part_expr(hour_expr, "hour_expr")
+            if minute_expr:
+                minute_expr = int_part_expr(minute_expr, "minute_expr")
+            if second_expr:
+                second_expr = int_part_expr(second_expr, "second_expr")
+                # Ensure seconds are int64 so the result of the later multiplication doesn't
+                # end up being int32 internally, potentially leading to overflow and the wrong answer.
+                second_expr = CastExpression(int_empty_data, second_expr)
+            if nanosecond_expr:
+                nanosecond_expr = int_part_expr(nanosecond_expr, "nanosecond_expr")
+
+            one_expr = ConstantExpression(int_empty_data, input_plan, 1)
+            zero_expr = ConstantExpression(int_empty_data, input_plan, 0)
+            twelve_expr = ConstantExpression(int_empty_data, input_plan, 12)
+
+            # Timestamp components (aside from the year) can be outside the usual ranges
+            # or even negative, so we must account for this and adjust the constructed timestamp.
+
+            # Calculate the year and month manually to ensure calendar awareness.
+
+            # Calculate month component.
+            # If (month-1) % 12 is 0 or positive, month component is (month-1) % 12 + 1.
+            # If (month-1) % 12 is negative, month component is 13 + (month-1) % 12.
+            month_minus_one = ArithOpExpression(
+                int_empty_data, month_expr, one_expr, "__sub__"
+            )
+            # We rely on bodo_mod returning a negative remainder when (month-1) is negative
+            month_remainder = ArithOpExpression(
+                int_empty_data, month_minus_one, twelve_expr, "__mod__"
+            )
+            month_remainder_negative = ComparisonOpExpression(
+                bool_empty_data, month_remainder, zero_expr, operator.lt
+            )
+            month_num_to_add = CaseExpression(
+                int_empty_data,
+                month_remainder_negative,
+                ConstantExpression(int_empty_data, input_plan, 13),
+                one_expr,
+            )
+            month_component = ArithOpExpression(
+                int_empty_data, month_remainder, month_num_to_add, "__add__"
+            )
+
+            # Calculate year component.
+            # If month is positive, year component is year + (month-1) // 12.
+            # If month is 0 or negative, year component is year + (month) // 12 - 1.
+            month_positive = ComparisonOpExpression(
+                bool_empty_data, month_expr, zero_expr, operator.gt
+            )
+            month_quotient = ArithOpExpression(
+                int_empty_data, month_expr, twelve_expr, "__floordiv__"
+            )
+            month_quotient_minus_one = ArithOpExpression(
+                int_empty_data, month_quotient, one_expr, "__sub__"
+            )
+            month_minus_one_quotient = ArithOpExpression(
+                int_empty_data, month_minus_one, twelve_expr, "__floordiv__"
+            )
+            year_offset = CaseExpression(
+                int_empty_data,
+                month_positive,
+                month_minus_one_quotient,
+                month_quotient_minus_one,
+            )
+            year_component = ArithOpExpression(
+                int_empty_data, year_expr, year_offset, "__add__"
+            )
+
+            # Concatenate date components to get a string that can be parsed by strptime
+            year_string = CastExpression(string_empty_data, year_component)
+            year_string = ArrowScalarFuncExpression(
+                string_empty_data, [year_string], "utf8_lpad", (4, "0")
+            )
+            month_string = CastExpression(string_empty_data, month_component)
+            month_string = ArrowScalarFuncExpression(
+                string_empty_data, [month_string], "utf8_lpad", (2, "0")
+            )
+            day_string = ConstantExpression(string_empty_data, input_plan, "01")
+            separator = ConstantExpression(string_empty_data, input_plan, "-")
+            date_string = ArrowScalarFuncExpression(
+                string_empty_data,
+                [year_string, month_string, day_string, separator],
+                "binary_join_element_wise",
+                (),
+            )
+
+            # Only use nanosecond precision if necessary (nanoseconds provided).
+            # This helps avoid overflow in some cases, and can allow us to represent more years.
+            use_nanosecond_precision = nanosecond_expr is not None
+            precision_str = "ns" if use_nanosecond_precision else "s"
+            timestamp_empty_data = pd.Series(
+                dtype=pd.ArrowDtype(pa.timestamp(precision_str))
+            )
+            duration_empty_data = pd.Series(
+                dtype=pd.ArrowDtype(pa.duration(precision_str))
+            )
+
+            # Pass date string to strptime to construct a timestamp from the components
+            timestamp_empty_data = pd.Series(
+                dtype=pd.ArrowDtype(pa.timestamp(precision_str))
+            )
+            timestamp_expr = ArrowScalarFuncExpression(
+                timestamp_empty_data,
+                [date_string],
+                "strptime",
+                ("%Y-%m-%d", precision_str),
+            )
+
+            # We passed 1 as the day, so now we need to add the remaining time to the timestamp.
+            # Convert days and time to nanosecond duration if needed or second duration
+
+            # Subtract one from the day since we already have a timestamp on the first day of the month
+            day_minus_one = ArithOpExpression(
+                int_empty_data, day_expr, one_expr, "__sub__"
+            )
+            day_scale_factor = ConstantExpression(
+                int_empty_data,
+                input_plan,
+                86400 * (1_000_000_000 if use_nanosecond_precision else 1),
+            )
+            day_scaled = ArithOpExpression(
+                int_empty_data, day_minus_one, day_scale_factor, "__mul__"
+            )
+
+            hour_scaled, minute_scaled, second_scaled = None, None, None
+            if hour_expr:
+                hour_scale_factor = ConstantExpression(
+                    int_empty_data,
+                    input_plan,
+                    3600 * (1_000_000_000 if use_nanosecond_precision else 1),
+                )
+                hour_scaled = ArithOpExpression(
+                    int_empty_data, hour_expr, hour_scale_factor, "__mul__"
+                )
+            if minute_expr:
+                minute_scale_factor = ConstantExpression(
+                    int_empty_data,
+                    input_plan,
+                    60 * (1_000_000_000 if use_nanosecond_precision else 1),
+                )
+                minute_scaled = ArithOpExpression(
+                    int_empty_data, minute_expr, minute_scale_factor, "__mul__"
+                )
+            if second_expr and use_nanosecond_precision:
+                second_scale_factor = ConstantExpression(
+                    int_empty_data, input_plan, 1_000_000_000
+                )
+                second_scaled = ArithOpExpression(
+                    int_empty_data, second_expr, second_scale_factor, "__mul__"
+                )
+            else:
+                second_scaled = second_expr
+
+            # Add up the nanoseconds/seconds from each day/time component
+            additional_time = day_scaled
+            for time_component_scaled in [
+                hour_scaled,
+                minute_scaled,
+                second_scaled,
+                nanosecond_expr,
+            ]:
+                if time_component_scaled:
+                    additional_time = ArithOpExpression(
+                        int_empty_data,
+                        additional_time,
+                        time_component_scaled,
+                        "__add__",
+                    )
+
+            # Convert integer time to duration so it can be added to the timestamp.
+            # CastExpressions are currently broken if the unit is not nanoseconds,
+            # so in the seconds case we workaround by multiplying by a unit duration[s].
+            if use_nanosecond_precision:
+                additional_time_duration = CastExpression(
+                    duration_empty_data, additional_time
+                )
+            else:
+                unit_duration = ConstantExpression(duration_empty_data, input_plan, 1)
+                additional_time_duration = ArithOpExpression(
+                    duration_empty_data, additional_time, unit_duration, "__mul__"
+                )
+
+            # Add remaining time to timestamp
+            timestamp_expr = ArithOpExpression(
+                timestamp_empty_data,
+                timestamp_expr,
+                additional_time_duration,
+                "__add__",
+            )
+            return timestamp_expr
+
+        if func_name == "TIMESTAMP_FROM_PARTS":
+            # Redirect to TZ-aware or TZ-naive version depending on whether a timezone is provided
+            if num_operands == 8:
+                func_name = "TIMESTAMP_TZ_FROM_PARTS"
+            elif num_operands in (2, 6, 7):
+                func_name = "TIMESTAMP_NTZ_FROM_PARTS"
+
+        if func_name == "TIMESTAMP_NTZ_FROM_PARTS" and num_operands in (2, 6, 7):
+            if num_operands in (6, 7):
+                # Parts provided individually, with or without nanoseconds
+                op_exprs = [
+                    java_expr_to_python_expr(ctx, o, input_plan)
+                    for o in java_call.getOperands()
+                ]
+                return timestamp_from_parts(*op_exprs)
+            elif num_operands == 2:
+                # Date expression and time expression provided
+                date_expr = java_expr_to_python_expr(
+                    ctx, java_call.getOperands()[0], input_plan
+                )
+                time_expr = java_expr_to_python_expr(
+                    ctx, java_call.getOperands()[1], input_plan
+                )
+
+                timestamp_empty_data = pd.Series(
+                    dtype=pd.ArrowDtype(pa.timestamp("ns"))
+                )
+                date_expr = CastExpression(timestamp_empty_data, date_expr)
+                # time_expr can be a timestamp, in which case we need to cast to time64 to extract the time part
+                time_expr = CastExpression(
+                    pd.Series(dtype=pd.ArrowDtype(pa.time64("ns"))), time_expr
+                )
+
+                # Convert time to duration so it can be added to the date
+                time_expr = CastExpression(
+                    pd.Series(dtype=pd.ArrowDtype(pa.int64())), time_expr
+                )
+                time_expr = CastExpression(
+                    pd.Series(dtype=pd.ArrowDtype(pa.duration("ns"))), time_expr
+                )
+
+                return ArithOpExpression(
+                    timestamp_empty_data, date_expr, time_expr, "__add__"
+                )
+
+        if func_name == "TIMESTAMP_TZ_FROM_PARTS" and num_operands in (6, 7, 8):
+            op_exprs = [
+                java_expr_to_python_expr(ctx, o, input_plan)
+                for o in java_call.getOperands()
+            ]
+            timestamp_expr = timestamp_from_parts(*op_exprs[:7])
+
+            if num_operands == 8:
+                timezone_expr = op_exprs[7]
+                ensure_arg_is_const_expr_of_type(timezone_expr, "timezone_expr", str)
+                timezone = timezone_expr.value
+            else:
+                timezone = ctx.default_tz if ctx.default_tz is not None else "UTC"
+
+            timestamp_empty_data = pd.Series(
+                dtype=pd.ArrowDtype(
+                    pa.timestamp("ns" if num_operands > 6 else "s", tz=timezone)
+                )
+            )
+            return ArrowScalarFuncExpression(
+                timestamp_empty_data, [timestamp_expr], "assume_timezone", (timezone,)
+            )
+
+        if func_name == "TIMESTAMP_LTZ_FROM_PARTS" and num_operands in (6, 7):
+            op_exprs = [
+                java_expr_to_python_expr(ctx, o, input_plan)
+                for o in java_call.getOperands()
+            ]
+            timestamp_expr = timestamp_from_parts(*op_exprs)
+            local_tz = ctx.default_tz if ctx.default_tz is not None else "UTC"
+            timestamp_empty_data = pd.Series(
+                dtype=pd.ArrowDtype(
+                    pa.timestamp("ns" if num_operands == 7 else "s", tz=local_tz)
+                )
+            )
+            return ArrowScalarFuncExpression(
+                timestamp_empty_data, [timestamp_expr], "assume_timezone", (local_tz,)
+            )
+
+        if func_name == "DATE_FROM_PARTS" and num_operands == 3:
+            year_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+            month_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[1], input_plan
+            )
+            day_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[2], input_plan
+            )
+
+            constructed_timestamp = timestamp_from_parts(
+                year_expr, month_expr, day_expr
+            )
+            return CastExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.date32())), constructed_timestamp
+            )
+
+        if func_name == "TIME_FROM_PARTS" and num_operands in (3, 4):
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+
+            # If any of the inputs are floats, we will round to the nearest integer.
+            # This is what the JIT implementation seems to do, even though float input isn't explicitly allowed in Snowflake.
+            def int_part_expr(op_index, part_expr_name):
+                part_expr = java_expr_to_python_expr(
+                    ctx, java_call.getOperands()[op_index], input_plan
+                )
+                ensure_type_of_expr(part_expr, part_expr_name, (int, float))
+                part_expr_dtype = get_expr_dtype(part_expr, part_expr_name)
+                if compare_types(part_expr_dtype, float):
+                    part_expr = ArrowScalarFuncExpression(
+                        pd.Series(dtype=pd.ArrowDtype(pa.float64())),
+                        [part_expr],
+                        "round",
+                        (0, "half_towards_infinity"),
+                    )
+                    part_expr = CastExpression(int_empty_data, part_expr)
+                return part_expr
+
+            hour_expr = int_part_expr(0, "hour_expr")
+            minute_expr = int_part_expr(1, "minute_expr")
+            second_expr = int_part_expr(2, "second_expr")
+            # Ensure seconds are int64 so the result of the later multiplication doesn't
+            # end up being int32 internally, leading to overflow and the wrong answer.
+            second_expr = CastExpression(int_empty_data, second_expr)
+
+            # Get the nanoseconds for each part
+            nanoseconds_per_hour = ConstantExpression(
+                int_empty_data, input_plan, 3_600_000_000_000
+            )
+            hour_nanos = ArithOpExpression(
+                int_empty_data, hour_expr, nanoseconds_per_hour, "__mul__"
+            )
+            nanoseconds_per_minute = ConstantExpression(
+                int_empty_data, input_plan, 60_000_000_000
+            )
+            minute_nanos = ArithOpExpression(
+                int_empty_data, minute_expr, nanoseconds_per_minute, "__mul__"
+            )
+            nanoseconds_per_second = ConstantExpression(
+                int_empty_data, input_plan, 1_000_000_000
+            )
+            second_nanos = ArithOpExpression(
+                int_empty_data, second_expr, nanoseconds_per_second, "__mul__"
+            )
+
+            total_nanos = ArithOpExpression(
+                int_empty_data, hour_nanos, minute_nanos, "__add__"
+            )
+            total_nanos = ArithOpExpression(
+                int_empty_data, total_nanos, second_nanos, "__add__"
+            )
+
+            if num_operands == 4:
+                nanosecond_expr = int_part_expr(3, "nanosecond_expr")
+                total_nanos = ArithOpExpression(
+                    int_empty_data, total_nanos, nanosecond_expr, "__add__"
+                )
+
+            # If the total nanoseconds are negative or exceed 24 hours in nanoseconds, casting to
+            # time64 will give us the nanoseconds modulo 24 hours, which is what we want.
+            time_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.time64("ns")))
+            return CastExpression(time_empty_data, total_nanos)
+
         if func_name == "MAKEDATE" and num_operands == 2:
             # MAKEDATE(year, dayofyear) → Jan 1 of year + (doy-1) days
             year_expr = java_expr_to_python_expr(
@@ -343,14 +766,28 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             doy_expr = java_expr_to_python_expr(
                 ctx, java_call.getOperands()[1], input_plan
             )
-            assert isinstance(year_expr, ConstantExpression) and isinstance(
-                doy_expr, ConstantExpression
-            ), "MAKEDATE requires constant integer arguments in C++ backend"
-            result_date = datetime(int(year_expr.value), 1, 1).date() + timedelta(
-                days=int(doy_expr.value) - 1
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            one_expr = ConstantExpression(int_empty_data, input_plan, 1)
+
+            # DATE_FROM_PARTS accepts negative days whereas MAKEDATE doesn't,
+            # so first check whether dayofyear is zero or negative.
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            invalid_doy = ComparisonOpExpression(
+                bool_empty_data, doy_expr, one_expr, operator.lt
             )
-            empty_data = pd.Series([result_date], dtype=pd.ArrowDtype(pa.date32()))
-            return ConstantExpression(empty_data, input_plan, result_date)
+
+            # Convert MAKEDATE(year, dayofyear) to DATE_FROM_PARTS(year, 1, dayofyear).
+            result_timestamp = timestamp_from_parts(year_expr, one_expr, doy_expr)
+
+            # If dayofyear is less than one, return NULL, else return the result date
+            date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
+            return CaseExpression(
+                date_empty_data,
+                invalid_doy,
+                NullExpression(date_empty_data, input_plan, 0),
+                result_timestamp,
+            )
 
         if func_name == "DATE_TRUNC" and num_operands == 2:
             # DATE_TRUNC(FLAG(DAY), timestamp) → floor_temporal(timestamp, unit)
@@ -849,6 +1286,138 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
             return date_diff
 
+        if func_name == "MONTHS_BETWEEN" and num_operands == 2:
+            # date_expr2 will be subtracted from date_expr1
+            date_expr1 = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+            date_expr2 = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[1], input_plan
+            )
+
+            # date_expr1 > date_expr2 is the normal case yielding a positive result.
+            # The math should still work out for date_expr1 < date_expr2 which equals -months_between(date_expr2, date_expr1).
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            float_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.float64()))
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
+
+            # Extract day parts of dates
+            date1_day = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr1], "day", ()
+            )
+            date2_day = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr2], "day", ()
+            )
+
+            # Get the month interval between the dates.
+            # This is just the number of crossed months, so it is not the correct output of MONTHS_BETWEEN.
+            # We use month_interval_between to get the integer portion.
+            # We adjust later if the day part of the later date is smaller than the day part of the earlier date.
+            month_interval = ArrowScalarFuncExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.int32())),
+                [date_expr2, date_expr1],
+                "month_interval_between",
+                (),
+            )
+            month_interval = CastExpression(float_empty_data, month_interval)
+
+            # Get the day component plus the time component of date1 and date2 in nanoseconds.
+            # We do this by subtracting the full date from the date truncated to the month.
+            date1_truncated = ArrowScalarFuncExpression(
+                date_empty_data, [date_expr1], "floor_temporal", (1, "month")
+            )
+            date2_truncated = ArrowScalarFuncExpression(
+                date_empty_data, [date_expr2], "floor_temporal", (1, "month")
+            )
+            date1_day_time = ArrowScalarFuncExpression(
+                int_empty_data, [date1_truncated, date_expr1], "nanoseconds_between", ()
+            )
+            date2_day_time = ArrowScalarFuncExpression(
+                int_empty_data, [date2_truncated, date_expr2], "nanoseconds_between", ()
+            )
+
+            # Get the nanosecond difference between the day and time components of the dates
+            day_time_diff = ArithOpExpression(
+                int_empty_data, date1_day_time, date2_day_time, "__sub__"
+            )
+            # It is okay if the difference is negative.
+            # In this case, month_interval_between would have counted a month that was not a full elapsed month between the dates.
+            # Therefore, adding a negative fraction to the integer month interval would just take away that extra whole month,
+            # which is what we want.
+
+            # Divide by 31 days to get the fraction of a month
+            # 31 days = 2_678_000_000_000_000 nanoseconds
+            month_nanos = ConstantExpression(
+                int_empty_data, input_plan, 2_678_000_000_000_000
+            )
+            month_fraction = ArithOpExpression(
+                float_empty_data, day_time_diff, month_nanos, "__truediv__"
+            )
+
+            # Add the fraction to the month interval (integer part) to get the complete result
+            months_between = ArithOpExpression(
+                float_empty_data, month_interval, month_fraction, "__add__"
+            )
+
+            # Special case: if the days are equal, the time portion is ignored and we can just return the month interval
+            day_parts_equal = ComparisonOpExpression(
+                bool_empty_data, date1_day, date2_day, operator.eq
+            )
+
+            # Special case: if both dates are on the last day of the month, we just return the integer month interval
+
+            one_month_interval = ConstantExpression(
+                date_empty_data,
+                input_plan,
+                ("MonthDayNanoInterval", 1, 0, 0),
+            )
+            one_day_interval = ConstantExpression(
+                date_empty_data,
+                input_plan,
+                ("MonthDayNanoInterval", 0, 1, 0),
+            )
+
+            def get_last_day_of_month(date_truncated):
+                next_month = ArithOpExpression(
+                    date_empty_data,
+                    date_truncated,
+                    one_month_interval,
+                    "__add__",
+                )
+                last_day_date = ArithOpExpression(
+                    date_empty_data,
+                    next_month,
+                    one_day_interval,
+                    "__sub__",
+                )
+                last_day = ArrowScalarFuncExpression(
+                    int_empty_data, [last_day_date], "day", ()
+                )
+                return last_day
+
+            date1_last_day = get_last_day_of_month(date1_truncated)
+            date2_last_day = get_last_day_of_month(date2_truncated)
+            is_date1_on_last_day = ComparisonOpExpression(
+                bool_empty_data, date1_day, date1_last_day, operator.eq
+            )
+            is_date2_on_last_day = ComparisonOpExpression(
+                bool_empty_data, date2_day, date2_last_day, operator.eq
+            )
+            both_dates_on_last_day = ConjunctionOpExpression(
+                bool_empty_data, is_date1_on_last_day, is_date2_on_last_day, "__and__"
+            )
+
+            # Is it a special case where we are supposed to use the raw month interval?
+            use_raw_month_interval = ConjunctionOpExpression(
+                bool_empty_data, day_parts_equal, both_dates_on_last_day, "__or__"
+            )
+
+            return CaseExpression(
+                float_empty_data, use_raw_month_interval, month_interval, months_between
+            )
+
         if func_name == "TIME_SLICE":
             # TIME_SLICE(date, interval) → floor_temporal(date, interval)
             date_expr = java_expr_to_python_expr(
@@ -925,6 +1494,102 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
             return week_part_appended
 
+        if func_name in ("TIMEZONE_HOUR", "TIMEZONE_MINUTE") and num_operands == 1:
+            timestamp_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+
+            # Subtract the timestamp converted to UTC from the original timestamp
+            # to get the nanoseconds between them.
+
+            utc_timestamp_empty_data = pd.Series(
+                dtype=pd.ArrowDtype(pa.timestamp("ns", tz="UTC"))
+            )
+            utc_timestamp_expr = CastExpression(
+                utc_timestamp_empty_data, timestamp_expr
+            )
+
+            timestamp_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns")))
+            local_timestamp = ArrowScalarFuncExpression(
+                timestamp_empty_data, [timestamp_expr], "local_timestamp", ()
+            )
+            local_utc_timestamp = ArrowScalarFuncExpression(
+                timestamp_empty_data, [utc_timestamp_expr], "local_timestamp", ()
+            )
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            utc_offset_nanos = ArrowScalarFuncExpression(
+                int_empty_data,
+                [local_utc_timestamp, local_timestamp],
+                "nanoseconds_between",
+                (),
+            )
+
+            float_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.float64()))
+            if func_name == "TIMEZONE_HOUR":
+                # Get the hour part of the UTC offset using floor division
+                nanoseconds_per_hour = ConstantExpression(
+                    int_empty_data, input_plan, 3_600_000_000_000
+                )
+                return ArithOpExpression(
+                    int_empty_data,
+                    utc_offset_nanos,
+                    nanoseconds_per_hour,
+                    "__floordiv__",
+                )
+            else:
+                # Get the minute part of the UTC offset using a modulo operation
+                nanoseconds_per_minute = ConstantExpression(
+                    int_empty_data, input_plan, 60_000_000_000
+                )
+                utc_offset_minutes = ArithOpExpression(
+                    float_empty_data,
+                    utc_offset_nanos,
+                    nanoseconds_per_minute,
+                    "__truediv__",
+                )
+                minutes_per_hour = ConstantExpression(int_empty_data, input_plan, 60)
+                return ArithOpExpression(
+                    float_empty_data, utc_offset_minutes, minutes_per_hour, "__mod__"
+                )
+
+        if func_name in (
+            "EPOCH_SECOND",
+            "EPOCH_MILLISECOND",
+            "EPOCH_MICROSECOND",
+            "EPOCH_NANOSECOND",
+        ):
+            timestamp_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+
+            # Handle TZ-aware timestamps by first converting to UTC
+            utc_timestamp_empty_data = pd.Series(
+                dtype=pd.ArrowDtype(pa.timestamp("ns", tz="UTC"))
+            )
+            utc_timestamp_expr = CastExpression(
+                utc_timestamp_empty_data, timestamp_expr
+            )
+
+            # Convert to int to get epoch nanoseconds, since Arrow timestamps are
+            # stored relative to the start of the UNIX epoch
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            timestamp_nanos = CastExpression(int_empty_data, utc_timestamp_expr)
+
+            if func_name != "EPOCH_NANOSECOND":
+                if func_name == "EPOCH_SECOND":
+                    divisor = 1_000_000_000
+                elif func_name == "EPOCH_MILLISECOND":
+                    divisor = 1_000_000
+                elif func_name == "EPOCH_MICROSECOND":
+                    divisor = 1_000
+                divisor_expr = ConstantExpression(int_empty_data, input_plan, divisor)
+                return ArithOpExpression(
+                    int_empty_data, timestamp_nanos, divisor_expr, "__floordiv__"
+                )
+            else:
+                return timestamp_nanos
+
     if operator_class_name in (
         "SqlMonotonicBinaryOperator",
         "SqlBinaryOperator",
@@ -975,17 +1640,124 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         if operand_type.getSqlTypeName().equals(
             SqlTypeName.VARCHAR
         ) and target_type.getSqlTypeName().equals(SqlTypeName.DATE):
+            string_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.string()))
+
+            # Replace any slashes with dashes since this is the format Arrow expects by default
+            cleaned_input = ArrowScalarFuncExpression(
+                string_empty_data, [in_expr], "replace_substring", ("/", "-")
+            )
+
+            # Add zeroes before the month and day if they are single digits
+            cleaned_input = ArrowScalarFuncExpression(
+                string_empty_data,
+                [cleaned_input],
+                "replace_substring_regex",
+                (r"-(\d)-", r"-0\1-"),
+            )
+            cleaned_input = ArrowScalarFuncExpression(
+                string_empty_data,
+                [cleaned_input],
+                "replace_substring_regex",
+                (r"-(\d)($|[ T])", r"-0\1\2"),
+            )
+
             # Cast to a timestamp first so we can parse string timestamps
             # before truncating to a date at the end.
             in_expr = CastExpression(
                 pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns"))),
+                cleaned_input,
+            )
+
+        if operand_type.getSqlTypeName().equals(
+            SqlTypeName.VARCHAR
+        ) and target_type.getSqlTypeName().equals(SqlTypeName.TIME):
+            string_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.string()))
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+
+            represents_int = ArrowScalarFuncExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.bool_())),
+                [in_expr],
+                "utf8_is_digit",
+                (),
+            )
+
+            # If the input represents simply an integer, interpret it as the number of seconds.
+            # For the strings that were times, replace them with 0 so that we don't get an error trying to cast them to integers
+            safe_int_strings = CaseExpression(
+                string_empty_data,
+                represents_int,
                 in_expr,
+                ConstantExpression(string_empty_data, input_plan, "0"),
+            )
+            seconds = CastExpression(int_empty_data, safe_int_strings)
+            nanoseconds = ArithOpExpression(
+                int_empty_data,
+                seconds,
+                ConstantExpression(int_empty_data, input_plan, 1_000_000_000),
+                "__mul__",
+            )
+            nanoseconds_time = CastExpression(empty_data, nanoseconds)
+
+            # Otherwise, we proceed with the usual parsing if the input string is formatted as a time
+
+            # Add zeroes before the hour, minute, and second if they are single digits
+            cleaned_input = ArrowScalarFuncExpression(
+                string_empty_data,
+                [in_expr],
+                "replace_substring_regex",
+                (r"^(\d):", r"0\1:"),
+            )
+            cleaned_input = ArrowScalarFuncExpression(
+                string_empty_data,
+                [cleaned_input],
+                "replace_substring_regex",
+                (r":(\d):", r":0\1:"),
+            )
+            cleaned_input = ArrowScalarFuncExpression(
+                string_empty_data,
+                [cleaned_input],
+                "replace_substring_regex",
+                (r":(\d)($|\.)", r":0\1\2"),
+            )
+
+            # For the strings that were integers, replace them with 00:00:00 so that we don't get an error trying to parse integers as times
+            safe_time_strings = CaseExpression(
+                string_empty_data,
+                represents_int,
+                ConstantExpression(string_empty_data, input_plan, "00:00:00"),
+                cleaned_input,
+            )
+
+            # Convert to a timestamp string before casting because Arrow has no way to directly parse as a time.
+            dummy_date_string = ConstantExpression(
+                string_empty_data, input_plan, "1970-01-01"
+            )
+            separator = ConstantExpression(string_empty_data, input_plan, " ")
+            timestamp_string = ArrowScalarFuncExpression(
+                string_empty_data,
+                [dummy_date_string, safe_time_strings, separator],
+                "binary_join_element_wise",
+                (),
+            )
+            # Parse as timestamp
+            timestamp_expr = CastExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns"))), timestamp_string
+            )
+            # Casting to time64 will strip off the dummy date part of the timestamp
+            timestamp_time = CastExpression(empty_data, timestamp_expr)
+
+            # Return the final time64 array, selecting the result based on whether each input was an integer string or time string
+            return CaseExpression(
+                empty_data, represents_int, nanoseconds_time, timestamp_time
             )
 
         # TO_TIMESTAMP/TO_TIMESTAMP_NTZ remove the timezone which is same as
         # local_timestamp() function of Arrow (not cast)
-        if operand_type.getSqlTypeName().equals(
-            SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+        if (
+            operand_type.getSqlTypeName().equals(
+                SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+            )
+            or operand_type.getSqlTypeName().equals(SqlTypeName.TIMESTAMP_TZ)
         ) and target_type.getSqlTypeName().equals(SqlTypeName.TIMESTAMP):
             return ArrowScalarFuncExpression(
                 empty_data,
@@ -1877,7 +2649,12 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         op_exprs = [java_expr_to_python_expr(ctx, o, input_plan) for o in operands]
         func_name = op.getName().upper()
 
-        if (
+        if func_name == "POW" and len(op_exprs) == 2:
+            left = op_exprs[0]
+            right = op_exprs[1]
+            out_empty = left.empty_data.iloc[:, 0] ** right.empty_data.iloc[:, 0]
+            return ArithOpExpression(out_empty, left, right, "__pow__")
+        elif (
             func_name in ("BITAND", "BITOR", "BITXOR", "BITSHIFTLEFT", "BITSHIFTRIGHT")
             and len(op_exprs) == 2
         ):

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -421,6 +421,91 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
             return last_day
 
+        if func_name in ("NEXT_DAY", "PREVIOUS_DAY") and num_operands == 2:
+            date_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+            dow_string_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[1], input_plan
+            )
+            ensure_type_of_expr(dow_string_expr, "dow_string_expr", str)
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+
+            # 0-6 integer matching order of Arrow's day_of_week
+            target_dow_expr = ArrowScalarFuncExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.int32())),
+                [dow_string_expr],
+                "day_of_week_num",
+                (),
+            )
+            # Returns day of week between 0 and 6
+            cur_dow_expr = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr], "day_of_week", ()
+            )
+
+            if func_name == "NEXT_DAY":
+                # ((target_dow - cur_dow - 1) + 7) % 7 + 1 to get a day offset between 1 and 7
+                diff_expr = ArithOpExpression(
+                    int_empty_data, target_dow_expr, cur_dow_expr, "__sub__"
+                )
+            else:
+                # ((cur_dow - target_dow - 1) + 7) % 7 + 1 to get a day offset between 1 and 7
+                diff_expr = ArithOpExpression(
+                    int_empty_data, cur_dow_expr, target_dow_expr, "__sub__"
+                )
+            diff_expr = ArithOpExpression(
+                int_empty_data,
+                diff_expr,
+                ConstantExpression(int_empty_data, input_plan, 6),
+                "__add__",
+            )
+            diff_mod_expr = ArithOpExpression(
+                int_empty_data,
+                diff_expr,
+                ConstantExpression(int_empty_data, input_plan, 7),
+                "__mod__",
+            )
+            days_to_offset_expr = ArithOpExpression(
+                int_empty_data,
+                diff_mod_expr,
+                ConstantExpression(int_empty_data, input_plan, 1),
+                "__add__",
+            )
+
+            # Get the number of seconds to add to or subtract from the input timestamp.
+            # Arrow's duration type is the easiest way to add/subtract time, but it only accepts seconds and smaller units.
+            seconds_in_day = ConstantExpression(int_empty_data, input_plan, 86400)
+            seconds_to_offset_expr = ArithOpExpression(
+                int_empty_data, days_to_offset_expr, seconds_in_day, "__mul__"
+            )
+            duration_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.duration("s")))
+            one_duration_expr = ConstantExpression(duration_empty_data, input_plan, 1)
+            seconds_to_offset_duration_expr = ArithOpExpression(
+                duration_empty_data,
+                seconds_to_offset_expr,
+                one_duration_expr,
+                "__mul__",
+            )
+
+            date_pa_type = date_expr.empty_data.iloc[:, 0].dtype.pyarrow_dtype
+            if pa.types.is_date(date_pa_type):
+                timestamp_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.timestamp("s")))
+            else:
+                # Otherwise, must be a timestamp
+                timestamp_empty_data = date_expr.empty_data
+
+            # Add or subtract the seconds offset to get the requested day
+            next_day_timestamp_expr = ArithOpExpression(
+                timestamp_empty_data,
+                date_expr,
+                seconds_to_offset_duration_expr,
+                "__add__" if func_name == "NEXT_DAY" else "__sub__",
+            )
+            # According to Snowflake, we should always cast result to a date
+            date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
+            return CastExpression(date_empty_data, next_day_timestamp_expr)
+
         # ADD_MONTHS(date, months) -> date + months * INTERVAL '1' MONTH
         if func_name == "ADD_MONTHS" and num_operands == 2:
             date_expr = java_expr_to_python_expr(

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1560,32 +1560,51 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 ctx, java_call.getOperands()[0], input_plan
             )
 
-            # Handle TZ-aware timestamps by first converting to UTC
-            utc_timestamp_empty_data = pd.Series(
-                dtype=pd.ArrowDtype(pa.timestamp("ns", tz="UTC"))
-            )
-            utc_timestamp_expr = CastExpression(
-                utc_timestamp_empty_data, timestamp_expr
-            )
+            # Get the scale factor from the current timestamp unit to
+            # the requested timestamp unit. This way we avoid a cast
+            # to timestamp[ns] and eliminate any chance of overflow
+            # during intermediate computation.
+            def calculate_scale_factor(current_unit, target_unit):
+                unit_scale = {"s": 1, "ms": 1_000, "us": 1_000_000, "ns": 1_000_000_000}
+                if unit_scale[target_unit] >= unit_scale[current_unit]:
+                    return "__mul__", unit_scale[target_unit] / unit_scale[current_unit]
+                else:
+                    return "__floordiv__", unit_scale[current_unit] / unit_scale[
+                        target_unit
+                    ]
 
-            # Convert to int to get epoch nanoseconds, since Arrow timestamps are
-            # stored relative to the start of the UNIX epoch
+            if func_name == "EPOCH_SECOND":
+                target_unit = "s"
+            elif func_name == "EPOCH_MILLISECOND":
+                target_unit = "ms"
+            elif func_name == "EPOCH_MICROSECOND":
+                target_unit = "us"
+            elif func_name == "EPOCH_NANOSECOND":
+                target_unit = "ns"
+
+            timestamp_pa_type = timestamp_expr.empty_data.iloc[:, 0].dtype.pyarrow_dtype
+            current_unit = timestamp_pa_type.unit
+
+            # Calculate the scale factor and direction to go from the original
+            # timestamp unit to the requested timestamp unit
+            scale_op, scale_factor = calculate_scale_factor(current_unit, target_unit)
+
+            # Convert to int to get epoch time (in the original timestamp units),
+            # since Arrow timestamps are stored relative to the start of the UNIX epoch.
+            # We don't need to cast to UTC to handle TZ-aware timestamps since
+            # the underlying timestamp integer is always in UTC.
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            timestamp_nanos = CastExpression(int_empty_data, utc_timestamp_expr)
+            epoch_time = CastExpression(int_empty_data, timestamp_expr)
 
-            if func_name != "EPOCH_NANOSECOND":
-                if func_name == "EPOCH_SECOND":
-                    divisor = 1_000_000_000
-                elif func_name == "EPOCH_MILLISECOND":
-                    divisor = 1_000_000
-                elif func_name == "EPOCH_MICROSECOND":
-                    divisor = 1_000
-                divisor_expr = ConstantExpression(int_empty_data, input_plan, divisor)
+            if scale_factor > 1:
+                scale_factor_expr = ConstantExpression(
+                    int_empty_data, input_plan, scale_factor
+                )
                 return ArithOpExpression(
-                    int_empty_data, timestamp_nanos, divisor_expr, "__floordiv__"
+                    int_empty_data, epoch_time, scale_factor_expr, scale_op
                 )
             else:
-                return timestamp_nanos
+                return epoch_time
 
     if operator_class_name in (
         "SqlMonotonicBinaryOperator",

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -61,7 +61,10 @@ _DATE_PART_ARROW_FUNCS = {
     "WEEKISO": "iso_week",
     "DAYOFYEAR": "day_of_year",
     "DAYOFWEEK": "day_of_week",
+    "DAYOFWEEKISO": "day_of_week",
     "WEEKDAY": "day_of_week",
+    "YEAROFWEEK": "iso_year",
+    "YEAROFWEEKISO": "iso_year",
     "MICROSECOND": "microsecond",
     "NANOSECOND": "nanosecond",
     "DOW": "day_of_week",
@@ -258,8 +261,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
     SqlKind = gateway.jvm.org.apache.calcite.sql.SqlKind
 
-    _DOW_NAMES = {"DAYOFWEEK", "DOW"}
-
     if operator_class_name == "SqlNullPolicyFunction":
         func_name = op.getName().upper()
         num_operands = len(java_call.getOperands())
@@ -271,14 +272,15 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
             arrow_func = _DATE_PART_ARROW_FUNCS[func_name]
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            raw_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
             if func_name in ("DAYOFWEEK", "DOW"):
-                # PyArrow default: 0=Monday, 6=Sunday.
-                # Bodo/Snowflake DAYOFWEEK: 1=Monday, 0=Sunday → (dow+1)%7
-                one = ConstantExpression(empty_data, input_plan, 1)
-                seven = ConstantExpression(empty_data, input_plan, 7)
-                raw_expr = ArithOpExpression(empty_data, raw_expr, one, "__add__")
-                raw_expr = ArithOpExpression(empty_data, raw_expr, seven, "__mod__")
+                # Default DAYOFWEEK for Bodo/Snowflake is Sunday=0, Monday=1, ..., Saturday=6.
+                raw_expr = ArrowScalarFuncExpression(
+                    empty_data, [input], arrow_func, (True, 7)
+                )
+            else:
+                raw_expr = ArrowScalarFuncExpression(
+                    empty_data, [input], arrow_func, ()
+                )
             # For WEEKDAY, PyArrow default (0=Monday..6=Sunday) exactly matches
             # Spark/Snowflake WEEKDAY, so no transformation is needed.
             return raw_expr
@@ -309,6 +311,25 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             return ArrowScalarFuncExpression(
                 empty_data, [input], "strftime", (arrow_fmt,)
             )
+
+        if func_name == "STR_TO_DATE" and num_operands == 2:
+            input = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+            mysql_fmt = str(java_call.getOperands()[1].toString())
+            if mysql_fmt.startswith("'") and mysql_fmt.endswith("'"):
+                mysql_fmt = mysql_fmt[1:-1]
+            arrow_fmt = _mysql_date_format_to_arrow_format(mysql_fmt)
+
+            timestamp_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns")))
+            timestamp_expr = ArrowScalarFuncExpression(
+                timestamp_empty_data, [input], "strptime", (arrow_fmt, "ns")
+            )
+
+            # Cast to date at the end no matter what.
+            # We need to truncate timestamps to be consistent with the JIT implementation.
+            date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
+            return CastExpression(date_empty_data, timestamp_expr)
 
         if func_name == "MAKEDATE" and num_operands == 2:
             # MAKEDATE(year, dayofyear) → Jan 1 of year + (doy-1) days
@@ -535,8 +556,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             if num_operands == 2:
                 # 2-operand form: DATEADD(date, interval) → date + interval
                 # This path handles Snowflake-style DATEADD with a date/timestamp
-                # and an interval literal. Default to DAY-based units
-                # (86_400_000_000_000 nanos per day) for the scalar fallback.
+                # and an interval literal.
                 date_expr = java_expr_to_python_expr(
                     ctx, java_call.getOperands()[0], input_plan
                 )
@@ -545,13 +565,30 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 )
                 int_empty = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
                 out_empty = pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns")))
+
+                amount_expr_dtype = get_expr_dtype(amount_expr, "DATEADD amount_expr")
+                if compare_types(amount_expr_dtype, (int, float)):
+                    # For the scalar fallback, default to DAY-based units
+                    # (86_400_000_000_000 nanos per day)
+                    nano_scale_expr = ConstantExpression(
+                        int_empty, input_plan, 86_400_000_000_000
+                    )
+                else:
+                    # Assume we have an interval type (e.g. a MonthDayNanoInterval tuple or duration type).
+                    # Get nanoseconds from interval literal by casting to int64.
+                    amount_expr = CastExpression(
+                        pd.Series(dtype=pd.ArrowDtype(pa.int64())), amount_expr
+                    )
+                    # nano_scale is 1 since we are already in units of nanoseconds
+                    nano_scale_expr = ConstantExpression(int_empty, input_plan, 1)
+
                 return ArrowScalarFuncExpression(
                     out_empty,
                     [
                         date_expr,
                         amount_expr,
                         ConstantExpression(int_empty, input_plan, 0),
-                        ConstantExpression(int_empty, input_plan, 86_400_000_000_000),
+                        nano_scale_expr,
                     ],
                     "bodo_dateadd",
                     (),
@@ -850,6 +887,31 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 "__add__",
             )
 
+        if func_name == "YEARWEEK" and num_operands == 1:
+            date_expr = java_expr_to_python_expr(
+                ctx, java_call.getOperands()[0], input_plan
+            )
+
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            year_part = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr], "iso_year", ()
+            )
+            week_part = ArrowScalarFuncExpression(
+                int_empty_data, [date_expr], "iso_week", ()
+            )
+
+            # Concatenate the year and the week parts in integer form
+            year_part_shifted = ArithOpExpression(
+                int_empty_data,
+                year_part,
+                ConstantExpression(int_empty_data, input_plan, 100),
+                "__mul__",
+            )
+            week_part_appended = ArithOpExpression(
+                int_empty_data, year_part_shifted, week_part, "__add__"
+            )
+            return week_part_appended
+
     if operator_class_name in (
         "SqlMonotonicBinaryOperator",
         "SqlBinaryOperator",
@@ -896,6 +958,16 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         empty_data = pd.Series(
             dtype=pd.ArrowDtype(sql_type_to_pa_type(ctx, target_type.getSqlTypeName()))
         )
+
+        if operand_type.getSqlTypeName().equals(
+            SqlTypeName.VARCHAR
+        ) and target_type.getSqlTypeName().equals(SqlTypeName.DATE):
+            # Cast to a timestamp first so we can parse string timestamps
+            # before truncating to a date at the end.
+            in_expr = CastExpression(
+                pd.Series(dtype=pd.ArrowDtype(pa.timestamp("ns"))),
+                in_expr,
+            )
 
         # TO_TIMESTAMP/TO_TIMESTAMP_NTZ remove the timezone which is same as
         # local_timestamp() function of Arrow (not cast)
@@ -1030,14 +1102,14 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         if arrow_func is None:
             raise NotImplementedError(f"Unsupported EXTRACT unit: {unit_str}")
         empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-        raw_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
+
         if unit_str in ("DAYOFWEEK", "DOW"):
-            # PyArrow default: 0=Monday, 6=Sunday.
-            # Bodo/Snowflake DAYOFWEEK: 1=Monday, 0=Sunday → (dow+1)%7
-            one = ConstantExpression(empty_data, input_plan, 1)
-            seven = ConstantExpression(empty_data, input_plan, 7)
-            raw_expr = ArithOpExpression(empty_data, raw_expr, one, "__add__")
-            raw_expr = ArithOpExpression(empty_data, raw_expr, seven, "__mod__")
+            # Default DAYOFWEEK for Bodo/Snowflake is Sunday=0, Monday=1, ..., Saturday=6.
+            raw_expr = ArrowScalarFuncExpression(
+                empty_data, [input], arrow_func, (True, 7)
+            )
+        else:
+            raw_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
         # For WEEKDAY, PyArrow default (0=Monday..6=Sunday) exactly matches
         # Spark/Snowflake WEEKDAY, so no transformation is needed.
         return raw_expr
@@ -1058,9 +1130,12 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             "DAY",
             "DAYOFMONTH",
             "DAYOFYEAR",
+            "WEEKDAY",
             "WEEK",
             "WEEKOFYEAR",
-            "WEEKISOHOUR",
+            "WEEKISO",
+            "YEAROFWEEK",
+            "YEAROFWEEKISO",
             "HOUR",
             "MINUTE",
             "SECOND",
@@ -1068,28 +1143,23 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             "MICROSECOND",
             "NANOSECOND",
         ):
+            # TODO: Properly differentiate between the ISO and non-ISO versions.
+            # Currently we resort to Arrow's ISO versions for the variants aside from regular DAYOFWEEK.
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
             return ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
 
-        if func_name in ("WEEK", "WEEKOFYEAR", "WEEKISO", "DAYOFYEAR"):
+        if func_name == "DAYOFWEEKISO":
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            return ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
+            # Set count_from_zero=False and week_start=1 which corresponds to Monday.
+            # Therefore we get Monday=1, Tuesday=2, ..., Sunday=7.
+            return ArrowScalarFuncExpression(
+                empty_data, [input], arrow_func, (False, 1)
+            )
 
         if func_name in ("DAYOFWEEK", "DOW"):
             empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            dow_expr = ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
-            # PyArrow default: 0=Monday, 6=Sunday.
-            # Bodo/Snowflake DAYOFWEEK: 1=Monday, 0=Sunday → (dow+1)%7
-            one_const = ConstantExpression(empty_data, input_plan, 1)
-            seven_const = ConstantExpression(empty_data, input_plan, 7)
-            plus_one = ArithOpExpression(empty_data, dow_expr, one_const, "__add__")
-            return ArithOpExpression(empty_data, plus_one, seven_const, "__mod__")
-
-        if func_name == "WEEKDAY":
-            empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            # PyArrow default (0=Monday..6=Sunday) exactly matches
-            # Spark/Snowflake WEEKDAY, so no transformation is needed.
-            return ArrowScalarFuncExpression(empty_data, [input], arrow_func, ())
+            # Pass week_start = 7 which corresponds to Sunday, so we have Sunday=0, Monday=1, ..., Saturday=6.
+            return ArrowScalarFuncExpression(empty_data, [input], arrow_func, (True, 7))
 
     if operator_class_name == "SqlCoalesceFunction":
         operands = java_call.getOperands()

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -445,6 +445,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             # Calculate year component.
             # If month is positive, year component is year + (month-1) // 12.
             # If month is 0 or negative, year component is year + (month) // 12 - 1.
+            # Here we rely on DuckDB's integer division to truncate towards zero.
             month_positive = ComparisonOpExpression(
                 bool_empty_data, month_expr, zero_expr, operator.gt
             )
@@ -497,9 +498,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
 
             # Pass date string to strptime to construct a timestamp from the components
-            timestamp_empty_data = pd.Series(
-                dtype=pd.ArrowDtype(pa.timestamp(precision_str))
-            )
             timestamp_expr = ArrowScalarFuncExpression(
                 timestamp_empty_data,
                 [date_string],

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -265,6 +265,312 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
     SqlKind = gateway.jvm.org.apache.calcite.sql.SqlKind
 
+    def timestamp_from_parts(
+        year_expr,
+        month_expr,
+        day_expr,
+        hour_expr=None,
+        minute_expr=None,
+        second_expr=None,
+        nanosecond_expr=None,
+    ):
+        """
+        Create a timestamp expression from the provided part expressions
+        (instances of bodo.pandas.plan.Expression).
+
+        If the inputs are within the normal ranges, the timestamp is constructed
+        as expected. However, the inputs (aside from the year) can also be
+        outside of the usual ranges in which they would appear in a timestamp.
+        At a high level, the resulting timestamp from this function will simply
+        be the sum of the parts.
+
+        More precisely, if month_expr = M, we add M-1 months after January of the
+        given year. Therefore, if M = 0, we subtract a month to get December of the
+        previous year, and if M = -1, we would go back two months.
+        The same rule applies to day_expr. We add day_expr - 1 days to the 1st of
+        the given month.
+        Adding the time components hour_expr, minute_expr, second_expr, and
+        nanosecond_expr is more intuitive because they start at zero.
+
+        Specifying the hour, minute, seconds, and nanosecond are optional,
+        and will default to 0 if not provided.
+
+        Any float inputs will be rounded to integers. Float inputs that cannot
+        fit in int64 will cause a NULL timestamp to be emitted.
+
+        The result will be timestamp[s] unless nanoseconds are provided, where we
+        return timestamp[ns]. In theory we can represent more years in an int64
+        timestamp this way, although the C++ backend may need better support for
+        returning timestamps of lower than ns resolution.
+        """
+
+        """
+        Since Arrow does not have a timestamp_from_parts function,
+        here is an overview of our approach:
+
+        We have a couple options to create a timestamp. One is to
+        calculate epoch time and then cast directly from an integer
+        to a timestamp. This method seems impractical
+        because you have to be conscious about days per month, leap
+        years, etc. The other option is to use Arrow's strptime, to
+        parse a formatted string as a timestamp.
+
+        Unfortunately we can't call strptime right away, because the given
+        timestamp components could be out of range. We could manully 
+        accumulate the components one by one using mod arithmetic to
+        calculate the effective timestamp part values, but it would be
+        tedious and potentially inefficient.
+        
+        Therefore we only compute the final year and month values beforehand
+        to ensure calendar awareness. Then we use those values with the first
+        day of that month to create a timestamp type via strptime. At this point,
+        we need to add the extra days, hours, minutes, seconds, and nanoseconds
+        we have yet to account for. We convert those to a common unit (seconds
+        or nanoseconds) and cast to a duration type before adding to our
+        year-month timestamp.
+        """
+
+        # Arrow currently lacks a function to make a date or timestamp from parts:
+        # https://github.com/apache/arrow/issues/49514.
+        # There is some possibility of it being added in the future,
+        # so we can revisit this strptime approach then.
+
+        int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+        float_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.float64()))
+        bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+        string_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.string()))
+
+        max_int64 = ConstantExpression(
+            int_empty_data, input_plan, np.iinfo(np.int64).max
+        )
+        min_int64 = ConstantExpression(
+            int_empty_data, input_plan, np.iinfo(np.int64).min
+        )
+
+        # If any of the inputs are floats, we will round to the nearest integer.
+        # This is what the JIT implementation seems to do, even though float input isn't explicitly allowed in Snowflake.
+        # See `construct_timestamp` in BodoSQL/bodosql/kernels/datetime_array_kernels.py.
+        def int_part_expr(part_expr, part_expr_name):
+            ensure_type_of_expr(part_expr, part_expr_name, (int, float))
+            part_expr_dtype = get_expr_dtype(part_expr, part_expr_name)
+            if compare_types(part_expr_dtype, float):
+                part_expr = ArrowScalarFuncExpression(
+                    float_empty_data,
+                    [part_expr],
+                    "round",
+                    (0, "half_towards_infinity"),
+                )
+
+                # The BodoSQL docs say we should return NULL when any input cannot be converted to int64
+                part_too_large = ComparisonOpExpression(
+                    bool_empty_data, part_expr, max_int64, operator.gt
+                )
+                part_too_small = ComparisonOpExpression(
+                    bool_empty_data, part_expr, min_int64, operator.lt
+                )
+                part_out_of_bounds = ConjunctionOpExpression(
+                    bool_empty_data, part_too_large, part_too_small, "__or__"
+                )
+                part_expr = CaseExpression(
+                    float_empty_data,
+                    part_out_of_bounds,
+                    NullExpression(float_empty_data, input_plan, 0),
+                    part_expr,
+                )
+
+                part_expr = CastExpression(int_empty_data, part_expr)
+            return part_expr
+
+        year_expr = int_part_expr(year_expr, "year_expr")
+        month_expr = int_part_expr(month_expr, "month_expr")
+        day_expr = int_part_expr(day_expr, "day_expr")
+
+        if hour_expr:
+            hour_expr = int_part_expr(hour_expr, "hour_expr")
+        if minute_expr:
+            minute_expr = int_part_expr(minute_expr, "minute_expr")
+        if second_expr:
+            second_expr = int_part_expr(second_expr, "second_expr")
+            # Ensure seconds are int64 so the result of the later multiplication doesn't
+            # end up being int32 internally, potentially leading to overflow and the wrong answer.
+            second_expr = CastExpression(int_empty_data, second_expr)
+        if nanosecond_expr:
+            nanosecond_expr = int_part_expr(nanosecond_expr, "nanosecond_expr")
+
+        one_expr = ConstantExpression(int_empty_data, input_plan, 1)
+        zero_expr = ConstantExpression(int_empty_data, input_plan, 0)
+        twelve_expr = ConstantExpression(int_empty_data, input_plan, 12)
+
+        # Timestamp components (aside from the year) can be outside the usual ranges
+        # or even negative, so we must account for this and adjust the constructed timestamp.
+
+        # Calculate the year and month manually to ensure calendar awareness.
+
+        # Calculate month component.
+        # If (month-1) % 12 is 0 or positive, month component is (month-1) % 12 + 1.
+        # If (month-1) % 12 is negative, month component is 13 + (month-1) % 12.
+        month_minus_one = ArithOpExpression(
+            int_empty_data, month_expr, one_expr, "__sub__"
+        )
+        # We rely on bodo_mod returning a negative remainder when (month-1) is negative
+        month_remainder = ArithOpExpression(
+            int_empty_data, month_minus_one, twelve_expr, "__mod__"
+        )
+        month_remainder_negative = ComparisonOpExpression(
+            bool_empty_data, month_remainder, zero_expr, operator.lt
+        )
+        month_num_to_add = CaseExpression(
+            int_empty_data,
+            month_remainder_negative,
+            ConstantExpression(int_empty_data, input_plan, 13),
+            one_expr,
+        )
+        month_component = ArithOpExpression(
+            int_empty_data, month_remainder, month_num_to_add, "__add__"
+        )
+
+        # Calculate year component.
+        # If month is positive, year component is year + (month-1) // 12.
+        # If month is 0 or negative, year component is year + (month) // 12 - 1.
+        # Here we rely on DuckDB's integer division to truncate towards zero.
+        month_positive = ComparisonOpExpression(
+            bool_empty_data, month_expr, zero_expr, operator.gt
+        )
+        month_quotient = ArithOpExpression(
+            int_empty_data, month_expr, twelve_expr, "__floordiv__"
+        )
+        month_quotient_minus_one = ArithOpExpression(
+            int_empty_data, month_quotient, one_expr, "__sub__"
+        )
+        month_minus_one_quotient = ArithOpExpression(
+            int_empty_data, month_minus_one, twelve_expr, "__floordiv__"
+        )
+        year_offset = CaseExpression(
+            int_empty_data,
+            month_positive,
+            month_minus_one_quotient,
+            month_quotient_minus_one,
+        )
+        year_component = ArithOpExpression(
+            int_empty_data, year_expr, year_offset, "__add__"
+        )
+
+        # Concatenate date components to get a string that can be parsed by strptime
+        year_string = CastExpression(string_empty_data, year_component)
+        year_string = ArrowScalarFuncExpression(
+            string_empty_data, [year_string], "utf8_lpad", (4, "0")
+        )
+        month_string = CastExpression(string_empty_data, month_component)
+        month_string = ArrowScalarFuncExpression(
+            string_empty_data, [month_string], "utf8_lpad", (2, "0")
+        )
+        day_string = ConstantExpression(string_empty_data, input_plan, "01")
+        separator = ConstantExpression(string_empty_data, input_plan, "-")
+        date_string = ArrowScalarFuncExpression(
+            string_empty_data,
+            [year_string, month_string, day_string, separator],
+            "binary_join_element_wise",
+            (),
+        )
+
+        # Only use nanosecond precision if necessary (nanoseconds provided).
+        # This helps avoid overflow in some cases, and can allow us to represent more years.
+        use_nanosecond_precision = nanosecond_expr is not None
+        precision_str = "ns" if use_nanosecond_precision else "s"
+        timestamp_empty_data = pd.Series(
+            dtype=pd.ArrowDtype(pa.timestamp(precision_str))
+        )
+        duration_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.duration(precision_str)))
+
+        # Pass date string to strptime to construct a timestamp from the components
+        timestamp_expr = ArrowScalarFuncExpression(
+            timestamp_empty_data,
+            [date_string],
+            "strptime",
+            ("%Y-%m-%d", precision_str),
+        )
+
+        # We passed 1 as the day, so now we need to add the remaining time to the timestamp.
+        # Convert days and time to nanosecond duration if needed or second duration
+
+        # Subtract one from the day since we already have a timestamp on the first day of the month
+        day_minus_one = ArithOpExpression(int_empty_data, day_expr, one_expr, "__sub__")
+        day_scale_factor = ConstantExpression(
+            int_empty_data,
+            input_plan,
+            86400 * (1_000_000_000 if use_nanosecond_precision else 1),
+        )
+        day_scaled = ArithOpExpression(
+            int_empty_data, day_minus_one, day_scale_factor, "__mul__"
+        )
+
+        hour_scaled, minute_scaled, second_scaled = None, None, None
+        if hour_expr:
+            hour_scale_factor = ConstantExpression(
+                int_empty_data,
+                input_plan,
+                3600 * (1_000_000_000 if use_nanosecond_precision else 1),
+            )
+            hour_scaled = ArithOpExpression(
+                int_empty_data, hour_expr, hour_scale_factor, "__mul__"
+            )
+        if minute_expr:
+            minute_scale_factor = ConstantExpression(
+                int_empty_data,
+                input_plan,
+                60 * (1_000_000_000 if use_nanosecond_precision else 1),
+            )
+            minute_scaled = ArithOpExpression(
+                int_empty_data, minute_expr, minute_scale_factor, "__mul__"
+            )
+        if second_expr and use_nanosecond_precision:
+            second_scale_factor = ConstantExpression(
+                int_empty_data, input_plan, 1_000_000_000
+            )
+            second_scaled = ArithOpExpression(
+                int_empty_data, second_expr, second_scale_factor, "__mul__"
+            )
+        else:
+            second_scaled = second_expr
+
+        # Add up the nanoseconds/seconds from each day/time component
+        additional_time = day_scaled
+        for time_component_scaled in [
+            hour_scaled,
+            minute_scaled,
+            second_scaled,
+            nanosecond_expr,
+        ]:
+            if time_component_scaled:
+                additional_time = ArithOpExpression(
+                    int_empty_data,
+                    additional_time,
+                    time_component_scaled,
+                    "__add__",
+                )
+
+        # Convert integer time to duration so it can be added to the timestamp.
+        # CastExpressions are currently broken if the unit is not nanoseconds,
+        # so in the seconds case we workaround by multiplying by a unit duration[s].
+        if use_nanosecond_precision:
+            additional_time_duration = CastExpression(
+                duration_empty_data, additional_time
+            )
+        else:
+            unit_duration = ConstantExpression(duration_empty_data, input_plan, 1)
+            additional_time_duration = ArithOpExpression(
+                duration_empty_data, additional_time, unit_duration, "__mul__"
+            )
+
+        # Add remaining time to timestamp
+        timestamp_expr = ArithOpExpression(
+            timestamp_empty_data,
+            timestamp_expr,
+            additional_time_duration,
+            "__add__",
+        )
+        return timestamp_expr
+
     if operator_class_name == "SqlNullPolicyFunction":
         func_name = op.getName().upper()
         num_operands = len(java_call.getOperands())
@@ -334,259 +640,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             # We need to truncate timestamps to be consistent with the JIT implementation.
             date_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.date32()))
             return CastExpression(date_empty_data, timestamp_expr)
-
-        def timestamp_from_parts(
-            year_expr,
-            month_expr,
-            day_expr,
-            hour_expr=None,
-            minute_expr=None,
-            second_expr=None,
-            nanosecond_expr=None,
-        ):
-            # Arrow currently lacks a function to make a date or timestamp from parts:
-            # https://github.com/apache/arrow/issues/49514.
-            # There is some possibility of it being added in the future,
-            # so we can revisit this strptime approach then.
-
-            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
-            float_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.float64()))
-            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
-            string_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.string()))
-
-            max_int64 = ConstantExpression(
-                int_empty_data, input_plan, np.iinfo(np.int64).max
-            )
-            min_int64 = ConstantExpression(
-                int_empty_data, input_plan, np.iinfo(np.int64).min
-            )
-
-            # If any of the inputs are floats, we will round to the nearest integer.
-            # This is what the JIT implementation seems to do, even though float input isn't explicitly allowed in Snowflake.
-            def int_part_expr(part_expr, part_expr_name):
-                ensure_type_of_expr(part_expr, part_expr_name, (int, float))
-                part_expr_dtype = get_expr_dtype(part_expr, part_expr_name)
-                if compare_types(part_expr_dtype, float):
-                    part_expr = ArrowScalarFuncExpression(
-                        float_empty_data,
-                        [part_expr],
-                        "round",
-                        (0, "half_towards_infinity"),
-                    )
-
-                    # The BodoSQL docs say we should return NULL when any input cannot be converted to int64
-                    part_too_large = ComparisonOpExpression(
-                        bool_empty_data, part_expr, max_int64, operator.gt
-                    )
-                    part_too_small = ComparisonOpExpression(
-                        bool_empty_data, part_expr, min_int64, operator.lt
-                    )
-                    part_out_of_bounds = ConjunctionOpExpression(
-                        bool_empty_data, part_too_large, part_too_small, "__or__"
-                    )
-                    part_expr = CaseExpression(
-                        float_empty_data,
-                        part_out_of_bounds,
-                        NullExpression(float_empty_data, input_plan, 0),
-                        part_expr,
-                    )
-
-                    part_expr = CastExpression(int_empty_data, part_expr)
-                return part_expr
-
-            year_expr = int_part_expr(year_expr, "year_expr")
-            month_expr = int_part_expr(month_expr, "month_expr")
-            day_expr = int_part_expr(day_expr, "day_expr")
-
-            if hour_expr:
-                hour_expr = int_part_expr(hour_expr, "hour_expr")
-            if minute_expr:
-                minute_expr = int_part_expr(minute_expr, "minute_expr")
-            if second_expr:
-                second_expr = int_part_expr(second_expr, "second_expr")
-                # Ensure seconds are int64 so the result of the later multiplication doesn't
-                # end up being int32 internally, potentially leading to overflow and the wrong answer.
-                second_expr = CastExpression(int_empty_data, second_expr)
-            if nanosecond_expr:
-                nanosecond_expr = int_part_expr(nanosecond_expr, "nanosecond_expr")
-
-            one_expr = ConstantExpression(int_empty_data, input_plan, 1)
-            zero_expr = ConstantExpression(int_empty_data, input_plan, 0)
-            twelve_expr = ConstantExpression(int_empty_data, input_plan, 12)
-
-            # Timestamp components (aside from the year) can be outside the usual ranges
-            # or even negative, so we must account for this and adjust the constructed timestamp.
-
-            # Calculate the year and month manually to ensure calendar awareness.
-
-            # Calculate month component.
-            # If (month-1) % 12 is 0 or positive, month component is (month-1) % 12 + 1.
-            # If (month-1) % 12 is negative, month component is 13 + (month-1) % 12.
-            month_minus_one = ArithOpExpression(
-                int_empty_data, month_expr, one_expr, "__sub__"
-            )
-            # We rely on bodo_mod returning a negative remainder when (month-1) is negative
-            month_remainder = ArithOpExpression(
-                int_empty_data, month_minus_one, twelve_expr, "__mod__"
-            )
-            month_remainder_negative = ComparisonOpExpression(
-                bool_empty_data, month_remainder, zero_expr, operator.lt
-            )
-            month_num_to_add = CaseExpression(
-                int_empty_data,
-                month_remainder_negative,
-                ConstantExpression(int_empty_data, input_plan, 13),
-                one_expr,
-            )
-            month_component = ArithOpExpression(
-                int_empty_data, month_remainder, month_num_to_add, "__add__"
-            )
-
-            # Calculate year component.
-            # If month is positive, year component is year + (month-1) // 12.
-            # If month is 0 or negative, year component is year + (month) // 12 - 1.
-            # Here we rely on DuckDB's integer division to truncate towards zero.
-            month_positive = ComparisonOpExpression(
-                bool_empty_data, month_expr, zero_expr, operator.gt
-            )
-            month_quotient = ArithOpExpression(
-                int_empty_data, month_expr, twelve_expr, "__floordiv__"
-            )
-            month_quotient_minus_one = ArithOpExpression(
-                int_empty_data, month_quotient, one_expr, "__sub__"
-            )
-            month_minus_one_quotient = ArithOpExpression(
-                int_empty_data, month_minus_one, twelve_expr, "__floordiv__"
-            )
-            year_offset = CaseExpression(
-                int_empty_data,
-                month_positive,
-                month_minus_one_quotient,
-                month_quotient_minus_one,
-            )
-            year_component = ArithOpExpression(
-                int_empty_data, year_expr, year_offset, "__add__"
-            )
-
-            # Concatenate date components to get a string that can be parsed by strptime
-            year_string = CastExpression(string_empty_data, year_component)
-            year_string = ArrowScalarFuncExpression(
-                string_empty_data, [year_string], "utf8_lpad", (4, "0")
-            )
-            month_string = CastExpression(string_empty_data, month_component)
-            month_string = ArrowScalarFuncExpression(
-                string_empty_data, [month_string], "utf8_lpad", (2, "0")
-            )
-            day_string = ConstantExpression(string_empty_data, input_plan, "01")
-            separator = ConstantExpression(string_empty_data, input_plan, "-")
-            date_string = ArrowScalarFuncExpression(
-                string_empty_data,
-                [year_string, month_string, day_string, separator],
-                "binary_join_element_wise",
-                (),
-            )
-
-            # Only use nanosecond precision if necessary (nanoseconds provided).
-            # This helps avoid overflow in some cases, and can allow us to represent more years.
-            use_nanosecond_precision = nanosecond_expr is not None
-            precision_str = "ns" if use_nanosecond_precision else "s"
-            timestamp_empty_data = pd.Series(
-                dtype=pd.ArrowDtype(pa.timestamp(precision_str))
-            )
-            duration_empty_data = pd.Series(
-                dtype=pd.ArrowDtype(pa.duration(precision_str))
-            )
-
-            # Pass date string to strptime to construct a timestamp from the components
-            timestamp_expr = ArrowScalarFuncExpression(
-                timestamp_empty_data,
-                [date_string],
-                "strptime",
-                ("%Y-%m-%d", precision_str),
-            )
-
-            # We passed 1 as the day, so now we need to add the remaining time to the timestamp.
-            # Convert days and time to nanosecond duration if needed or second duration
-
-            # Subtract one from the day since we already have a timestamp on the first day of the month
-            day_minus_one = ArithOpExpression(
-                int_empty_data, day_expr, one_expr, "__sub__"
-            )
-            day_scale_factor = ConstantExpression(
-                int_empty_data,
-                input_plan,
-                86400 * (1_000_000_000 if use_nanosecond_precision else 1),
-            )
-            day_scaled = ArithOpExpression(
-                int_empty_data, day_minus_one, day_scale_factor, "__mul__"
-            )
-
-            hour_scaled, minute_scaled, second_scaled = None, None, None
-            if hour_expr:
-                hour_scale_factor = ConstantExpression(
-                    int_empty_data,
-                    input_plan,
-                    3600 * (1_000_000_000 if use_nanosecond_precision else 1),
-                )
-                hour_scaled = ArithOpExpression(
-                    int_empty_data, hour_expr, hour_scale_factor, "__mul__"
-                )
-            if minute_expr:
-                minute_scale_factor = ConstantExpression(
-                    int_empty_data,
-                    input_plan,
-                    60 * (1_000_000_000 if use_nanosecond_precision else 1),
-                )
-                minute_scaled = ArithOpExpression(
-                    int_empty_data, minute_expr, minute_scale_factor, "__mul__"
-                )
-            if second_expr and use_nanosecond_precision:
-                second_scale_factor = ConstantExpression(
-                    int_empty_data, input_plan, 1_000_000_000
-                )
-                second_scaled = ArithOpExpression(
-                    int_empty_data, second_expr, second_scale_factor, "__mul__"
-                )
-            else:
-                second_scaled = second_expr
-
-            # Add up the nanoseconds/seconds from each day/time component
-            additional_time = day_scaled
-            for time_component_scaled in [
-                hour_scaled,
-                minute_scaled,
-                second_scaled,
-                nanosecond_expr,
-            ]:
-                if time_component_scaled:
-                    additional_time = ArithOpExpression(
-                        int_empty_data,
-                        additional_time,
-                        time_component_scaled,
-                        "__add__",
-                    )
-
-            # Convert integer time to duration so it can be added to the timestamp.
-            # CastExpressions are currently broken if the unit is not nanoseconds,
-            # so in the seconds case we workaround by multiplying by a unit duration[s].
-            if use_nanosecond_precision:
-                additional_time_duration = CastExpression(
-                    duration_empty_data, additional_time
-                )
-            else:
-                unit_duration = ConstantExpression(duration_empty_data, input_plan, 1)
-                additional_time_duration = ArithOpExpression(
-                    duration_empty_data, additional_time, unit_duration, "__mul__"
-                )
-
-            # Add remaining time to timestamp
-            timestamp_expr = ArithOpExpression(
-                timestamp_empty_data,
-                timestamp_expr,
-                additional_time_duration,
-                "__add__",
-            )
-            return timestamp_expr
 
         if func_name == "TIMESTAMP_FROM_PARTS":
             # Redirect to TZ-aware or TZ-naive version depending on whether a timezone is provided
@@ -695,6 +748,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
             # If any of the inputs are floats, we will round to the nearest integer.
             # This is what the JIT implementation seems to do, even though float input isn't explicitly allowed in Snowflake.
+            # See `time_from_parts` in BodoSQL/bodosql/kernels/time_array_kernels.py.
             def int_part_expr(op_index, part_expr_name):
                 part_expr = java_expr_to_python_expr(
                     ctx, java_call.getOperands()[op_index], input_plan

--- a/BodoSQL/bodosql/tests/test_date.py
+++ b/BodoSQL/bodosql/tests/test_date.py
@@ -501,6 +501,7 @@ def test_datediff_upcasting(func, unit, answer, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "func_name",
     [
@@ -580,6 +581,7 @@ def test_min_date_group_by(date_df, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_str_to_date_literals(basic_df, memory_leak_check):
     """
     Checks that calling STR_TO_DATE on literals behaves as expected
@@ -594,6 +596,7 @@ def test_str_to_date_literals(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_str_to_date_columns(memory_leak_check):
     """
     Checks that calling STR_TO_DATE on columns behaves as expected
@@ -612,6 +615,7 @@ def test_str_to_date_columns(memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_str_to_date_columns_format(memory_leak_check):
     """
     Checks that calling STR_TO_DATE on columns behaves as expected when

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -399,6 +399,7 @@ def test_dt_fns_cols(spark_info, dt_fn_info, dt_fn_dataframe, memory_leak_check)
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_dt_fns_scalars(spark_info, dt_fn_info, dt_fn_dataframe, memory_leak_check):
     """tests that the specified string functions work on Scalars"""
     bodo_fn_name = dt_fn_info[0]
@@ -2873,6 +2874,7 @@ def test_date_add_sub_interval_with_date_input(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_subdate_cols_int_arg1(
     subdate_equiv_fns,
     dt_fn_dataframe,
@@ -2930,6 +2932,7 @@ def test_subdate_scalar_int_arg1(
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_subdate_cols_td_arg1(
     subdate_equiv_fns,
     dt_fn_dataframe,
@@ -3105,6 +3108,7 @@ def test_tz_aware_subdate(use_case, interval_amt, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_yearweek(dt_fn_dataframe, memory_leak_check):
     """Test for YEARWEEK, which returns a 6-character string
     with the date's year and week (1-53) concatenated together"""
@@ -3124,9 +3128,11 @@ def test_yearweek(dt_fn_dataframe, memory_leak_check):
         check_dtype=False,
         only_python=True,
         expected_output=expected_output,
+        use_duckdb=True,
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_yearweek(tz_aware_df, memory_leak_check):
     """Test for YEARWEEK on timezone aware data.
@@ -3134,40 +3140,26 @@ def test_tz_aware_yearweek(tz_aware_df, memory_leak_check):
     and week (1-53) concatenated together"""
 
     query = "SELECT YEARWEEK(A) AS OUTPUT from table1"
-
-    expected_output = pd.DataFrame(
-        {
-            "OUTPUT": tz_aware_df["TABLE1"]["A"].dt.year * 100
-            + tz_aware_df["TABLE1"]["A"].dt.isocalendar().week
-        }
-    )
     check_query(
         query,
         tz_aware_df,
         spark=None,
         check_dtype=False,
         only_python=True,
-        expected_output=expected_output,
+        use_duckdb=True,
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_yearweek_scalars(dt_fn_dataframe, memory_leak_check):
     query = "SELECT CASE WHEN YEARWEEK(timestamps) = 0 THEN -1 ELSE YEARWEEK(timestamps) END AS OUTPUT from table1"
-
-    expected_output = pd.DataFrame(
-        {
-            "OUTPUT": dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.year * 100
-            + dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.isocalendar().week
-        }
-    )
-
     check_query(
         query,
         dt_fn_dataframe,
         None,
         check_dtype=False,
         only_python=True,
-        expected_output=expected_output,
+        use_duckdb=True,
     )
 
 
@@ -3189,6 +3181,7 @@ def test_date_trunc_time_part(sql_func, time_df, time_part_strings, memory_leak_
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize("sql_func", ["DATE_TRUNC", "TRUNC"])
 def test_date_trunc_day_part_handling(
     sql_func, time_df, day_part_strings, memory_leak_check
@@ -3317,23 +3310,7 @@ def test_date_trunc_unquoted_timeunit(dt_fn_dataframe, memory_leak_check):
     )
 
 
-@pytest.mark.tz_aware
-def test_tz_aware_yearofweekiso(tz_aware_df, memory_leak_check):
-    """
-    Test Snowflake's yearofweekiso function on columns.
-    """
-    query = "SELECT YEAROFWEEKISO(A) as A from table1"
-    # Use expected output because this function isn't in SparkSQL
-    expected_output = pd.DataFrame({"A": tz_aware_df["TABLE1"]["A"].dt.year})
-    check_query(
-        query,
-        tz_aware_df,
-        None,
-        expected_output=expected_output,
-        check_dtype=False,
-    )
-
-
+@pytest.mark.bodosql_cpp
 def test_yearofweekiso(dt_fn_dataframe, memory_leak_check):
     """
     Test Snowflake's yearofweekiso function on columns.
@@ -3352,6 +3329,7 @@ def test_yearofweekiso(dt_fn_dataframe, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_yearofweekiso(tz_aware_df, memory_leak_check):
     """
@@ -3371,6 +3349,7 @@ def test_tz_aware_yearofweekiso(tz_aware_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_yearofweekiso_scalar(dt_fn_dataframe, memory_leak_check):
     """
     Test Snowflake's yearofweekiso function on scalars.
@@ -3393,6 +3372,7 @@ def test_yearofweekiso_scalar(dt_fn_dataframe, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_yearofweekiso_scalar(tz_aware_df, memory_leak_check):
     """
@@ -3453,6 +3433,7 @@ def test_weekiso_scalar(dt_fn_dataframe, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_weekiso(tz_aware_df, memory_leak_check):
     """simplest weekiso test on timezone aware data"""
@@ -3470,6 +3451,7 @@ def test_tz_aware_weekiso(tz_aware_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_weekiso_case(tz_aware_df, memory_leak_check):
     """weekiso test in case statement on timezone aware data"""
@@ -3491,6 +3473,7 @@ def test_tz_aware_weekiso_case(tz_aware_df, memory_leak_check):
 dm = {"mo": 0, "tu": 1, "we": 2, "th": 3, "fr": 4, "sa": 5, "su": 6}
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize("next_or_prev", ["NEXT", "PREVIOUS"])
 @pytest.mark.parametrize("dow_str", ["days_of_week", "su"])
 def test_next_previous_day_cols(
@@ -3535,6 +3518,7 @@ def test_next_previous_day_cols(
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize("next_or_prev", ["NEXT", "PREVIOUS"])
 @pytest.mark.parametrize("dow_str", ["days_of_week", "su"])
 def test_next_previous_day_scalars(
@@ -3763,6 +3747,7 @@ def test_tz_aware_week_quarter_dayname(large_tz_df, case, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 @pytest.mark.parametrize(
     "case",

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -1258,6 +1258,7 @@ def test_makedate_scalars(basic_df, dt_fn_dataframe, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [
@@ -4424,6 +4425,7 @@ def date_from_parts_data():
     return years, months, days, answer
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [
@@ -4478,6 +4480,7 @@ def date_from_parts_float_data():
     return years, months, days, answer
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [
@@ -4597,6 +4600,7 @@ def timestamp_from_parts_data(request):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "func",
     [
@@ -4676,6 +4680,7 @@ def test_timestamp_from_parts(
     check_query(query, ctx, None, expected_output=py_output, check_names=False)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "func, use_case, use_timestamp",
     [

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -3113,21 +3113,12 @@ def test_yearweek(dt_fn_dataframe, memory_leak_check):
     """Test for YEARWEEK, which returns a 6-character string
     with the date's year and week (1-53) concatenated together"""
     query = "SELECT YEARWEEK(timestamps) AS OUTPUT from table1"
-
-    expected_output = pd.DataFrame(
-        {
-            "OUTPUT": dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.year * 100
-            + dt_fn_dataframe["TABLE1"]["TIMESTAMPS"].dt.isocalendar().week
-        }
-    )
-
     check_query(
         query,
         dt_fn_dataframe,
         None,
         check_dtype=False,
         only_python=True,
-        expected_output=expected_output,
         use_duckdb=True,
     )
 

--- a/BodoSQL/bodosql/tests/test_time_constructors.py
+++ b/BodoSQL/bodosql/tests/test_time_constructors.py
@@ -190,6 +190,7 @@ def to_time_invalid_data():
     return ctx, answer
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [
@@ -200,9 +201,9 @@ def to_time_invalid_data():
 def test_to_time_valid(to_time_fn, to_time_valid_data, use_case, memory_leak_check):
     ctx, result = to_time_valid_data
     if use_case:
-        query = f"SELECT {to_time_fn}(S) as A FROM table1"
-    else:
         query = f"SELECT CASE WHEN B THEN {to_time_fn}(S) END AS A FROM table1"
+    else:
+        query = f"SELECT {to_time_fn}(S) as A FROM table1"
     expected_output = pd.DataFrame({"A": result.copy()})
     check_query(query, ctx, None, expected_output=expected_output)
 
@@ -496,6 +497,7 @@ def time_from_parts_data(request):
     return ctx, answer, args
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [

--- a/BodoSQL/bodosql/tests/test_timestamp.py
+++ b/BodoSQL/bodosql/tests/test_timestamp.py
@@ -434,6 +434,7 @@ def test_to_timestamp_ntz_utc_literal(timestamp_literal, memory_leak_check):
     check_query(query, ctx, None, expected_output=expected_output)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "table, answer",
     [
@@ -609,6 +610,7 @@ def test_date_part_epoch(table, answer, memory_leak_check):
     check_query(query, ctx, None, check_dtype=False, expected_output=answer)
 
 
+@pytest.mark.bodosql_cpp
 def test_date_part_epoch_case(memory_leak_check):
     """
     Tests date_part with an epoch unit when used in a case statement.
@@ -655,6 +657,7 @@ def test_date_part_epoch_case(memory_leak_check):
     check_query(query, ctx, None, check_dtype=False, expected_output=answer)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "table, answer",
     [
@@ -714,6 +717,7 @@ def test_date_part_timezone_unit(table, answer, memory_leak_check):
     check_query(query, ctx, None, check_dtype=False, expected_output=answer)
 
 
+@pytest.mark.bodosql_cpp
 def test_date_part_timezone_unit_case(memory_leak_check):
     """
     Tests date_part with a timezone unit when used in a case statement.

--- a/BodoSQL/bodosql/tests/test_timestamp_tz.py
+++ b/BodoSQL/bodosql/tests/test_timestamp_tz.py
@@ -969,6 +969,7 @@ def test_casting_type_to_tz(data_col, session_tz, answer, memory_leak_check):
                 bodo.types.TimestampTZ.fromLocal("2025-05-25 12:00:00", -420),
             ],
             id="no_case-no_ns-no_tz",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "CASE WHEN I <= 1 THEN NULL ELSE TIMESTAMP_TZ_FROM_PARTS(2024, 12, 31, 06, 45, 15, POW(16, I)) END",
@@ -991,6 +992,7 @@ def test_casting_type_to_tz(data_col, session_tz, answer, memory_leak_check):
                 bodo.types.TimestampTZ.fromLocal("2025-05-25 12:00:00.926", 120),
             ],
             id="no_case-with_ns-with_tz",
+            marks=pytest.mark.bodosql_cpp,
         ),
     ],
 )

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -428,6 +428,18 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
     return result;
 }
 
+// Similar to DuckDB's code:
+// https://github.com/bodo-ai/Bodo/blob/4d9d829f25e5e6d51c96ccbdb3794e99c9d349bf/bodo/pandas/vendor/duckdb/src/planner/expression/bound_cast_expression.cpp#L13
+static duckdb::BoundCastInfo BindCastFunction(
+    const duckdb::LogicalType &source, const duckdb::LogicalType &target) {
+    duckdb::shared_ptr<duckdb::ClientContext> context = get_duckdb_context();
+
+    auto &cast_functions =
+        duckdb::DBConfig::GetConfig(*context).GetCastFunctions();
+    duckdb::GetCastFunctionInput input(*context);
+    return cast_functions.GetCastFunction(source, target, input);
+}
+
 std::unique_ptr<duckdb::Expression> make_cast_expr(
     std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py) {
     // Convert std::unique_ptr to duckdb::unique_ptr.
@@ -436,8 +448,12 @@ std::unique_ptr<duckdb::Expression> make_cast_expr(
     auto field = out_schema->field(0);
     auto [_, out_type] = arrow_field_to_duckdb(field);
 
+    // NOTE: using a proper cast function here is necessary since DuckDB's
+    // expression evaluator may run it (as part of optimizer or binding other
+    // functions like arithmetic ops).
     return duckdb::make_uniq<duckdb::BoundCastExpression>(
-        std::move(source_duck), out_type, duckdb::BoundCastInfo(nullptr));
+        std::move(source_duck), out_type,
+        BindCastFunction(source_duck->return_type, out_type));
 }
 
 duckdb::unique_ptr<duckdb::Expression> make_conjunction_expr(

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1956,7 +1956,7 @@ std::pair<duckdb::string, duckdb::LogicalType> arrow_field_to_duckdb(
                     duckdb_type = duckdb::LogicalType::TIME;
                     break;
                 case arrow::TimeUnit::NANO:
-                    duckdb_type = duckdb::LogicalType::TIME;
+                    duckdb_type = duckdb::LogicalType::TIME_NS;
                     break;
                 default:
                     throw std::runtime_error("Unsupported Time64 unit");

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1476,15 +1476,52 @@ const char *get_py_single_arg_as_cstr(PyObject *args, const char *func_name) {
     return c_str;
 }
 
-int64_t get_py_round_arg(PyObject *args) {
+std::tuple<int64_t, arrow::compute::RoundMode> get_py_round_args(
+    PyObject *args) {
     int64_t digits = 0;  // default value if no argument is provided
-    if (PyTuple_Check(args) && PyTuple_Size(args) == 1) {
-        // Get the first element (borrowed reference)
-        PyObject *py_digits = PyTuple_GetItem(args, 0);
+    // half_to_even is the default round mode in Arrow; we could change it if we
+    // wanted
+    arrow::compute::RoundMode round_mode =
+        arrow::compute::RoundMode::HALF_TO_EVEN;
+    if (PyTuple_Check(args)) {
+        size_t num_args = PyTuple_Size(args);
+        if (num_args >= 1) {
+            // Get the first element (borrowed reference)
+            PyObject *py_digits = PyTuple_GetItem(args, 0);
+            digits = get_py_object_as_int64(py_digits, "round args element 0");
+        }
+        if (num_args == 2) {
+            PyObject *py_round_mode = PyTuple_GetItem(args, 1);
+            std::string round_mode_str = std::string(
+                get_py_object_as_cstr(py_round_mode, "round args element 1"));
 
-        digits = get_py_object_as_int64(py_digits, "round args element");
+            if (round_mode_str == "down") {
+                round_mode = arrow::compute::RoundMode::DOWN;
+            } else if (round_mode_str == "up") {
+                round_mode = arrow::compute::RoundMode::UP;
+            } else if (round_mode_str == "towards_zero") {
+                round_mode = arrow::compute::RoundMode::TOWARDS_ZERO;
+            } else if (round_mode_str == "towards_infinity") {
+                round_mode = arrow::compute::RoundMode::TOWARDS_INFINITY;
+            } else if (round_mode_str == "half_down") {
+                round_mode = arrow::compute::RoundMode::HALF_DOWN;
+            } else if (round_mode_str == "half_up") {
+                round_mode = arrow::compute::RoundMode::HALF_UP;
+            } else if (round_mode_str == "half_towards_zero") {
+                round_mode = arrow::compute::RoundMode::HALF_TOWARDS_ZERO;
+            } else if (round_mode_str == "half_towards_infinity") {
+                round_mode = arrow::compute::RoundMode::HALF_TOWARDS_INFINITY;
+            } else if (round_mode_str == "half_to_even") {
+                round_mode = arrow::compute::RoundMode::HALF_TO_EVEN;
+            } else if (round_mode_str == "half_to_odd") {
+                round_mode = arrow::compute::RoundMode::HALF_TO_ODD;
+            } else {
+                throw std::invalid_argument(
+                    "Unrecognized round mode provided: " + round_mode_str);
+            }
+        }
     }
-    return digits;
+    return {digits, round_mode};
 }
 
 template <typename StopMaxT>

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1479,8 +1479,9 @@ const char *get_py_single_arg_as_cstr(PyObject *args, const char *func_name) {
 std::tuple<int64_t, arrow::compute::RoundMode> get_py_round_args(
     PyObject *args) {
     int64_t digits = 0;  // default value if no argument is provided
-    // half_to_even is the default round mode in Arrow; we could change it if we
-    // wanted
+    // We set the default here to half_to_even to match Arrow.
+    // In BodoSQL, the default is half_towards_infinity, but we
+    // override the round mode argument elsewhere (for UnaryOpExpressions).
     arrow::compute::RoundMode round_mode =
         arrow::compute::RoundMode::HALF_TO_EVEN;
     if (PyTuple_Check(args)) {

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -327,6 +327,32 @@ duckdb::Value ArrowScalarToDuckDBValue(
             break;
         }
 
+        case arrow::Type::DURATION: {
+            auto dur_scalar =
+                std::static_pointer_cast<arrow::DurationScalar>(scalar);
+            auto dur_type =
+                std::static_pointer_cast<arrow::DurationType>(scalar->type);
+
+            // DuckDB INTERVAL uses microseconds. If Arrow is not micro,
+            // we must scale.
+            int64_t val = dur_scalar->value;
+            switch (dur_type->unit()) {
+                case arrow::TimeUnit::SECOND:
+                    val *= 1000000;
+                    break;
+                case arrow::TimeUnit::MILLI:
+                    val *= 1000;
+                    break;
+                case arrow::TimeUnit::MICRO:
+                    break;  // No change
+                case arrow::TimeUnit::NANO:
+                    val /= 1000;
+                    break;
+            }
+
+            return duckdb::Value::INTERVAL(duckdb::Interval::FromMicro(val));
+        }
+
         default:
             throw std::runtime_error(
                 "ArrowScalarToDuckDBValue unhandled type: " +

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -2,6 +2,7 @@
 
 #include <Python.h>
 #include <arrow/api.h>
+#include <arrow/compute/api_scalar.h>
 #include <fmt/format.h>
 #include <cstdint>
 #include <limits>
@@ -549,13 +550,16 @@ auto get_py_args_as_types(PyObject *args, const char *func_name,
 const char *get_py_single_arg_as_cstr(PyObject *args, const char *func_name);
 
 /**
- * @brief Extract the number of digits to round to from Python function call's
- * args
+ * @brief Extract the number of digits to round to and the round mode enum
+ * value from Python function call's args
  *
  * @param args Python tuple containing the function arguments
- * @return int64_t The number of digits to round to
+ * @return std::tuple<int64_t, arrow::compute::RoundMode> A tuple of the
+ * number of digits to round to followed by the round mode
+ * (default HALF_TO_EVEN).
  */
-int64_t get_py_round_arg(PyObject *args);
+std::tuple<int64_t, arrow::compute::RoundMode> get_py_round_args(
+    PyObject *args);
 
 /**
  * @brief Extract slice arguments (start, stop, step) from a Python 3-element

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -629,11 +629,45 @@ arrow::Datum do_arrow_compute_cast(arrow::Datum left_res,
 
     // No need to cast if type is already the target type
     if (left_res.type()->Equals(arrow_ret_type)) {
-        return left_res;
+        if (arrow_ret_type->id() == arrow::Type::TIMESTAMP) {
+            auto left_timestamp_type =
+                std::static_pointer_cast<arrow::TimestampType>(left_res.type());
+            auto ret_timestamp_type =
+                std::static_pointer_cast<arrow::TimestampType>(arrow_ret_type);
+            if (left_timestamp_type->unit() == ret_timestamp_type->unit()) {
+                return left_res;
+            }
+        } else if (arrow_ret_type->id() == arrow::Type::DURATION) {
+            auto left_duration_type =
+                std::static_pointer_cast<arrow::DurationType>(left_res.type());
+            auto ret_duration_type =
+                std::static_pointer_cast<arrow::DurationType>(arrow_ret_type);
+            if (left_duration_type->unit() == ret_duration_type->unit()) {
+                return left_res;
+            }
+        } else if (arrow_ret_type->id() == arrow::Type::TIME64) {
+            auto left_time64_type =
+                std::static_pointer_cast<arrow::Time64Type>(left_res.type());
+            auto ret_time64_type =
+                std::static_pointer_cast<arrow::Time64Type>(arrow_ret_type);
+            if (left_time64_type->unit() == ret_time64_type->unit()) {
+                return left_res;
+            }
+        } else if (arrow_ret_type->id() == arrow::Type::TIME32) {
+            auto left_time32_type =
+                std::static_pointer_cast<arrow::Time32Type>(left_res.type());
+            auto ret_time32_type =
+                std::static_pointer_cast<arrow::Time32Type>(arrow_ret_type);
+            if (left_time32_type->unit() == ret_time32_type->unit()) {
+                return left_res;
+            }
+        } else {
+            return left_res;
+        }
     }
 
     // Globally set the allow_int_overflow cast option to true; in the future,
-    // CaseExpressions should support these options.
+    // CastExpressions should support these options.
     arrow::compute::CastOptions cast_opts;
     cast_opts.allow_int_overflow = true;
     arrow::Result<arrow::Datum> cmp_res =

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -634,11 +634,10 @@ arrow::Datum do_arrow_compute_cast(arrow::Datum left_res,
                 std::static_pointer_cast<arrow::TimestampType>(left_res.type());
             auto ret_timestamp_type =
                 std::static_pointer_cast<arrow::TimestampType>(arrow_ret_type);
-            if (left_timestamp_type->unit() == ret_timestamp_type->unit()) {
-                if (left_timestamp_type->timezone() ==
+            if (left_timestamp_type->unit() == ret_timestamp_type->unit() &&
+                left_timestamp_type->timezone() ==
                     ret_timestamp_type->timezone()) {
-                    return left_res;
-                }
+                return left_res;
             }
         } else if (arrow_ret_type->id() == arrow::Type::DURATION) {
             auto left_duration_type =

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -635,7 +635,10 @@ arrow::Datum do_arrow_compute_cast(arrow::Datum left_res,
             auto ret_timestamp_type =
                 std::static_pointer_cast<arrow::TimestampType>(arrow_ret_type);
             if (left_timestamp_type->unit() == ret_timestamp_type->unit()) {
-                return left_res;
+                if (left_timestamp_type->timezone() ==
+                    ret_timestamp_type->timezone()) {
+                    return left_res;
+                }
             }
         } else if (arrow_ret_type->id() == arrow::Type::DURATION) {
             auto left_duration_type =

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1588,6 +1588,23 @@ class PhysicalArrowExpression : public PhysicalExpression {
             // year_month_day, which returns a struct. To match the output dtype
             // of Pandas, we Cast to Date32 instead.
             result = do_arrow_compute_cast(res, duckdb::LogicalType::DATE);
+        } else if (scalar_func_data.arrow_func_name == "day_of_week") {
+            assert_py_args_is_tuple(scalar_func_data.args,
+                                    scalar_func_data.arrow_func_name.c_str());
+            size_t num_args = PyTuple_Size(scalar_func_data.args);
+            if (num_args == 2) {
+                auto [count_from_zero, week_start] = get_py_args_as_types(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str(),
+                    get_py_object_as_bool, get_py_object_as_int64);
+
+                arrow::compute::DayOfWeekOptions opts(count_from_zero,
+                                                      week_start);
+                result = do_arrow_compute_unary(res, "day_of_week", &opts);
+            } else {
+                // Only support 0 or 2 optional parameters for now
+                result = do_arrow_compute_unary(res, "day_of_week");
+            }
         } else if (scalar_func_data.arrow_func_name == "day_of_week_num") {
             // day_of_week_num is a made up function representing the
             // number representing a day of week string.
@@ -1796,6 +1813,26 @@ class PhysicalArrowExpression : public PhysicalExpression {
                 scalar_func_data.arrow_func_name.c_str());
             arrow::compute::StrftimeOptions opts(fmt_str);
             result = do_arrow_compute_unary(res, "strftime", &opts);
+        } else if (scalar_func_data.arrow_func_name == "strptime") {
+            auto [fmt_str, unit_cstr] = get_py_args_as_types(
+                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
+                get_py_object_as_cstr, get_py_object_as_cstr);
+            std::string unit_str(unit_cstr);
+            arrow::TimeUnit::type time_unit;
+            if (unit_str == "s") {
+                time_unit = arrow::TimeUnit::SECOND;
+            } else if (unit_str == "ms") {
+                time_unit = arrow::TimeUnit::MILLI;
+            } else if (unit_str == "us") {
+                time_unit = arrow::TimeUnit::MICRO;
+            } else if (unit_str == "ns") {
+                time_unit = arrow::TimeUnit::NANO;
+            } else {
+                throw std::invalid_argument(
+                    "strptime: Invalid time unit string: " + unit_str);
+            }
+            arrow::compute::StrptimeOptions opts(fmt_str, time_unit, false);
+            result = do_arrow_compute_unary(res, "strptime", &opts);
         } else if (scalar_func_data.arrow_func_name == "floor_temporal" ||
                    scalar_func_data.arrow_func_name == "ceil_temporal" ||
                    scalar_func_data.arrow_func_name == "round_temporal") {

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1391,6 +1391,11 @@ class PhysicalArrowExpression : public PhysicalExpression {
     PhysicalArrowExpressionMetrics metrics;
 
     template <typename T>
+    using compute_return_t =
+        std::conditional_t<std::is_same_v<T, std::shared_ptr<ExprResult>>,
+                           std::shared_ptr<array_info>, T>;
+
+    template <typename T>
     arrow::Datum do_arrow_compute_regexp_substr(T res, std::string pattern_str,
                                                 std::string regex_params_str,
                                                 int64_t group_to_extract) {
@@ -1515,9 +1520,44 @@ class PhysicalArrowExpression : public PhysicalExpression {
     }
 
     template <typename T>
-    using compute_return_t =
-        std::conditional_t<std::is_same_v<T, std::shared_ptr<ExprResult>>,
-                           std::shared_ptr<array_info>, T>;
+    arrow::Datum do_arrow_compute_dow_num(T res) {
+        // We strip off the leading spaces and only look at the first two
+        // characters of the input string in accordance with Snowflake (e.g.
+        // NEXT_DAY/PREVIOUS_DAY)
+
+        // Create Arrow array containing the days of the week. The order (index)
+        // determines the result DoW number.
+        arrow::StringBuilder builder;
+        arrow::Status status =
+            builder.AppendValues({"mo", "tu", "we", "th", "fr", "sa", "su"});
+        if (!status.ok()) {
+            throw std::runtime_error(
+                "do_arrow_compute_dow_num: Failed to append values to "
+                "StringBuilder");
+        }
+        std::shared_ptr<arrow::Array> dow_array = builder.Finish().ValueOrDie();
+
+        arrow::Datum res_datum =
+            ConvertExprResultToDatum(res, "day_of_week_num input");
+
+        // Normalize string to two lowercase characters representing the day of
+        // the week
+        arrow::Datum trimmed_dow_string =
+            do_arrow_compute_unary(res_datum, "utf8_ltrim_whitespace");
+        arrow::compute::SliceOptions slice_opts(0, 2, 1);
+        arrow::Datum sliced_dow_string = do_arrow_compute_unary(
+            trimmed_dow_string, "utf8_slice_codeunits", &slice_opts);
+        arrow::Datum lowered_dow_string =
+            do_arrow_compute_unary(sliced_dow_string, "utf8_lower");
+
+        // Get index of string into DoW array, which equals the DoW number
+        arrow::compute::SetLookupOptions set_lookup_opts(dow_array);
+        arrow::Datum dow_num = do_arrow_compute_unary(
+            lowered_dow_string, "index_in", &set_lookup_opts);
+
+        return dow_num;
+    }
+
     template <typename T>
     compute_return_t<T> do_arrow_compute(T res) {
         compute_return_t<T> result;
@@ -1548,6 +1588,18 @@ class PhysicalArrowExpression : public PhysicalExpression {
             // year_month_day, which returns a struct. To match the output dtype
             // of Pandas, we Cast to Date32 instead.
             result = do_arrow_compute_cast(res, duckdb::LogicalType::DATE);
+        } else if (scalar_func_data.arrow_func_name == "day_of_week_num") {
+            // day_of_week_num is a made up function representing the
+            // number representing a day of week string.
+            // Monday = 0, ..., Sunday = 6
+            arrow::Datum dow_num_datum = do_arrow_compute_dow_num(res);
+
+            // Convert DoW number and assign to result based on input type
+            if constexpr (std::is_same_v<T, arrow::Datum>) {
+                result = dow_num_datum;
+            } else {
+                result = ConvertDatumToArrayInfo(dow_num_datum);
+            }
         } else if (scalar_func_data.arrow_func_name ==
                        "match_substring_regex" ||
                    scalar_func_data.arrow_func_name ==

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1665,9 +1665,10 @@ class PhysicalArrowExpression : public PhysicalExpression {
             arrow::compute::MatchSubstringOptions opts(pattern, ignore_case);
             result = do_arrow_compute_unary(res, func_name, &opts);
         } else if (scalar_func_data.arrow_func_name == "round") {
-            int64_t digits = get_py_round_arg(scalar_func_data.args);
+            auto [digits, round_mode] =
+                get_py_round_args(scalar_func_data.args);
 
-            arrow::compute::RoundOptions opts(digits);
+            arrow::compute::RoundOptions opts(digits, round_mode);
             result = do_arrow_compute_unary(
                 res, scalar_func_data.arrow_func_name, &opts);
         } else if (scalar_func_data.arrow_func_name == "is_null") {

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -696,6 +696,7 @@ cdef class ConstantExpression(Expression):
     """
 
     def __cinit__(self, object const_schema, object value):
+        self.out_schema = const_schema
         self.c_expression = make_const_expr(const_schema, value)
 
     def __str__(self):
@@ -743,6 +744,7 @@ cdef class PythonScalarFuncExpression(Expression):
 cdef class ArrowScalarFuncExpression(Expression):
     """Wrapper around DuckDB's BoundFunctionExpression for running Python/Arrow functions.
     """
+    cdef readonly function_name
 
     def __cinit__(self,
         object out_schema,
@@ -755,6 +757,7 @@ cdef class ArrowScalarFuncExpression(Expression):
             in_c_exprs.push_back(move((<Expression>in_expr).c_expression))
 
         self.out_schema = out_schema
+        self.function_name = function_name
         self.c_expression = make_scalar_func_expr(
             out_schema, in_c_exprs, args, False, False, function_name.encode())
 


### PR DESCRIPTION
## Changes included in this PR

More date/time functions are supported in the C++ backend, including `TIMESTAMP_FROM_PARTS` (and variations), `DATE_FROM_PARTS`, `TIME_FROM_PARTS`, `MAKEDATE` with array input, `MONTHS_BETWEEN`, `TIMEZONE_HOUR`/`TIMEZONE_MINUTE`, and `EPOCH` part functions.
This PR also improves the range of date/time strings SQL cast functions can parse.

## Testing strategy

PR CI and Nightly

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.