### PR TITLE
Fix UnaryOpExpression for basic math function support in C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1326,21 +1326,32 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         if func_name == "EXP" and len(op_exprs) == 1:
             inp = op_exprs[0]
             out_empty = inp.empty_data
-            out_empty = out_empty.astype("float64")
             return UnaryOpExpression(out_empty, inp, "exp")
 
-        # LN(x) or LOG(x) -> natural log
-        if func_name in ("LN", "LOG") and len(op_exprs) == 1:
+        # LN(x) -> natural log
+        # The SQL function LOG(x) is mapped to Calcite LOG(x),
+        # which in Calcite and most systems means LN(x), but Bodo
+        # defines SQL LOG(x) as LOG10(x). Should we do anything
+        # about the mismatch?
+        if func_name == "LN" and len(op_exprs) == 1:
             inp = op_exprs[0]
             out_empty = inp.empty_data
-            out_empty = out_empty.astype("float64")
-            return UnaryOpExpression(out_empty, inp, "log")
+            return UnaryOpExpression(out_empty, inp, "ln")
 
         # ROUND(x, d) or ROUND(x) -> map to a unary/binary op if supported
         if func_name == "ROUND" and len(op_exprs) in (1, 2):
             inp = op_exprs[0]
             out_empty = inp.empty_data
-            return UnaryOpExpression(out_empty, inp, "round")
+
+            if len(op_exprs) == 1:
+                return UnaryOpExpression(out_empty, inp, "round")
+            else:
+                precision_digits = op_exprs[1]
+                # Not a traditional arithmetic operation, but this is what
+                # we currently have available to retrieve binary functions
+                # from the DuckDB catalog.
+                print("Precision type:", get_expr_dtype(precision_digits))
+                return ArithOpExpression(out_empty, inp, precision_digits, "round")
 
         if func_name == "MOD" and len(op_exprs) == 2:
             inp = op_exprs[0]
@@ -1876,7 +1887,16 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         op_exprs = [java_expr_to_python_expr(ctx, o, input_plan) for o in operands]
         func_name = op.getName().upper()
 
-        if (
+        if func_name in ("FLOOR", "CEIL") and len(op_exprs) == 1:
+            inp = op_exprs[0]
+            out_empty = inp.empty_data
+            return UnaryOpExpression(out_empty, inp, func_name.lower())
+        elif func_name == "POW" and len(op_exprs) == 2:
+            left = op_exprs[0]
+            right = op_exprs[1]
+            out_empty = left.empty_data.iloc[:, 0] ** right.empty_data.iloc[:, 0]
+            return ArithOpExpression(out_empty, left, right, "__pow__")
+        elif (
             func_name in ("BITAND", "BITOR", "BITXOR", "BITSHIFTLEFT", "BITSHIFTRIGHT")
             and len(op_exprs) == 2
         ):

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1350,7 +1350,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 # Not a traditional arithmetic operation, but this is what
                 # we currently have available to retrieve binary functions
                 # from the DuckDB catalog.
-                print("Precision type:", get_expr_dtype(precision_digits))
                 return ArithOpExpression(out_empty, inp, precision_digits, "round")
 
         if func_name == "MOD" and len(op_exprs) == 2:

--- a/BodoSQL/bodosql/tests/test_numeric_fns.py
+++ b/BodoSQL/bodosql/tests/test_numeric_fns.py
@@ -82,8 +82,11 @@ def bodosql_conv_df(request):
 
 @pytest.fixture(
     params=[
-        pytest.param(("ABS", "ABS", "MIXED_INTS"), marks=pytest.mark.slow),
-        ("ABS", "ABS", "MIXED_FLOATS"),
+        pytest.param(
+            ("ABS", "ABS", "MIXED_INTS"),
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
+        ),
+        pytest.param(("ABS", "ABS", "MIXED_FLOATS"), marks=pytest.mark.bodosql_cpp),
         pytest.param(("CBRT", "CBRT", "MIXED_FLOATS"), marks=pytest.mark.slow),
         ("CBRT", "CBRT", "MIXED_INTS"),
         pytest.param(
@@ -94,9 +97,11 @@ def bodosql_conv_df(request):
         # the second argument to POW for SQUARE (2) is provided below
         pytest.param(("SQUARE", "POW", "MIXED_FLOATS"), marks=pytest.mark.slow),
         ("SQUARE", "POW", "MIXED_INTS"),
-    ]
-    + [(x, x, "POSITIVE_FLOATS") for x in ["LOG10", "LOG2", "LN", "EXP", "SQRT"]]
-    + [
+        ("LOG10", "LOG10", "POSITIVE_FLOATS"),
+        ("LOG2", "LOG2", "POSITIVE_FLOATS"),
+        pytest.param(("LN", "LN", "POSITIVE_FLOATS"), marks=pytest.mark.bodosql_cpp),
+        pytest.param(("EXP", "EXP", "POSITIVE_FLOATS"), marks=pytest.mark.bodosql_cpp),
+        ("SQRT", "SQRT", "POSITIVE_FLOATS"),
         pytest.param(("LOG", "LOG10", "POSITIVE_FLOATS"), marks=pytest.mark.slow),
     ]
     # currently, behavior for log(0) differs from sparks behavior, see BS-374
@@ -120,14 +125,20 @@ def single_op_numeric_fn_info(request):
         pytest.param(
             ("MOD", "MOD", "UNSIGNED_INT64S", "UNSIGNED_INT32S"), marks=pytest.mark.slow
         ),
-        ("POW", "POW", "POSITIVE_FLOATS", "MIXED_FLOATS"),
+        pytest.param(
+            ("POW", "POW", "POSITIVE_FLOATS", "MIXED_FLOATS"),
+            marks=pytest.mark.bodosql_cpp,
+        ),
         pytest.param(
             ("POWER", "POWER", "POSITIVE_FLOATS", "MIXED_FLOATS"),
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
-        ("POW", "POW", "MIXED_FLOATS", "MIXED_INTS"),
         pytest.param(
-            ("POW", "POW", "MIXED_FLOATS", "MIXED_FLOATS"), marks=pytest.mark.slow
+            ("POW", "POW", "MIXED_FLOATS", "MIXED_INTS"), marks=pytest.mark.bodosql_cpp
+        ),
+        pytest.param(
+            ("POW", "POW", "MIXED_FLOATS", "MIXED_FLOATS"),
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
     ]
 )
@@ -1043,6 +1054,7 @@ def test_to_number_columns_with_scale(fn_name):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "fn_name",
@@ -1334,6 +1346,7 @@ def round_data(request):
     return ctx, scale_str, answer
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [
@@ -1358,12 +1371,22 @@ def test_round(round_data, use_case, memory_leak_check):
 
 
 @pytest.mark.slow
-def test_floor_ceil(memory_leak_check):
+@pytest.mark.parametrize(
+    "query",
+    [
+        pytest.param(
+            "SELECT FLOOR(X), CEIL(X) FROM table1",
+            id="one_arg",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param("SELECT FLOOR(X, P), CEIL(X, P) FROM table1", id="two_args"),
+    ],
+)
+def test_floor_ceil(query, memory_leak_check):
     """
     Tests the rounding functions FLOOR and CEIL with 1 argument and with
     2 arguments.
     """
-    query = "SELECT FLOOR(X), CEIL(X), FLOOR(X, P), CEIL(X, P) FROM table1"
     ctx = {
         "TABLE1": pd.DataFrame(
             {"X": [2.71828] * 3 + [123.456] * 3, "P": [1, -1, 3] * 2}

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -380,9 +380,12 @@ std::unique_ptr<duckdb::Expression> make_arithop_expr(
 }
 
 std::unique_ptr<duckdb::Expression> make_unaryop_expr(
-    std::unique_ptr<duckdb::Expression> &source, std::string opstr) {
+    std::unique_ptr<duckdb::Expression> &source, std::string opstr,
+    PyObject *out_schema_py) {
     // Convert std::unique_ptr to duckdb::unique_ptr.
     auto lhs_duck = to_duckdb(source);
+    std::shared_ptr<arrow::Schema> out_schema = unwrap_schema(out_schema_py);
+
     duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> children;
     children.emplace_back(std::move(lhs_duck));
 
@@ -422,9 +425,16 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
             "make_unaryop_expr BindScalarFunction did not return a "
             "BOUND_FUNCTION");
     }
+
+    auto &bound_func_expr = result->Cast<duckdb::BoundFunctionExpression>();
+    bound_func_expr.bind_info =
+        duckdb::make_uniq<BodoScalarFunctionData>(out_schema);
+
     if (started_transaction) {
         client_context->transaction.Rollback({});
     }
+
+    result->return_type = arrowTypeToDuckDB(out_schema->field(0)->type());
     return result;
 }
 
@@ -1675,56 +1685,100 @@ duckdb::unique_ptr<duckdb::LogicalGet> make_iceberg_get_node(
     return out_get;
 }
 
-void registerFloor(duckdb::shared_ptr<duckdb::DuckDB> db) {
-    duckdb::LogicalType double_type(duckdb::LogicalType::DOUBLE);
-    duckdb::LogicalType float_type(duckdb::LogicalType::FLOAT);
-    duckdb::vector<duckdb::LogicalType> double_arguments = {double_type};
-    duckdb::vector<duckdb::LogicalType> float_arguments = {float_type};
-    duckdb::ScalarFunction floor_fun_double("floor", double_arguments,
-                                            double_type, nullptr);
-    duckdb::ScalarFunction floor_fun_float("floor", float_arguments, float_type,
-                                           nullptr);
-    duckdb::ScalarFunctionSet floor_set("floor");
-    floor_set.AddFunction(floor_fun_double);
-    floor_set.AddFunction(floor_fun_float);
-    duckdb::CreateScalarFunctionInfo floor_info(floor_set);
+struct ScalarFunctionSignature {
+    duckdb::vector<duckdb::LogicalType> param_types;
+    duckdb::LogicalType return_type;
+};
+
+void register_duckdb_scalar_func(
+    duckdb::shared_ptr<duckdb::DuckDB> db, const std::string &func_name,
+    const duckdb::vector<ScalarFunctionSignature> &signatures) {
+    duckdb::ScalarFunctionSet func_set(func_name);
+
+    for (const ScalarFunctionSignature &signature : signatures) {
+        duckdb::ScalarFunction scalar_func(func_name, signature.param_types,
+                                           signature.return_type, nullptr);
+        func_set.AddFunction(scalar_func);
+    }
+
+    duckdb::CreateScalarFunctionInfo func_info(func_set);
     auto &system_catalog = duckdb::Catalog::GetSystemCatalog(*(db->instance));
     auto data =
         duckdb::CatalogTransaction::GetSystemTransaction(*(db->instance));
-    system_catalog.CreateFunction(data, floor_info);
+    system_catalog.CreateFunction(data, func_info);
 }
 
-void registerPower(duckdb::shared_ptr<duckdb::DuckDB> db) {
-    duckdb::LogicalType double_type(duckdb::LogicalType::DOUBLE);
-    duckdb::LogicalType float_type(duckdb::LogicalType::FLOAT);
-    duckdb::vector<duckdb::LogicalType> double_arguments = {double_type,
-                                                            double_type};
-    duckdb::vector<duckdb::LogicalType> float_arguments = {float_type,
-                                                           float_type};
-    duckdb::ScalarFunction power_fun_double("POWER", double_arguments,
-                                            double_type, nullptr);
-    duckdb::ScalarFunction power_fun_float("POWER", float_arguments, float_type,
-                                           nullptr);
-    duckdb::ScalarFunctionSet power_set("POWER");
-    power_set.AddFunction(power_fun_double);
-    power_set.AddFunction(power_fun_float);
-    duckdb::CreateScalarFunctionInfo power_info(power_set);
-    auto &system_catalog = duckdb::Catalog::GetSystemCatalog(*(db->instance));
-    auto data =
-        duckdb::CatalogTransaction::GetSystemTransaction(*(db->instance));
-    system_catalog.CreateFunction(data, power_info);
+const duckdb::vector<ScalarFunctionSignature> UNARY_FLOAT_SIGNATURES = {
+    ScalarFunctionSignature({duckdb::LogicalType::DOUBLE},
+                            duckdb::LogicalType::DOUBLE),
+    ScalarFunctionSignature({duckdb::LogicalType::FLOAT},
+                            duckdb::LogicalType::FLOAT)};
+
+const duckdb::vector<ScalarFunctionSignature> UNARY_INT_SIGNATURES = {
+    ScalarFunctionSignature({duckdb::LogicalType::TINYINT},
+                            duckdb::LogicalType::TINYINT),
+    ScalarFunctionSignature({duckdb::LogicalType::SMALLINT},
+                            duckdb::LogicalType::SMALLINT),
+    ScalarFunctionSignature({duckdb::LogicalType::INTEGER},
+                            duckdb::LogicalType::INTEGER),
+    ScalarFunctionSignature({duckdb::LogicalType::BIGINT},
+                            duckdb::LogicalType::BIGINT)};
+
+duckdb::vector<ScalarFunctionSignature> &&append_signatures(
+    duckdb::vector<ScalarFunctionSignature> &&signatures,
+    const duckdb::vector<ScalarFunctionSignature> &signatures_to_append) {
+    for (const ScalarFunctionSignature &signature : signatures_to_append) {
+        signatures.emplace_back(signature);
+    }
+    return std::move(signatures);
+}
+
+duckdb::vector<ScalarFunctionSignature> copy_signatures(
+    const duckdb::vector<ScalarFunctionSignature> &signatures) {
+    return signatures;
+}
+
+void register_duckdb_scalar_funcs(duckdb::shared_ptr<duckdb::DuckDB> db) {
+    register_duckdb_scalar_func(db, "floor", UNARY_FLOAT_SIGNATURES);
+    register_duckdb_scalar_func(db, "ceil", UNARY_FLOAT_SIGNATURES);
+    register_duckdb_scalar_func(
+        db, "abs",
+        append_signatures(copy_signatures(UNARY_FLOAT_SIGNATURES),
+                          UNARY_INT_SIGNATURES));
+    register_duckdb_scalar_func(db, "sqrt", UNARY_FLOAT_SIGNATURES);
+    register_duckdb_scalar_func(db, "exp", UNARY_FLOAT_SIGNATURES);
+    register_duckdb_scalar_func(db, "ln", UNARY_FLOAT_SIGNATURES);
+    // Unary and binary round
+    register_duckdb_scalar_func(
+        db, "round",
+        append_signatures(
+            {ScalarFunctionSignature(
+                 {duckdb::LogicalType::DOUBLE, duckdb::LogicalType::BIGINT},
+                 duckdb::LogicalType::DOUBLE),
+             ScalarFunctionSignature(
+                 {duckdb::LogicalType::FLOAT, duckdb::LogicalType::BIGINT},
+                 duckdb::LogicalType::FLOAT)},
+            UNARY_FLOAT_SIGNATURES));
+
+    register_duckdb_scalar_func(
+        db, "power",
+        {ScalarFunctionSignature(
+             {duckdb::LogicalType::DOUBLE, duckdb::LogicalType::DOUBLE},
+             duckdb::LogicalType::DOUBLE),
+         ScalarFunctionSignature(
+             {duckdb::LogicalType::FLOAT, duckdb::LogicalType::FLOAT},
+             duckdb::LogicalType::FLOAT)});
 }
 
 duckdb::shared_ptr<duckdb::DuckDB> get_duckdb() {
     static duckdb::shared_ptr<duckdb::DuckDB> db =
         duckdb::make_shared_ptr<duckdb::DuckDB>(nullptr);
-    static bool floor_registered = []() {
-        registerFloor(db);
-        registerPower(db);
+    static bool scalar_funcs_registered = []() {
+        register_duckdb_scalar_funcs(db);
         return true;
     }();
     // Prevent unused variable error.
-    (void)floor_registered;
+    (void)scalar_funcs_registered;
     return db;
 }
 

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -445,10 +445,12 @@ std::unique_ptr<duckdb::Expression> make_arithop_expr(
  *
  * @param source - the source of the expression
  * @param opstr - the name of the function to apply to the source
+ * @param out_schema_py output data type
  * @return duckdb::unique_ptr<duckdb::Expression> - the output expr
  */
 std::unique_ptr<duckdb::Expression> make_unaryop_expr(
-    std::unique_ptr<duckdb::Expression> &source, std::string opstr);
+    std::unique_ptr<duckdb::Expression> &source, std::string opstr,
+    PyObject *out_schema_py);
 
 /**
  * @brief Create a cast expression.

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -465,35 +465,38 @@ std::shared_ptr<array_info> do_arrow_compute_multi_input(
 std::shared_ptr<array_info> do_arrow_compute_binary(
     std::shared_ptr<ExprResult> left_res, std::shared_ptr<ExprResult> right_res,
     const std::string& comparator,
+    const arrow::compute::FunctionOptions* func_options,
     const std::shared_ptr<arrow::DataType> result_type) {
     arrow::Datum src1 =
         ConvertExprResultToDatum(left_res, "do_arrow_compute left");
     arrow::Datum src2 =
         ConvertExprResultToDatum(right_res, "do_arrow_compute right");
-    arrow::Datum cmp_res_datum =
-        do_arrow_compute_binary(src1, src2, comparator, result_type);
+    arrow::Datum cmp_res_datum = do_arrow_compute_binary(
+        src1, src2, comparator, func_options, result_type);
     return ConvertDatumToArrayInfo(cmp_res_datum);
 }
 
 std::shared_ptr<array_info> do_arrow_compute_binary(
     arrow::Datum left_res, std::shared_ptr<ExprResult> right_res,
     const std::string& comparator,
+    const arrow::compute::FunctionOptions* func_options,
     const std::shared_ptr<arrow::DataType> result_type) {
     arrow::Datum src2 =
         ConvertExprResultToDatum(right_res, "do_arrow_compute right");
-    arrow::Datum cmp_res_datum =
-        do_arrow_compute_binary(left_res, src2, comparator, result_type);
+    arrow::Datum cmp_res_datum = do_arrow_compute_binary(
+        left_res, src2, comparator, func_options, result_type);
     return ConvertDatumToArrayInfo(cmp_res_datum);
 }
 
 std::shared_ptr<array_info> do_arrow_compute_binary(
     std::shared_ptr<ExprResult> left_res, arrow::Datum right_res,
     const std::string& comparator,
+    const arrow::compute::FunctionOptions* func_options,
     const std::shared_ptr<arrow::DataType> result_type) {
     arrow::Datum src1 =
         ConvertExprResultToDatum(left_res, "do_arrow_compute left");
-    arrow::Datum cmp_res_datum =
-        do_arrow_compute_binary(src1, right_res, comparator, result_type);
+    arrow::Datum cmp_res_datum = do_arrow_compute_binary(
+        src1, right_res, comparator, func_options, result_type);
     return ConvertDatumToArrayInfo(cmp_res_datum);
 }
 
@@ -520,9 +523,10 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
 arrow::Datum do_arrow_compute_binary(
     arrow::Datum left_res, arrow::Datum right_res,
     const std::string& comparator,
+    const arrow::compute::FunctionOptions* func_options,
     const std::shared_ptr<arrow::DataType> result_type) {
-    arrow::Result<arrow::Datum> cmp_res =
-        arrow::compute::CallFunction(comparator, {left_res, right_res});
+    arrow::Result<arrow::Datum> cmp_res = arrow::compute::CallFunction(
+        comparator, {left_res, right_res}, func_options);
     if (!cmp_res.ok()) [[unlikely]] {
         throw std::runtime_error(
             "do_array_compute_binary: Error in Arrow compute: " +

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -216,6 +216,7 @@ std::shared_ptr<array_info> do_arrow_compute_unary(
 std::shared_ptr<array_info> do_arrow_compute_binary(
     std::shared_ptr<ExprResult> left_res, std::shared_ptr<ExprResult> right_res,
     const std::string &comparator,
+    const arrow::compute::FunctionOptions *func_options = nullptr,
     const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
@@ -226,6 +227,7 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
 std::shared_ptr<array_info> do_arrow_compute_binary(
     arrow::Datum left_res, std::shared_ptr<ExprResult> right_res,
     const std::string &comparator,
+    const arrow::compute::FunctionOptions *func_options = nullptr,
     const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
@@ -236,6 +238,7 @@ std::shared_ptr<array_info> do_arrow_compute_binary(
 std::shared_ptr<array_info> do_arrow_compute_binary(
     std::shared_ptr<ExprResult> left_res, arrow::Datum right_res,
     const std::string &comparator,
+    const arrow::compute::FunctionOptions *func_options = nullptr,
     const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
@@ -270,6 +273,7 @@ arrow::Datum do_arrow_compute_unary(
 arrow::Datum do_arrow_compute_binary(
     arrow::Datum left_res, arrow::Datum right_res,
     const std::string &comparator,
+    const arrow::compute::FunctionOptions *func_options = nullptr,
     const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
@@ -893,10 +897,12 @@ class PhysicalUnaryExpression : public PhysicalExpression {
     PhysicalUnaryExpression(std::shared_ptr<PhysicalExpression> left,
                             std::string &opstr) {
         children.push_back(left);
-        if (opstr == "floor") {
-            comparator = "floor";
+        if (opstr == "floor" || opstr == "ceil" || opstr == "abs" ||
+            opstr == "sqrt" || opstr == "exp" || opstr == "ln" ||
+            opstr == "round") {
+            comparator = opstr;
         } else {
-            throw std::runtime_error("Unhandled unary expression opstr " +
+            throw std::runtime_error("Unhandled unary expression opstr: " +
                                      opstr);
         }
     }
@@ -912,7 +918,22 @@ class PhysicalUnaryExpression : public PhysicalExpression {
         // Process child first.
         std::shared_ptr<ExprResult> left_res =
             children[0]->ProcessBatch(input_batch);
-        auto result = do_arrow_compute_unary(left_res, comparator);
+
+        arrow::compute::FunctionOptions *func_options;
+        if (comparator == "round") {
+            // Override the default Arrow round mode to
+            // HALF_TOWARDS_INFINITY to match SQL semantics.
+            // See
+            // https://docs.bodo.ai/latest/api_docs/sql/functions/numeric/round/
+            arrow::compute::RoundOptions opts(
+                0, arrow::compute::RoundMode::HALF_TOWARDS_INFINITY);
+            func_options = &opts;
+        } else {
+            func_options = nullptr;
+        }
+        auto result =
+            do_arrow_compute_unary(left_res, comparator, func_options);
+
         auto left_as_scalar =
             std::dynamic_pointer_cast<ScalarExprResult>(left_res);
         if (left_as_scalar) {
@@ -979,13 +1000,13 @@ class PhysicalBinaryExpression : public PhysicalExpression {
             // "//" is integer division in DuckDB which is handled by divide
             // function of Arrow
             comparator = "divide";
-        } else if (opstr == "floor") {
-            comparator = "floor";
         } else if (opstr == "%") {
             EnsureModRegistered();
             comparator = "bodo_mod";
-        } else if (opstr == "POWER") {
-            comparator = "power";
+        } else if (opstr == "floor" || opstr == "power") {
+            comparator = opstr;
+        } else if (opstr == "round") {
+            comparator = "round_binary";
         } else {
             throw std::runtime_error("Unhandled binary expression opstr " +
                                      opstr);
@@ -1006,8 +1027,21 @@ class PhysicalBinaryExpression : public PhysicalExpression {
         std::shared_ptr<ExprResult> right_res =
             children[1]->ProcessBatch(input_batch);
 
+        arrow::compute::FunctionOptions *func_options;
+        if (comparator == "round_binary") {
+            // Override the default Arrow round mode to
+            // HALF_TOWARDS_INFINITY to match SQL semantics.
+            // See
+            // https://docs.bodo.ai/latest/api_docs/sql/functions/numeric/round/
+            arrow::compute::RoundBinaryOptions opts(
+                arrow::compute::RoundMode::HALF_TOWARDS_INFINITY);
+            func_options = &opts;
+        } else {
+            func_options = nullptr;
+        }
         std::shared_ptr<array_info> result = do_arrow_compute_binary(
-            left_res, right_res, comparator, result_type);
+            left_res, right_res, comparator, func_options, result_type);
+
         auto left_as_scalar =
             std::dynamic_pointer_cast<ScalarExprResult>(left_res);
         auto right_as_scalar =

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -669,6 +669,16 @@ class PhysicalGPUUnaryExpression : public PhysicalGPUExpression {
         children.push_back(left);
         if (opstr == "floor") {
             comparator = cudf::unary_operator::FLOOR;
+        } else if (opstr == "ceil") {
+            comparator = cudf::unary_operator::CEIL;
+        } else if (opstr == "abs") {
+            comparator = cudf::unary_operator::ABS;
+        } else if (opstr == "sqrt") {
+            comparator = cudf::unary_operator::SQRT;
+        } else if (opstr == "exp") {
+            comparator = cudf::unary_operator::EXP;
+        } else if (opstr == "ln") {
+            comparator = cudf::unary_operator::LOG;
         } else {
             throw std::runtime_error("Unhandled unary expression opstr " +
                                      opstr);
@@ -822,7 +832,7 @@ class PhysicalGPUBinaryExpression : public PhysicalGPUExpression {
             comparator = cudf::binary_operator::FLOOR_DIV;
         } else if (opstr == "%") {
             comparator = cudf::binary_operator::MOD;
-        } else if (opstr == "POWER") {
+        } else if (opstr == "power") {
             comparator = cudf::binary_operator::POW;
         } else {
             throw std::runtime_error("Unhandled binary expression opstr " +

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -359,7 +359,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_scalar_func_expr(object out_schema, vector[unique_ptr[CExpression]] in_exprs, object args, c_bool is_cfunc, c_bool has_state, c_string arrow_compute_func) except +
     cdef unique_ptr[CExpression] make_comparison_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_arithop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, c_string opstr, object out_schema) except +
-    cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr) except +
+    cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr, object out_schema) except +
     cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema) except +
     cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_unary_expr(unique_ptr[CExpression] lhs, CExpressionType etype, object out_schema) except +
@@ -866,9 +866,22 @@ def python_arith_dunder_to_duckdb(str opstr):
         # NOTE: only used for integers since "//" is integer division in duckdb
         return "//"
     elif opstr == "__pow__":
-        return "POWER"
+        return "power"
     else:
         raise NotImplementedError("Unknown Python arith dunder method name")
+
+
+def unary_func_name_to_duckdb(str opstr):
+    """
+    Convert a unary function name to duckdb catalog name.
+    For now we just lower the function name, but we leave
+    the possibility open for special mappings.
+    """
+    opstr_lowered = opstr.lower()
+    if opstr_lowered in ("floor", "ceil", "sqrt", "abs", "exp", "ln", "round"):
+        return opstr_lowered
+    else:
+        raise NotImplementedError("Unknown unary function name: " + opstr_lowered)
 
 
 def is_integer_expr(object expr):
@@ -905,10 +918,12 @@ cdef class ArithOpExpression(Expression):
                 rhs_expr,
                 "/".encode(),
                 self.out_schema)
-            unaryop_expr = make_unaryop_expr(truediv_expression, "floor".encode())
-            self.c_expression = make_cast_expr(unaryop_expr, self.out_schema)
+            self.c_expression = make_unaryop_expr(truediv_expression, "floor".encode(), self.out_schema)
         else:
-            duckdb_op = python_arith_dunder_to_duckdb(opstr)
+            if opstr.lower() == "round":
+                duckdb_op = "round"
+            else:
+                duckdb_op = python_arith_dunder_to_duckdb(opstr)
             self.c_expression = make_arithop_expr(
                 lhs_expr,
                 rhs_expr,
@@ -947,9 +962,18 @@ cdef class UnaryOpExpression(Expression):
         source_expr = move((<Expression>source).c_expression) if isinstance(source, Expression) else move(make_const_expr(None, source))
 
         self.out_schema = out_schema
-        self.c_expression = make_unary_expr(
-            source_expr,
-            str_to_expr_type(op), out_schema)
+        try:
+            self.c_expression = make_unary_expr(
+                source_expr,
+                str_to_expr_type(op), out_schema)
+        except NotImplementedError:
+            duckdb_op = unary_func_name_to_duckdb(op)
+            try:
+                self.c_expression = make_unaryop_expr(
+                    source_expr,
+                    duckdb_op.encode(), out_schema)
+            except NotImplementedError:
+                raise NotImplementedError("Unknown Python dunder method name or unary function name: " + op)
 
     def __str__(self):
         return f"UnaryOpExpression({self.out_schema})"


### PR DESCRIPTION
## Changes included in this PR

For unary operators that don't have their own DuckDB `ExpressionType`, `UnaryOpExpression` now attempts to search for them in the catalog where we register them individually.
Registered DuckDB scalar functions for the math functions we already had in `plan_conversion.py` that were broken. Added a bit more infrastructure to make the registration easier.
Added out_schema parameter to `make_unaryop_expr` to be consistent with `make_arithop_expr`.
Enabled the relevant tests that are now passing on the C++ backend.

## Testing strategy

CI

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.