### PR TITLE
BSE-5484: Deterministic Groupby Combination

### DIFF
--- a/bodo/libs/streaming/_groupby.cpp
+++ b/bodo/libs/streaming/_groupby.cpp
@@ -4059,8 +4059,53 @@ bool GroupbyState::MaxPartitionExceedsThreshold(size_t num_bits,
     }
 }
 
+void GroupbyState::FinalCombinePendingRecvs() {
+    // Fold the per-source-rank pending shuffle receives into the partitions in
+    // fixed ascending rank order. By the time we get here, GetGlobalIsLast has
+    // confirmed that every rank's sends have been received (SendRecvEmpty()),
+    // so pending_recv_tables contains the complete set of partials for this
+    // rank's groups. Combining in rank order (rather than network-arrival
+    // order) makes the final running values a deterministic function of the
+    // input, which is required for floating-point reductions like SUM whose
+    // results may be joined or compared across separate aggregates. See
+    // RACE_CONDITION_INVESTIGATION.md.
+    auto& pending = this->pending_recv_tables;
+    for (size_t src = 0; src < pending.size(); src++) {
+        for (std::shared_ptr<table_info>& new_data : pending[src]) {
+            if (new_data->nrows() == 0) {
+                continue;
+            }
+            std::shared_ptr<
+                bodo::vector<std::shared_ptr<bodo::vector<uint32_t>>>>
+                dict_hashes = this->GetDictionaryHashesForKeys();
+            time_pt start_hash = start_timer();
+            std::shared_ptr<uint32_t[]> batch_hashes_groupby = hash_keys_table(
+                new_data, this->n_keys, SEED_HASH_GROUPBY_SHUFFLE,
+                this->parallel, /*global_dict_needed*/ false);
+            this->metrics.input_groupby_hashing_time += end_timer(start_hash);
+            start_hash = start_timer();
+            std::shared_ptr<uint32_t[]> batch_hashes_partition =
+                hash_keys_table(new_data, this->n_keys, SEED_HASH_PARTITION,
+                                this->parallel,
+                                /*global_dict_needed*/ false, dict_hashes);
+            this->metrics.input_part_hashing_time += end_timer(start_hash);
+            this->metrics.input_hashing_nrows += new_data->nrows();
+            this->UpdateGroupsAndCombine(new_data, batch_hashes_partition,
+                                         batch_hashes_groupby);
+        }
+    }
+    pending.clear();
+    pending.shrink_to_fit();
+}
+
 void GroupbyState::FinalizeBuild() {
     time_pt start_finalize = start_timer();
+    // Fold any pending per-source shuffle receives into the partitions in a
+    // deterministic rank order before finalizing. This must happen before
+    // shuffle_state->Finalize() frees the shuffle state, since
+    // GetDictionaryHashesForKeys() may consult the shuffle state's dict
+    // builders.
+    this->FinalCombinePendingRecvs();
     // Clear the shuffle state since it is longer required.
     this->shuffle_state->Finalize();
 
@@ -4409,28 +4454,29 @@ bool groupby_agg_build_consume_batch(GroupbyState* groupby_state,
     append_row_to_build_table.resize(0);
 
     if (groupby_state->parallel) {
-        std::optional<std::shared_ptr<table_info>> new_data_ =
-            groupby_state->shuffle_state->ShuffleIfRequired(local_is_last);
+        std::optional<std::vector<std::pair<int, std::shared_ptr<table_info>>>>
+            new_data_ =
+                groupby_state->shuffle_state->ShuffleIfRequired(local_is_last);
         if (new_data_.has_value()) {
-            std::shared_ptr<table_info> new_data = new_data_.value();
-            dict_hashes = groupby_state->GetDictionaryHashesForKeys();
-            start_hash = start_timer();
-            batch_hashes_groupby = hash_keys_table(
-                new_data, groupby_state->n_keys, SEED_HASH_GROUPBY_SHUFFLE,
-                groupby_state->parallel, /*global_dict_needed*/ false);
-            groupby_state->metrics.input_groupby_hashing_time +=
-                end_timer(start_hash);
-            start_hash = start_timer();
-            batch_hashes_partition =
-                hash_keys_table(new_data, groupby_state->n_keys,
-                                SEED_HASH_PARTITION, groupby_state->parallel,
-                                /*global_dict_needed*/ false, dict_hashes);
-            groupby_state->metrics.input_part_hashing_time +=
-                end_timer(start_hash);
-            groupby_state->metrics.input_hashing_nrows += new_data->nrows();
-
-            groupby_state->UpdateGroupsAndCombine(
-                new_data, batch_hashes_partition, batch_hashes_groupby);
+            // Stash each received batch keyed by its source rank. We do NOT
+            // fold into the partition running values here, because the
+            // network-arrival order is non-deterministic and folding in that
+            // order would make floating-point SUM results vary across runs
+            // (breaking joins on those sums). Instead, FinalizeBuild folds
+            // pending_recv_tables into the partitions in fixed rank order,
+            // giving a deterministic final result. See
+            // RACE_CONDITION_INVESTIGATION.md.
+            auto& pending = groupby_state->pending_recv_tables;
+            for (auto& [src, new_data] : new_data_.value()) {
+                if (new_data->nrows() == 0) {
+                    continue;
+                }
+                if ((size_t)src >= pending.size()) {
+                    pending.resize(src + 1);
+                }
+                pending[src].push_back(new_data);
+                groupby_state->metrics.input_hashing_nrows += new_data->nrows();
+            }
         }
     }
 
@@ -4518,27 +4564,29 @@ bool groupby_acc_build_consume_batch(GroupbyState* groupby_state,
 
     // Shuffle data of other ranks and append received data to local buffer
     if (groupby_state->parallel) {
-        std::optional<std::shared_ptr<table_info>> new_data_ =
-            groupby_state->shuffle_state->ShuffleIfRequired(local_is_last);
+        std::optional<std::vector<std::pair<int, std::shared_ptr<table_info>>>>
+            new_data_ =
+                groupby_state->shuffle_state->ShuffleIfRequired(local_is_last);
         if (new_data_.has_value()) {
-            std::shared_ptr<table_info> new_data = new_data_.value();
             // Dictionary hashes for the key columns which will be used for
             // the partitioning hashes:
             dict_hashes = groupby_state->GetDictionaryHashesForKeys();
+            for (auto& [src, new_data] : new_data_.value()) {
+                // Append input rows to local or shuffle buffer:
+                batch_hashes_partition = hash_keys_table(
+                    new_data, groupby_state->n_keys, SEED_HASH_PARTITION,
+                    groupby_state->parallel, false, dict_hashes);
 
-            // Append input rows to local or shuffle buffer:
-            batch_hashes_partition = hash_keys_table(
-                new_data, groupby_state->n_keys, SEED_HASH_PARTITION,
-                groupby_state->parallel, false, dict_hashes);
+                // XXX Technically, we don't need the partition hashes if
+                // there's just one partition and we aren't computing the
+                // histogram. We could move the hash computation
+                // inside AppendBuildBatch and only do it if there are multiple
+                // partitions.
+                groupby_state->AppendBuildBatch(new_data,
+                                                batch_hashes_partition);
 
-            // XXX Technically, we don't need the partition hashes if
-            // there's just one partition and we aren't computing the
-            // histogram. We could move the hash computation
-            // inside AppendBuildBatch and only do it if there are multiple
-            // partitions.
-            groupby_state->AppendBuildBatch(new_data, batch_hashes_partition);
-
-            batch_hashes_partition.reset();
+                batch_hashes_partition.reset();
+            }
         }
     }
 

--- a/bodo/libs/streaming/_groupby.h
+++ b/bodo/libs/streaming/_groupby.h
@@ -1134,6 +1134,21 @@ class GroupbyState {
     // updated after the last input to avoid repeating the final steps.
     bool build_input_finalized = false;
 
+    /// @brief Per-source-rank received shuffle tables accumulated during the
+    /// build phase. Rather than folding shuffled receives into partition
+    /// running values incrementally in network-arrival order (which is
+    /// non-deterministic and breaks floating-point joins on SUM results), we
+    /// stash each received batch keyed by its source rank and fold them into
+    /// the partitions in a fixed rank order at FinalizeBuild time. This gives
+    /// a hard determinism guarantee: the final running values are a fixed
+    /// function of {local partials in input order, per-source partials in
+    /// send order, fixed rank-order fold}. See RACE_CONDITION_INVESTIGATION.md
+    /// for background.
+    /// Only the agg path (groupby_agg_build_consume_batch) uses this; the acc
+    /// path (groupby_acc_build_consume_batch) appends rows rather than
+    /// combining, so it folds received tables directly as before.
+    std::vector<std::vector<std::shared_ptr<table_info>>> pending_recv_tables;
+
     /// @brief Whether we should print debug information
     /// about partitioning such as when a partition is split.
     bool debug_partitioning = false;
@@ -1380,6 +1395,17 @@ class GroupbyState {
      *
      */
     void FinalizeBuild();
+
+    /**
+     * @brief Fold the per-source-rank pending shuffle receives into the
+     * partitions in fixed rank order. Called at the start of FinalizeBuild
+     * (after GetGlobalIsLast has confirmed all sends/receives are complete) so
+     * that the final running values are a deterministic function of the input
+     * regardless of network-arrival order. This matters for non-associative
+     * floating-point reductions (e.g. SUM) whose results may be joined or
+     * compared across separate aggregates. See RACE_CONDITION_INVESTIGATION.md.
+     */
+    void FinalCombinePendingRecvs();
 
     /**
      * @brief Disable partitioning by disabling threshold

--- a/bodo/libs/streaming/_join.cpp
+++ b/bodo/libs/streaming/_join.cpp
@@ -3264,26 +3264,28 @@ bool join_build_consume_batch(HashJoinState* join_state,
     in_table.reset();
 
     if (join_state->build_parallel) {
-        std::optional<std::shared_ptr<table_info>> new_data_ =
-            join_state->build_shuffle_state.ShuffleIfRequired(local_is_last);
+        std::optional<std::vector<std::pair<int, std::shared_ptr<table_info>>>>
+            new_data_ = join_state->build_shuffle_state.ShuffleIfRequired(
+                local_is_last);
         if (new_data_.has_value()) {
-            std::shared_ptr<table_info> new_data = new_data_.value();
             // NOTE: Partition hashes need to be consistent across ranks, so
             // need to use dictionary hashes. Since we are using dictionary
             // hashes, we don't need dictionaries to be global. In fact,
             // hash_keys_table will ignore the dictionaries entirely when
             // dict_hashes are provided.
             dict_hashes = join_state->GetDictionaryHashesForKeys();
-            start_part_hash = start_timer();
-            std::shared_ptr<uint32_t[]> batch_hashes_partition =
-                hash_keys_table(new_data, join_state->n_keys,
-                                SEED_HASH_PARTITION, /*is_parallel*/ true,
-                                /*global_dict_needed*/ false, dict_hashes);
-            join_state->metrics.build_input_part_hashing_time +=
-                end_timer(start_part_hash);
-            // Add new batch of data to partitions (bulk insert)
-            join_state->AppendBuildBatch(new_data, batch_hashes_partition);
-            batch_hashes_partition.reset();
+            for (auto& [src, new_data] : new_data_.value()) {
+                start_part_hash = start_timer();
+                std::shared_ptr<uint32_t[]> batch_hashes_partition =
+                    hash_keys_table(new_data, join_state->n_keys,
+                                    SEED_HASH_PARTITION, /*is_parallel*/ true,
+                                    /*global_dict_needed*/ false, dict_hashes);
+                join_state->metrics.build_input_part_hashing_time +=
+                    end_timer(start_part_hash);
+                // Add new batch of data to partitions (bulk insert)
+                join_state->AppendBuildBatch(new_data, batch_hashes_partition);
+                batch_hashes_partition.reset();
+            }
         }
     }
 
@@ -3695,176 +3697,191 @@ bool join_probe_consume_batch(HashJoinState* join_state,
     probe_idxs.clear();
 
     if (shuffle_possible) {
-        std::optional<std::shared_ptr<table_info>> new_data_ =
-            join_state->probe_shuffle_state.ShuffleIfRequired(local_is_last);
+        std::optional<std::vector<std::pair<int, std::shared_ptr<table_info>>>>
+            new_data_ = join_state->probe_shuffle_state.ShuffleIfRequired(
+                local_is_last);
         if (new_data_.has_value()) {
-            std::shared_ptr<table_info> new_data = new_data_.value();
-            active_partition->probe_table = new_data;
             // NOTE: partition hashes need to be consistent across ranks
             // so need to use dictionary hashes
             std::shared_ptr<
                 bodo::vector<std::shared_ptr<bodo::vector<uint32_t>>>>
                 new_data_dict_hashes = join_state->GetDictionaryHashesForKeys();
-            // Fetch the raw array pointers from the arrays for passing
-            // to the non-equijoin condition
-            std::vector<array_info*> build_table_info_ptrs,
-                probe_table_info_ptrs;
-            // Vectors for data
-            std::vector<void*> build_col_ptrs, probe_col_ptrs;
-            // Vectors for null bitmaps for fast null checking from the
-            // cfunc
-            std::vector<void*> build_null_bitmaps, probe_null_bitmaps;
-            if (non_equi_condition) {
-                std::tie(build_table_info_ptrs, build_col_ptrs,
-                         build_null_bitmaps) =
-                    get_gen_cond_data_ptrs(
-                        active_partition->build_table_buffer->data_table);
-                std::tie(probe_table_info_ptrs, probe_col_ptrs,
-                         probe_null_bitmaps) =
-                    get_gen_cond_data_ptrs(active_partition->probe_table);
-            }
-
-            append_time = 0;
-            for (size_t batch_start_row = 0;
-                 batch_start_row < new_data->nrows();
-                 batch_start_row += STREAMING_BATCH_SIZE) {
-                size_t nrows = std::min<size_t>(
-                    STREAMING_BATCH_SIZE, new_data->nrows() - batch_start_row);
-                // Probe hash table with new data
-                start_join_hash = start_timer();
-                std::shared_ptr<uint32_t[]> batch_hashes_join = hash_keys_table(
-                    new_data, join_state->n_keys, SEED_HASH_JOIN,
-                    shuffle_possible, false, nullptr, batch_start_row, nrows);
-                join_state->metrics.probe_join_hashing_time +=
-                    end_timer(start_join_hash);
-                active_partition->probe_table_hashes = batch_hashes_join.get();
-                // Since we only have the hashes for this batch we need an
-                // offset to the row when indexing into the hashtable
-                active_partition->probe_table_hashes_offset = batch_start_row;
-                join_state->metrics.num_processed_probe_table_rows += nrows;
-
-                if (join_state->is_mark_join) {
-                    append_to_mark_output->clear();
-                    append_to_mark_output->resize(nrows, true);
+            for (auto& [src, new_data] : new_data_.value()) {
+                active_partition->probe_table = new_data;
+                // Fetch the raw array pointers from the arrays for passing
+                // to the non-equijoin condition
+                std::vector<array_info*> build_table_info_ptrs,
+                    probe_table_info_ptrs;
+                // Vectors for data
+                std::vector<void*> build_col_ptrs, probe_col_ptrs;
+                // Vectors for null bitmaps for fast null checking from the
+                // cfunc
+                std::vector<void*> build_null_bitmaps, probe_null_bitmaps;
+                if (non_equi_condition) {
+                    std::tie(build_table_info_ptrs, build_col_ptrs,
+                             build_null_bitmaps) =
+                        get_gen_cond_data_ptrs(
+                            active_partition->build_table_buffer->data_table);
+                    std::tie(probe_table_info_ptrs, probe_col_ptrs,
+                             probe_null_bitmaps) =
+                        get_gen_cond_data_ptrs(active_partition->probe_table);
                 }
 
-                if (join_state->partitions.size() > 1) {
-                    // NOTE: Partition hashes need to be consistent across
-                    // ranks, so need to use dictionary hashes. Since we are
-                    // using dictionary hashes, we don't need dictionaries to be
-                    // global. In fact, hash_keys_table will ignore the
-                    // dictionaries entirely when dict_hashes are provided. They
-                    // are only needed when there is more than 1 partition.
-                    start_part_hash = start_timer();
-                    std::shared_ptr<uint32_t[]> batch_hashes_partition =
+                append_time = 0;
+                for (size_t batch_start_row = 0;
+                     batch_start_row < new_data->nrows();
+                     batch_start_row += STREAMING_BATCH_SIZE) {
+                    size_t nrows =
+                        std::min<size_t>(STREAMING_BATCH_SIZE,
+                                         new_data->nrows() - batch_start_row);
+                    // Probe hash table with new data
+                    start_join_hash = start_timer();
+                    std::shared_ptr<uint32_t[]> batch_hashes_join =
                         hash_keys_table(new_data, join_state->n_keys,
-                                        SEED_HASH_PARTITION, shuffle_possible,
-                                        /*global_dict_needed*/ false,
-                                        new_data_dict_hashes, batch_start_row,
-                                        nrows);
-                    join_state->metrics.probe_part_hashing_time +=
-                        end_timer(start_part_hash);
+                                        SEED_HASH_JOIN, shuffle_possible, false,
+                                        nullptr, batch_start_row, nrows);
+                    join_state->metrics.probe_join_hashing_time +=
+                        end_timer(start_join_hash);
+                    active_partition->probe_table_hashes =
+                        batch_hashes_join.get();
+                    // Since we only have the hashes for this batch we need an
+                    // offset to the row when indexing into the hashtable
+                    active_partition->probe_table_hashes_offset =
+                        batch_start_row;
+                    join_state->metrics.num_processed_probe_table_rows += nrows;
 
-                    // Initialize bit-vector to false.
-                    append_to_probe_inactive_partition.resize(nrows, false);
-                    start_ht_probe = start_timer();
-                    group_ids.resize(nrows);
-                    for (size_t i_row = 0; i_row < nrows; i_row++) {
-                        if (active_partition->is_in_partition(
-                                batch_hashes_partition[i_row])) {
+                    if (join_state->is_mark_join) {
+                        append_to_mark_output->clear();
+                        append_to_mark_output->resize(nrows, true);
+                    }
+
+                    if (join_state->partitions.size() > 1) {
+                        // NOTE: Partition hashes need to be consistent across
+                        // ranks, so need to use dictionary hashes. Since we are
+                        // using dictionary hashes, we don't need dictionaries
+                        // to be global. In fact, hash_keys_table will ignore
+                        // the dictionaries entirely when dict_hashes are
+                        // provided. They are only needed when there is more
+                        // than 1 partition.
+                        start_part_hash = start_timer();
+                        std::shared_ptr<uint32_t[]> batch_hashes_partition =
+                            hash_keys_table(
+                                new_data, join_state->n_keys,
+                                SEED_HASH_PARTITION, shuffle_possible,
+                                /*global_dict_needed*/ false,
+                                new_data_dict_hashes, batch_start_row, nrows);
+                        join_state->metrics.probe_part_hashing_time +=
+                            end_timer(start_part_hash);
+
+                        // Initialize bit-vector to false.
+                        append_to_probe_inactive_partition.resize(nrows, false);
+                        start_ht_probe = start_timer();
+                        group_ids.resize(nrows);
+                        for (size_t i_row = 0; i_row < nrows; i_row++) {
+                            if (active_partition->is_in_partition(
+                                    batch_hashes_partition[i_row])) {
+                                group_ids[i_row] =
+                                    handle_probe_input_for_partition(
+                                        active_partition_ht,
+                                        // Add offset to get the actual row
+                                        // index in the full table:
+                                        i_row + batch_start_row);
+                            } else {
+                                append_to_probe_inactive_partition[i_row] =
+                                    true;
+                                group_ids[i_row] = -1;
+                            }
+                        }
+                        join_state->metrics.ht_probe_time +=
+                            end_timer(start_ht_probe);
+                        append_time = 0;
+                        start_produce_probe = start_timer();
+                        for (size_t i_row = 0; i_row < nrows; i_row++) {
+                            produce_probe_output<
+                                build_table_outer, probe_table_outer,
+                                non_equi_condition, is_anti_join>(
+                                join_state->cond_func, active_partition.get(),
+                                i_row + batch_start_row, batch_start_row,
+                                group_ids, build_idxs, probe_idxs,
+                                build_table_info_ptrs, probe_table_info_ptrs,
+                                build_col_ptrs, probe_col_ptrs,
+                                build_null_bitmaps, probe_null_bitmaps,
+                                join_state->output_buffer,
+                                active_partition->build_table_buffer
+                                    ->data_table,
+                                new_data, build_kept_cols, probe_kept_cols,
+                                append_time, join_state->is_mark_join);
+                        }
+                        join_state->metrics.produce_probe_out_idxs_time +=
+                            end_timer(start_produce_probe) - append_time;
+                        group_ids.clear();
+                        join_state->AppendProbeBatchToInactivePartition(
+                            new_data, batch_hashes_join, batch_hashes_partition,
+                            append_to_probe_inactive_partition,
+                            /*in_table_start_offset*/ batch_start_row,
+                            /*table_nrows*/ nrows);
+                        if (join_state->is_mark_join) {
+                            for (size_t i = 0; i < nrows; i++) {
+                                (*append_to_mark_output)[i] =
+                                    !append_to_probe_inactive_partition[i];
+                            }
+                        }
+                        // Reset the bit-vector. This is important for
+                        // correctness.
+                        append_to_probe_inactive_partition.clear();
+                    } else {
+                        // Fast path for the single partition case:
+                        start_ht_probe = start_timer();
+                        group_ids.resize(nrows);
+                        for (size_t i_row = 0; i_row < nrows; i_row++) {
                             group_ids[i_row] = handle_probe_input_for_partition(
                                 active_partition_ht,
-                                // Add offset to get the actual row index in
-                                // the full table:
+                                // Add offset to get the actual row index in the
+                                // full table:
                                 i_row + batch_start_row);
-                        } else {
-                            append_to_probe_inactive_partition[i_row] = true;
-                            group_ids[i_row] = -1;
                         }
-                    }
-                    join_state->metrics.ht_probe_time +=
-                        end_timer(start_ht_probe);
-                    append_time = 0;
-                    start_produce_probe = start_timer();
-                    for (size_t i_row = 0; i_row < nrows; i_row++) {
-                        produce_probe_output<build_table_outer,
-                                             probe_table_outer,
-                                             non_equi_condition, is_anti_join>(
-                            join_state->cond_func, active_partition.get(),
-                            i_row + batch_start_row, batch_start_row, group_ids,
-                            build_idxs, probe_idxs, build_table_info_ptrs,
-                            probe_table_info_ptrs, build_col_ptrs,
-                            probe_col_ptrs, build_null_bitmaps,
-                            probe_null_bitmaps, join_state->output_buffer,
-                            active_partition->build_table_buffer->data_table,
-                            new_data, build_kept_cols, probe_kept_cols,
-                            append_time, join_state->is_mark_join);
-                    }
-                    join_state->metrics.produce_probe_out_idxs_time +=
-                        end_timer(start_produce_probe) - append_time;
-                    group_ids.clear();
-                    join_state->AppendProbeBatchToInactivePartition(
-                        new_data, batch_hashes_join, batch_hashes_partition,
-                        append_to_probe_inactive_partition,
-                        /*in_table_start_offset*/ batch_start_row,
-                        /*table_nrows*/ nrows);
-                    if (join_state->is_mark_join) {
-                        for (size_t i = 0; i < nrows; i++) {
-                            (*append_to_mark_output)[i] =
-                                !append_to_probe_inactive_partition[i];
+                        join_state->metrics.ht_probe_time +=
+                            end_timer(start_ht_probe);
+                        append_time = 0;
+                        start_produce_probe = start_timer();
+                        for (size_t i_row = 0; i_row < nrows; i_row++) {
+                            produce_probe_output<
+                                build_table_outer, probe_table_outer,
+                                non_equi_condition, is_anti_join>(
+                                join_state->cond_func, active_partition.get(),
+                                i_row + batch_start_row, batch_start_row,
+                                group_ids, build_idxs, probe_idxs,
+                                build_table_info_ptrs, probe_table_info_ptrs,
+                                build_col_ptrs, probe_col_ptrs,
+                                build_null_bitmaps, probe_null_bitmaps,
+                                join_state->output_buffer,
+                                active_partition->build_table_buffer
+                                    ->data_table,
+                                new_data, build_kept_cols, probe_kept_cols,
+                                append_time, join_state->is_mark_join);
                         }
+                        join_state->metrics.produce_probe_out_idxs_time +=
+                            end_timer(start_produce_probe) - append_time;
+                        group_ids.clear();
                     }
-                    // Reset the bit-vector. This is important for correctness.
-                    append_to_probe_inactive_partition.clear();
-                } else {
-                    // Fast path for the single partition case:
-                    start_ht_probe = start_timer();
-                    group_ids.resize(nrows);
-                    for (size_t i_row = 0; i_row < nrows; i_row++) {
-                        group_ids[i_row] = handle_probe_input_for_partition(
-                            active_partition_ht,
-                            // Add offset to get the actual row index in the
-                            // full table:
-                            i_row + batch_start_row);
-                    }
-                    join_state->metrics.ht_probe_time +=
-                        end_timer(start_ht_probe);
-                    append_time = 0;
-                    start_produce_probe = start_timer();
-                    for (size_t i_row = 0; i_row < nrows; i_row++) {
-                        produce_probe_output<build_table_outer,
-                                             probe_table_outer,
-                                             non_equi_condition, is_anti_join>(
-                            join_state->cond_func, active_partition.get(),
-                            i_row + batch_start_row, batch_start_row, group_ids,
-                            build_idxs, probe_idxs, build_table_info_ptrs,
-                            probe_table_info_ptrs, build_col_ptrs,
-                            probe_col_ptrs, build_null_bitmaps,
-                            probe_null_bitmaps, join_state->output_buffer,
-                            active_partition->build_table_buffer->data_table,
-                            new_data, build_kept_cols, probe_kept_cols,
-                            append_time, join_state->is_mark_join);
-                    }
-                    join_state->metrics.produce_probe_out_idxs_time +=
-                        end_timer(start_produce_probe) - append_time;
-                    group_ids.clear();
+
+                    // Reset active partition state
+                    active_partition->probe_table_hashes = nullptr;
+                    active_partition->probe_table_hashes_offset = 0;
+
+                    batch_hashes_join.reset();
+                    batch_hashes_partition.reset();
+
+                    join_state->output_buffer->AppendJoinOutput(
+                        active_partition->build_table_buffer->data_table,
+                        new_data, build_idxs, probe_idxs, build_kept_cols,
+                        probe_kept_cols, join_state->is_mark_join,
+                        append_to_mark_output);
+                    build_idxs.clear();
+                    probe_idxs.clear();
                 }
-
-                // Reset active partition state
-                active_partition->probe_table_hashes = nullptr;
-                active_partition->probe_table_hashes_offset = 0;
-
-                batch_hashes_join.reset();
-                batch_hashes_partition.reset();
-
-                join_state->output_buffer->AppendJoinOutput(
-                    active_partition->build_table_buffer->data_table, new_data,
-                    build_idxs, probe_idxs, build_kept_cols, probe_kept_cols,
-                    join_state->is_mark_join, append_to_mark_output);
-                build_idxs.clear();
-                probe_idxs.clear();
+                active_partition->probe_table = nullptr;
             }
-            active_partition->probe_table = nullptr;
         }
     }
 

--- a/bodo/libs/streaming/_shuffle.cpp
+++ b/bodo/libs/streaming/_shuffle.cpp
@@ -684,7 +684,7 @@ int get_next_available_tag(std::unordered_set<int>& inflight_tags) {
     return -1;
 }
 
-std::optional<std::shared_ptr<table_info>>
+std::optional<std::vector<std::pair<int, std::shared_ptr<table_info>>>>
 IncrementalShuffleState::ShuffleIfRequired(const bool is_last) {
     // Reduce MPI call overheads by communicating only every 10 iterations
     if (!(is_last || ((this->curr_iter % 10) == 0))) {
@@ -702,23 +702,31 @@ IncrementalShuffleState::ShuffleIfRequired(const bool is_last) {
         this->metrics.shuffle_recv_time += end_timer(start);
     }
 
-    TableBuildBuffer out_builder(this->schema, this->dict_builders);
-
     time_pt start = start_timer();
-    // Check for finished recvs
-    consume_completed_recvs(this->recv_states, this->shuffle_comm,
-                            this->dict_builders, this->metrics, out_builder);
+    // Check for finished recvs. Each completed receive is tagged with its
+    // source rank so callers (e.g. the streaming groupby) can combine partial
+    // results in a deterministic rank order at finalization rather than in
+    // network-arrival order, which matters for non-associative floating-point
+    // reductions such as SUM.
+    std::vector<std::pair<int, std::shared_ptr<table_info>>> completed_recvs =
+        consume_completed_recvs(this->recv_states, this->shuffle_comm,
+                                this->dict_builders, this->metrics);
     this->metrics.shuffle_recv_finalization_time += end_timer(start);
 
-    std::optional<std::shared_ptr<table_info>> new_data =
-        out_builder.data_table->nrows() != 0
-            ? std::make_optional(out_builder.data_table)
-            : std::nullopt;
-    this->metrics.total_recv_nrows +=
-        new_data.has_value() ? new_data.value()->nrows() : 0;
-    this->metrics.total_recv_size_bytes +=
-        new_data.has_value() ? table_local_memory_size(new_data.value(), false)
-                             : 0;
+    std::optional<std::vector<std::pair<int, std::shared_ptr<table_info>>>>
+        new_data = completed_recvs.empty()
+                       ? std::nullopt
+                       : std::make_optional(std::move(completed_recvs));
+    int64_t new_data_nrows = 0;
+    int64_t new_data_size_bytes = 0;
+    if (new_data.has_value()) {
+        for (const auto& [src, table] : new_data.value()) {
+            new_data_nrows += table->nrows();
+            new_data_size_bytes += table_local_memory_size(table, false);
+        }
+    }
+    this->metrics.total_recv_nrows += new_data_nrows;
+    this->metrics.total_recv_size_bytes += new_data_size_bytes;
 
     start = start_timer();
     // Remove send state if recv done
@@ -1127,16 +1135,18 @@ void AsyncShuffleRecvState::PostMetadataRecv(MPI_Status& status,
         "AsyncShuffleRecvState::PostMetadataRecv: MPI error on MPI_Imrecv:");
 }
 
-void consume_completed_recvs(
+std::vector<std::pair<int, std::shared_ptr<table_info>>>
+consume_completed_recvs(
     std::vector<AsyncShuffleRecvState>& recv_states, MPI_Comm shuffle_comm,
     const std::vector<std::shared_ptr<DictionaryBuilder>>& dict_builders,
-    IncrementalShuffleMetrics& metrics, TableBuildBuffer& out_builder) {
+    IncrementalShuffleMetrics& metrics) {
+    std::vector<std::pair<int, std::shared_ptr<table_info>>> completed;
     std::erase_if(recv_states, [&](AsyncShuffleRecvState& s) {
         auto [done, table] = s.recvDone(dict_builders, shuffle_comm, metrics);
         if (done) {
-            out_builder.ReserveTable(table);
-            out_builder.UnsafeAppendBatch(table);
+            completed.emplace_back(s.source, table);
         }
         return done;
     });
+    return completed;
 }

--- a/bodo/libs/streaming/_shuffle.h
+++ b/bodo/libs/streaming/_shuffle.h
@@ -761,13 +761,16 @@ class AsyncShuffleRecvState {
 };
 
 /**
- * @brief If any recieve states are complete, erase them from the input and
- * append their out tables to out_builder
+ * @brief If any receive states are complete, erase them from the input and
+ * return their (source rank, table) pairs. Returned in the order the receives
+ * completed (arrival order); callers that require a deterministic combine
+ * order across ranks must sort the result by source rank before consuming it.
  */
-void consume_completed_recvs(
+std::vector<std::pair<int, std::shared_ptr<table_info>>>
+consume_completed_recvs(
     std::vector<AsyncShuffleRecvState>& recv_states, MPI_Comm shuffle_comm,
     const std::vector<std::shared_ptr<DictionaryBuilder>>& dict_builders,
-    IncrementalShuffleMetrics& metrics, TableBuildBuffer& out_builder);
+    IncrementalShuffleMetrics& metrics);
 
 /**
  * @brief Common hash-shuffle functionality for streaming operators such as
@@ -862,16 +865,19 @@ class IncrementalShuffleState {
      * This must be called in every iteration, but only if shuffle is possible
      * (i.e. data is distributed and requires shuffling). If no shuffle was
      * done, we will not return anything. If we do shuffle, we will return the
-     * output shuffle table. The DICT columns in the output will have
-     * dictionaries unified with the dict-builders. We will also reset the
+     * received tables tagged with their source rank. Callers that require a
+     * deterministic combine order across ranks must sort the returned vector
+     * by source rank before consuming it. The DICT columns in the output will
+     * have dictionaries unified with the dict-builders. We will also reset the
      * shuffle buffer after every shuffle.
      *
      * @param is_last Is the last iteration.
-     * @return std::optional<std::shared_ptr<table_info>> Output shuffle table
-     * if we did a shuffle.
+     * @return std::optional<std::vector<std::pair<int,
+     * std::shared_ptr<table_info>>>> Vector of (source rank, received table)
+     * pairs, or std::nullopt if no receives completed this iteration.
      */
-    std::optional<std::shared_ptr<table_info>> ShuffleIfRequired(
-        const bool is_last);
+    std::optional<std::vector<std::pair<int, std::shared_ptr<table_info>>>>
+    ShuffleIfRequired(const bool is_last);
 
     bool SendRecvEmpty();
 

--- a/bodo/tests/test_streaming/test_shuffle.cpp
+++ b/bodo/tests/test_streaming/test_shuffle.cpp
@@ -59,6 +59,7 @@ std::shared_ptr<table_info> test_shuffle(std::shared_ptr<table_info> table) {
         state.AppendBatch(std::move(table), append);
     }
     std::shared_ptr<table_info> shuffle_table = nullptr;
+    std::unique_ptr<TableBuildBuffer> shuffle_table_builder = nullptr;
     MPI_Request finish_req = MPI_REQUEST_NULL;
     int finish_flag = 0;
     do {
@@ -74,9 +75,24 @@ std::shared_ptr<table_info> test_shuffle(std::shared_ptr<table_info> table) {
             }
         }
         if (shuffle_result.has_value()) {
-            shuffle_table = shuffle_result.value();
+            for (auto& [src, table] : shuffle_result.value()) {
+                if (table->nrows() == 0) {
+                    continue;
+                }
+                if (shuffle_table_builder == nullptr) {
+                    std::unique_ptr<bodo::Schema> schema_ = table->schema();
+                    shuffle_table_builder = std::make_unique<TableBuildBuffer>(
+                        std::move(schema_), dict_builders);
+                }
+                shuffle_table_builder->ReserveTable(table);
+                shuffle_table_builder->UnsafeAppendBatch(table);
+            }
         }
     } while (!finish_flag || !state.SendRecvEmpty());
+    if (shuffle_table_builder != nullptr &&
+        shuffle_table_builder->data_table->nrows() != 0) {
+        shuffle_table = shuffle_table_builder->data_table;
+    }
     return shuffle_table;
 }
 
@@ -99,7 +115,9 @@ int64_t shuffle_groupby(GroupbyIncrementalShuffleState& state) {
             }
         }
         if (shuffle_result.has_value()) {
-            n_recv_rows += shuffle_result.value()->nrows();
+            for (const auto& [src, table] : shuffle_result.value()) {
+                n_recv_rows += table->nrows();
+            }
         }
     } while (!finish_flag || !state.SendRecvEmpty());
     CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, &n_recv_rows, 1, MPI_LONG_LONG_INT,
@@ -847,8 +865,12 @@ static bodo::tests::suite tests([] {
             TableBuildBuffer result_table(std::move(schema), dict_builders);
             IncrementalShuffleMetrics metrics;
             while (recv_states.size() != 0) {
-                consume_completed_recvs(recv_states, MPI_COMM_WORLD,
-                                        dict_builders, metrics, result_table);
+                auto completed = consume_completed_recvs(
+                    recv_states, MPI_COMM_WORLD, dict_builders, metrics);
+                for (auto& [src, table] : completed) {
+                    result_table.ReserveTable(table);
+                    result_table.UnsafeAppendBatch(table);
+                }
             }
 
             // check that the recv'd table looks correct


### PR DESCRIPTION
## Changes included in this PR
We saw an incorrect result caused by floats being summed in different orders across ranks so they didn't match join keys. This PR makes groupby aggregate per rank (MPI guarantees order within ranks) and then across ranks from 0 .. n at finalization.
<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->

## Testing strategy
PyDough TPCH q15 and PR CI
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.