### PR TITLE
Fix GPU conda package runtime deps

### DIFF
--- a/buildscripts/bodo/conda-recipe/conda_build_config.yaml
+++ b/buildscripts/bodo/conda-recipe/conda_build_config.yaml
@@ -41,3 +41,6 @@ is_platform:
 
 cuda_compiler:
   - cuda-nvcc
+
+rapids_version:
+  - "26.06"

--- a/buildscripts/bodo/conda-recipe/meta.yaml
+++ b/buildscripts/bodo/conda-recipe/meta.yaml
@@ -110,8 +110,8 @@ requirements:
     - rmm ={{ rapids_version }}                   # [gpu]
     - librmm ={{ rapids_version }}                # [gpu]
 
-    # Constrain CUDA version to the same major version used in the build environment
-    - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x") }}  # [gpu]
+    # Constrain cuda-version to >= version installed by host and < next major version
+    - {{ pin_compatible("cuda-version") }}        # [gpu]
 
   # run_constrained means these packages are not required deps
   # but will restrict them if they are present in the conda env.

--- a/buildscripts/bodo/conda-recipe/meta.yaml
+++ b/buildscripts/bodo/conda-recipe/meta.yaml
@@ -111,6 +111,7 @@ requirements:
     - librmm ={{ rapids_version }}                # [gpu]
 
     # Constrain cuda-version to >= version installed by host and < next major version
+    # TODO[BSE-5508]: Enabled more minor versions
     - {{ pin_compatible("cuda-version") }}        # [gpu]
 
   # run_constrained means these packages are not required deps

--- a/buildscripts/bodo/conda-recipe/meta.yaml
+++ b/buildscripts/bodo/conda-recipe/meta.yaml
@@ -111,7 +111,7 @@ requirements:
     - librmm ={{ rapids_version }}                # [gpu]
 
     # Constrain CUDA version to the same major version used in the build environment
-    - {{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}  # [gpu]
+    - {{ pin_compatible("cuda-version", min_pin="x", max_pin="x") }}  # [gpu]
 
   # run_constrained means these packages are not required deps
   # but will restrict them if they are present in the conda env.

--- a/buildscripts/bodo/conda-recipe/meta.yaml
+++ b/buildscripts/bodo/conda-recipe/meta.yaml
@@ -82,11 +82,11 @@ requirements:
 
     # GPU dependencies
     # This pin is necessary to avoid compatibility issues
-    - cudf =26.06                  # [gpu]
-    - rmm =26.06                   # [gpu]
-    - librmm =26.06                # [gpu]
-    - cuda-version 13.*            # [gpu]
-    - cuda-nvml-dev                # [gpu]
+    - cudf ={{ rapids_version }}        # [gpu]
+    - rmm ={{ rapids_version }}         # [gpu]
+    - librmm ={{ rapids_version }}      # [gpu]
+    - cuda-version 13.*                 # [gpu]
+    - cuda-nvml-dev                     # [gpu]
 
   run:
     - python
@@ -106,12 +106,12 @@ requirements:
     - pytz
 
     # GPU dependencies
-    - cudf =26.04                  # [gpu]
-    - rmm =26.04                   # [gpu]
-    - librmm =26.04                # [gpu]
-    - cuda-version 13.*            # [gpu]
+    - cudf ={{ rapids_version }}                  # [gpu]
+    - rmm ={{ rapids_version }}                   # [gpu]
+    - librmm ={{ rapids_version }}                # [gpu]
 
-    - {{ pin_compatible("cuda-version") }}  # [gpu]
+    # Constrain CUDA version to the same major version used in the build environment
+    - {{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}  # [gpu]
 
   # run_constrained means these packages are not required deps
   # but will restrict them if they are present in the conda env.


### PR DESCRIPTION
## Changes included in this PR

Use a variable for rapids package versions set in our CBC to avoid having to update in multiple places when upgrading rapids.

Similarly, gets rid of cuda-version 13.* line, since that is already handled by pin_compatible. 
## Testing strategy

Release pipeline passed

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.