### PR TITLE
Set Arrow type in CAST expressions to avoid type info loss

### DIFF
--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1,5 +1,6 @@
 #include "_plan.h"
 #include <arrow/python/pyarrow.h>
+#include <arrow/type.h>
 #include <fmt/format.h>
 #include <cstddef>
 #include <cstdlib>
@@ -451,9 +452,13 @@ std::unique_ptr<duckdb::Expression> make_cast_expr(
     // NOTE: using a proper cast function here is necessary since DuckDB's
     // expression evaluator may run it (as part of optimizer or binding other
     // functions like arithmetic ops).
-    return duckdb::make_uniq<duckdb::BoundCastExpression>(
+    auto res = duckdb::make_uniq<duckdb::BoundCastExpression>(
         std::move(source_duck), out_type,
         BindCastFunction(source_duck->return_type, out_type));
+    // Store the Arrow type in the cast info to have full type information (e.g.
+    // interval precision).
+    res->bound_cast.arrow_type = field->type();
+    return res;
 }
 
 duckdb::unique_ptr<duckdb::Expression> make_conjunction_expr(

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -9,8 +9,10 @@
 #include <arrow/table.h>
 #include <arrow/type_fwd.h>
 #include <arrow/util/decimal.h>
+#include <memory>
 #include "../io/arrow_compat.h"
 #include "../libs/_utils.h"
+#include "_plan.h"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -974,6 +976,27 @@ PyObject *_duckdbFilterToPyicebergFilter(
             tf->DebugToString());
     }
     return py_expr;
+}
+
+std::shared_ptr<arrow::DataType> getCastReturnType(
+    const duckdb::BoundCastExpression &bce) {
+    std::shared_ptr<arrow::DataType> arrow_type = bce.bound_cast.arrow_type;
+    std::shared_ptr<arrow::DataType> duck_arrow_type =
+        duckdbTypeToArrow(bce.return_type);
+
+    auto [_, arrow_duck_type] = arrow_field_to_duckdb(
+        std::make_shared<arrow::Field>("", duck_arrow_type));
+
+    // DuckDB generated cast nodes don't have Arrow type or DuckDB may change
+    // the type so reconcile here by prioritizing the DuckDB type. BodoSQL
+    // generated nodes have Arrow type and we run minimal DuckDB optimization so
+    // Arrow type is likely used for BodoSQL which has more complex date/time
+    // types with precision issues.
+    if (!arrow_type || !arrow_duck_type.EqualTypeInfo(bce.return_type)) {
+        arrow_type = duck_arrow_type;
+    }
+
+    return arrow_type;
 }
 
 PyObject *duckdbFilterSetToPyicebergFilter(

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -2,6 +2,7 @@
 
 #include <Python.h>
 #include <arrow/api.h>
+#include <arrow/type.h>
 #include <fmt/format.h>
 #include <cstdint>
 #include <limits>
@@ -303,6 +304,18 @@ runPythonScalarFunction(std::shared_ptr<table_info> input_batch,
  */
 std::shared_ptr<table_info> runCfuncScalarFunction(
     std::shared_ptr<table_info> input_batch, table_udf_t cfunc_ptr);
+
+/**
+ * @brief Get the return type of cast nodes. Bodo generated cast nodes
+ * save the Arrow type since DuckDB types may lose information (e.g. Interval
+ * precision). DuckDB generated types don't have Arrow type or DuckDB may change
+ * the type so this function has to reconcile.
+ *
+ * @param bce Cast node
+ * @return std::shared_ptr<arrow::DataType> return type of the cast node
+ */
+std::shared_ptr<arrow::DataType> getCastReturnType(
+    const duckdb::BoundCastExpression &bce);
 
 /**
  * @brief Convert duckdb table filters to pyiceberg expressions.

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -509,7 +509,7 @@ std::shared_ptr<array_info> do_arrow_compute_unary(
 
 std::shared_ptr<array_info> do_arrow_compute_cast(
     std::shared_ptr<ExprResult> left_res,
-    const duckdb::LogicalType& return_type) {
+    const std::shared_ptr<arrow::DataType>& return_type) {
     arrow::Datum src1 =
         ConvertExprResultToDatum(left_res, "do_arrow_compute left");
 
@@ -622,13 +622,11 @@ arrow::Datum do_arrow_compute_unary(
     return cmp_res.ValueOrDie();
 }
 
-arrow::Datum do_arrow_compute_cast(arrow::Datum left_res,
-                                   const duckdb::LogicalType& return_type) {
-    std::shared_ptr<arrow::DataType> arrow_ret_type =
-        duckdbTypeToArrow(return_type);
-
+arrow::Datum do_arrow_compute_cast(
+    arrow::Datum left_res,
+    const std::shared_ptr<arrow::DataType>& return_type) {
     // No need to cast if type is already the target type
-    if (left_res.type()->Equals(arrow_ret_type)) {
+    if (left_res.type()->Equals(return_type)) {
         return left_res;
     }
 
@@ -637,7 +635,7 @@ arrow::Datum do_arrow_compute_cast(arrow::Datum left_res,
     arrow::compute::CastOptions cast_opts;
     cast_opts.allow_int_overflow = true;
     arrow::Result<arrow::Datum> cmp_res =
-        arrow::compute::Cast(left_res, arrow_ret_type, cast_opts);
+        arrow::compute::Cast(left_res, return_type, cast_opts);
     if (!cmp_res.ok()) [[unlikely]] {
         throw std::runtime_error(
             "do_arrow_compute_cast: Error in Arrow compute: " +
@@ -960,7 +958,7 @@ std::shared_ptr<PhysicalExpression> buildPhysicalExprTree(
             return std::static_pointer_cast<PhysicalExpression>(
                 std::make_shared<PhysicalCastExpression>(
                     buildPhysicalExprTree(bce.child, col_ref_map, no_scalars),
-                    bce.return_type));
+                    bce.bound_cast.arrow_type));
         } break;  // suppress wrong fallthrough error
         case duckdb::ExpressionClass::BOUND_BETWEEN: {
             // Convert the base duckdb::Expression node to its actual derived

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -958,7 +958,7 @@ std::shared_ptr<PhysicalExpression> buildPhysicalExprTree(
             return std::static_pointer_cast<PhysicalExpression>(
                 std::make_shared<PhysicalCastExpression>(
                     buildPhysicalExprTree(bce.child, col_ref_map, no_scalars),
-                    bce.bound_cast.arrow_type));
+                    getCastReturnType(bce)));
         } break;  // suppress wrong fallthrough error
         case duckdb::ExpressionClass::BOUND_BETWEEN: {
             // Convert the base duckdb::Expression node to its actual derived

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -8,6 +8,7 @@
 #include <arrow/compute/kernel.h>
 #include <arrow/result.h>
 #include <arrow/status.h>
+#include <arrow/type_fwd.h>
 #include <arrow/type_traits.h>
 #include <future>
 #include <mutex>
@@ -244,7 +245,7 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
  */
 std::shared_ptr<array_info> do_arrow_compute_cast(
     std::shared_ptr<ExprResult> left_res,
-    const duckdb::LogicalType &return_type);
+    const std::shared_ptr<arrow::DataType> &return_type);
 
 /**
  * @brief Convert ExprResult to arrow and run case compute on them.
@@ -276,8 +277,8 @@ arrow::Datum do_arrow_compute_binary(
  * @brief Run cast on arrow Datum.
  *
  */
-arrow::Datum do_arrow_compute_cast(arrow::Datum left_res,
-                                   const duckdb::LogicalType &return_type);
+arrow::Datum do_arrow_compute_cast(
+    arrow::Datum left_res, const std::shared_ptr<arrow::DataType> &return_type);
 
 /**
  * @brief Physical expression tree node type for comparisons resulting in
@@ -817,7 +818,7 @@ class PhysicalConjunctionExpression : public PhysicalExpression {
 class PhysicalCastExpression : public PhysicalExpression {
    public:
     PhysicalCastExpression(std::shared_ptr<PhysicalExpression> left,
-                           duckdb::LogicalType _return_type)
+                           std::shared_ptr<arrow::DataType> _return_type)
         : PhysicalExpression(PhysicalExpressionType::CAST),
           return_type(_return_type) {
         children.push_back(left);
@@ -854,7 +855,7 @@ class PhysicalCastExpression : public PhysicalExpression {
     }
 
    protected:
-    duckdb::LogicalType return_type;
+    std::shared_ptr<arrow::DataType> return_type;
 };
 
 /**
@@ -1555,7 +1556,7 @@ class PhysicalArrowExpression : public PhysicalExpression {
             // The Arrow compute equivalent of Series.dt.date() is
             // year_month_day, which returns a struct. To match the output dtype
             // of Pandas, we Cast to Date32 instead.
-            result = do_arrow_compute_cast(res, duckdb::LogicalType::DATE);
+            result = do_arrow_compute_cast(res, arrow::date32());
         } else if (scalar_func_data.arrow_func_name ==
                        "match_substring_regex" ||
                    scalar_func_data.arrow_func_name ==

--- a/bodo/pandas/physical/project_utils.h
+++ b/bodo/pandas/physical/project_utils.h
@@ -155,8 +155,7 @@ inline std::shared_ptr<bodo::Schema> getProjectionOutputSchema(
             auto& bce = expr->Cast<duckdb::BoundCastExpression>();
 
             std::unique_ptr<bodo::DataType> col_type =
-                arrow_type_to_bodo_data_type(duckdbTypeToArrow(bce.return_type))
-                    ->copy();
+                arrow_type_to_bodo_data_type(bce.bound_cast.arrow_type)->copy();
             output_schema->append_column(std::move(col_type));
             if (input_schema->column_names.size() > 0) {
                 col_names.emplace_back(input_schema->column_names[0]);

--- a/bodo/pandas/physical/project_utils.h
+++ b/bodo/pandas/physical/project_utils.h
@@ -3,6 +3,7 @@
 #include <arrow/api.h>
 #include <arrow/type.h>
 #include <arrow/type_traits.h>
+#include "../_util.h"
 
 /**
  * @brief Convert an unsigned Arrow integer type to its signed counterpart.
@@ -155,7 +156,7 @@ inline std::shared_ptr<bodo::Schema> getProjectionOutputSchema(
             auto& bce = expr->Cast<duckdb::BoundCastExpression>();
 
             std::unique_ptr<bodo::DataType> col_type =
-                arrow_type_to_bodo_data_type(bce.bound_cast.arrow_type)->copy();
+                arrow_type_to_bodo_data_type(getCastReturnType(bce))->copy();
             output_schema->append_column(std::move(col_type));
             if (input_schema->column_names.size() > 0) {
                 col_names.emplace_back(input_schema->column_names[0]);

--- a/bodo/pandas/vendor/duckdb/CMakeLists.txt
+++ b/bodo/pandas/vendor/duckdb/CMakeLists.txt
@@ -31,7 +31,8 @@ set(DUCKDB_MODULE_BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
+# Bodo change: Set C++ standard to 17 since we include Arrow headers in default_casts.hpp
+set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/bodo/pandas/vendor/duckdb/src/function/cast/default_casts.cpp
+++ b/bodo/pandas/vendor/duckdb/src/function/cast/default_casts.cpp
@@ -20,12 +20,12 @@ BoundCastData::~BoundCastData() {
 }
 
 BoundCastInfo::BoundCastInfo(cast_function_t function_p, unique_ptr<BoundCastData> cast_data_p,
-                             init_cast_local_state_t init_local_state_p)
-    : function(function_p), init_local_state(init_local_state_p), cast_data(std::move(cast_data_p)) {
+                             init_cast_local_state_t init_local_state_p, std::shared_ptr<arrow::DataType> arrow_type)
+    : function(function_p), init_local_state(init_local_state_p), cast_data(std::move(cast_data_p)), arrow_type(arrow_type) {
 }
 
 BoundCastInfo BoundCastInfo::Copy() const {
-	return BoundCastInfo(function, cast_data ? cast_data->Copy() : nullptr, init_local_state);
+	return BoundCastInfo(function, cast_data ? cast_data->Copy() : nullptr, init_local_state, arrow_type);
 }
 
 bool DefaultCasts::NopCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {

--- a/bodo/pandas/vendor/duckdb/src/function/cast/default_casts.cpp
+++ b/bodo/pandas/vendor/duckdb/src/function/cast/default_casts.cpp
@@ -19,6 +19,7 @@ BindCastInfo::~BindCastInfo() {
 BoundCastData::~BoundCastData() {
 }
 
+// Bodo change: added arrow_type
 BoundCastInfo::BoundCastInfo(cast_function_t function_p, unique_ptr<BoundCastData> cast_data_p,
                              init_cast_local_state_t init_local_state_p, std::shared_ptr<arrow::DataType> arrow_type)
     : function(function_p), init_local_state(init_local_state_p), cast_data(std::move(cast_data_p)), arrow_type(arrow_type) {

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/function/cast/default_casts.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/function/cast/default_casts.hpp
@@ -111,6 +111,7 @@ struct BoundCastInfo {
 	DUCKDB_API
 	BoundCastInfo( // NOLINT: allow explicit cast from cast_function_t
 	    cast_function_t function, unique_ptr<BoundCastData> cast_data = nullptr,
+		// Bodo change: added arrow_type
 	    init_cast_local_state_t init_local_state = nullptr, std::shared_ptr<arrow::DataType> arrow_type = nullptr);
 	cast_function_t function;
 	init_cast_local_state_t init_local_state;

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/function/cast/default_casts.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/function/cast/default_casts.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include <arrow/type.h>
 
 namespace duckdb {
 
@@ -110,10 +111,13 @@ struct BoundCastInfo {
 	DUCKDB_API
 	BoundCastInfo( // NOLINT: allow explicit cast from cast_function_t
 	    cast_function_t function, unique_ptr<BoundCastData> cast_data = nullptr,
-	    init_cast_local_state_t init_local_state = nullptr);
+	    init_cast_local_state_t init_local_state = nullptr, std::shared_ptr<arrow::DataType> arrow_type = nullptr);
 	cast_function_t function;
 	init_cast_local_state_t init_local_state;
 	unique_ptr<BoundCastData> cast_data;
+
+	// Bodo change: add a pointer to the target Arrow type (DuckDB's types lose information e.g. interval precision)
+	std::shared_ptr<arrow::DataType> arrow_type = nullptr;  // Pointer to the target Arrow type (filled by Bodo)
 
 public:
 	BoundCastInfo Copy() const;


### PR DESCRIPTION
Makes sure Arrow data type is saved in CAST expressions since DuckDB data types lose information like interval precision. Follow up PRs will add tests I presume.