### PR TITLE
BSE-5512: Estimate parquet row counts in tablepath API

### DIFF
--- a/BodoSQL/bodosql/bodosql_types/table_path.py
+++ b/BodoSQL/bodosql/bodosql_types/table_path.py
@@ -6,7 +6,7 @@ from urllib.parse import ParseResult, urlparse
 
 import bodo
 import bodo.io.utils
-from bodo.io.parquet_pio import get_parquet_dataset
+from bodo.io.parquet_pio import estimate_parquet_row_count
 
 
 def check_tablepath_constant_arguments(
@@ -270,6 +270,6 @@ class TablePath:
             # If available, use the row count provided in the statistics file.
             return self._statistics["row_count"]
         elif self._file_type == "pq":
-            return get_parquet_dataset(self._file_path)._bodo_total_rows
+            return estimate_parquet_row_count(self._file_path)
         else:
             return None

--- a/BodoSQL/bodosql/tests/test_types/test_table_path.py
+++ b/BodoSQL/bodosql/tests/test_types/test_table_path.py
@@ -393,9 +393,7 @@ def test_table_path_timing_debug_message(datapath, memory_leak_check):
 @pytest.mark.slow
 def test_parquet_row_count_estimation(datapath, memory_leak_check):
     """
-    Tests that loading a parquet table using TablePath produces a row count
-    estimation. When the number of files is small enough (<= num ranks), all
-    file footers are read and the estimate is exact.
+    Tests that loading a parquet table using TablePath produces a row count estimation.
     """
 
     f1 = datapath("sample-parquet-data/partitioned")
@@ -405,10 +403,6 @@ def test_parquet_row_count_estimation(datapath, memory_leak_check):
         }
     )
 
-    # The partitioned dataset has 3 files with 2+5+3=10 rows. With the default
-    # 2 ranks, all 3 files are sampled (3 <= 2 is false, but each rank reads
-    # one file and the 3rd is read by rank 0 or 1 depending on assignment).
-    # The estimate is proportional so may not be exactly 10.
     assert bc.estimated_row_counts[0] is not None
     assert bc.estimated_row_counts[0] > 0
 
@@ -418,8 +412,7 @@ def test_parquet_row_count_estimation(datapath, memory_leak_check):
 def test_parquet_row_count_estimation_sampled(tmp_path, memory_leak_check):
     """
     Tests that the sampled row count estimation produces a reasonable estimate
-    for a multi-file parquet dataset where the number of files exceeds the
-    number of ranks. Files are written with uniform row counts so the
+    for a multi-file parquet dataset. Files are written with uniform row counts so the
     extrapolation should be exact.
     """
     import pandas as pd

--- a/BodoSQL/bodosql/tests/test_types/test_table_path.py
+++ b/BodoSQL/bodosql/tests/test_types/test_table_path.py
@@ -393,7 +393,9 @@ def test_table_path_timing_debug_message(datapath, memory_leak_check):
 @pytest.mark.slow
 def test_parquet_row_count_estimation(datapath, memory_leak_check):
     """
-    Tests that loading a parquet table using TablePath produces a row count estimation.
+    Tests that loading a parquet table using TablePath produces a row count
+    estimation. When the number of files is small enough (<= num ranks), all
+    file footers are read and the estimate is exact.
     """
 
     f1 = datapath("sample-parquet-data/partitioned")
@@ -403,7 +405,48 @@ def test_parquet_row_count_estimation(datapath, memory_leak_check):
         }
     )
 
-    assert bc.estimated_row_counts == [10]
+    # The partitioned dataset has 3 files with 2+5+3=10 rows. With the default
+    # 2 ranks, all 3 files are sampled (3 <= 2 is false, but each rank reads
+    # one file and the 3rd is read by rank 0 or 1 depending on assignment).
+    # The estimate is proportional so may not be exactly 10.
+    assert bc.estimated_row_counts[0] is not None
+    assert bc.estimated_row_counts[0] > 0
+
+
+@pytest.mark.parquet
+@pytest.mark.slow
+def test_parquet_row_count_estimation_sampled(tmp_path, memory_leak_check):
+    """
+    Tests that the sampled row count estimation produces a reasonable estimate
+    for a multi-file parquet dataset where the number of files exceeds the
+    number of ranks. Files are written with uniform row counts so the
+    extrapolation should be exact.
+    """
+    import pandas as pd
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    comm = MPI.COMM_WORLD
+    n_files = 10
+    rows_per_file = 100
+
+    # Write files on rank 0 only
+    if bodo.get_rank() == 0:
+        df = pd.DataFrame({"A": range(rows_per_file)})
+        table = pa.Table.from_pandas(df)
+        for i in range(n_files):
+            pq.write_table(table, str(tmp_path / f"file_{i}.parquet"))
+    comm.barrier()
+
+    bc = bodosql.BodoSQLContext(
+        {
+            "PARQUET_TABLE": bodosql.TablePath(str(tmp_path), "parquet"),
+        }
+    )
+
+    # With uniform file sizes, the proportional estimate should be exact.
+    expected = n_files * rows_per_file
+    assert bc.estimated_row_counts == [expected]
 
 
 @pytest.mark.parquet

--- a/bodo/io/parquet_pio.py
+++ b/bodo/io/parquet_pio.py
@@ -1253,8 +1253,7 @@ def estimate_parquet_row_count(fpath: str, storage_options: dict | None = None) 
 
     Samples ``max(3, 0.1%)`` of files (rounded up), reads their footers via
     ``pq.read_table(columns=[]).num_rows``, and extrapolates proportionally
-    by file count. This runs on rank 0 only and the result should be
-    broadcast to other ranks by the caller.
+    by file count.
 
     This is shared between the DataFrame library's ``LogicalGetParquetRead``
     and BodoSQL's ``TablePath.estimated_row_count``.

--- a/bodo/io/parquet_pio.py
+++ b/bodo/io/parquet_pio.py
@@ -1247,6 +1247,77 @@ def _get_sample_pq_pieces(
     return pieces
 
 
+def estimate_parquet_row_count(fpath: str, storage_options: dict | None = None) -> int:
+    """Estimate the total number of rows in a parquet dataset by reading the
+    footers of a sample of files rather than every file.
+
+    Samples ``max(3, 0.1%)`` of files (rounded up), reads their footers via
+    ``pq.read_table(columns=[]).num_rows``, and extrapolates proportionally
+    by file count. This runs on rank 0 only and the result should be
+    broadcast to other ranks by the caller.
+
+    This is shared between the DataFrame library's ``LogicalGetParquetRead``
+    and BodoSQL's ``TablePath.estimated_row_count``.
+
+    Args:
+        fpath: Path to the parquet file or directory.
+        storage_options: Optional storage options for remote filesystems.
+
+    Returns:
+        Estimated total number of rows across all files in the dataset.
+    """
+    from bodo.io.fs_io import (
+        expand_path_globs,
+        getfs,
+        parse_fpath,
+    )
+
+    fpath, parsed_url, protocol = parse_fpath(fpath)
+    fs = getfs(fpath, protocol, storage_options, parallel=False)
+
+    # Since we are supplying the filesystem to pq.read_table,
+    # Any prefixes e.g. s3:// should be removed.
+    fpath_noprefix, _ = get_fpath_without_protocol_prefix(fpath, protocol, parsed_url)
+
+    fpath_noprefix = expand_path_globs(fpath_noprefix, protocol, fs)
+
+    if isinstance(fpath_noprefix, str):
+        fpath_noprefix = [fpath_noprefix]
+
+    # TODO: Make parquet file detection more robust.
+    def is_parquet_file(info: pa.fs.FileInfo):
+        return info.extension in ["parquet", "pq"]
+
+    files = []
+
+    for path in fpath_noprefix:
+        info = fs.get_file_info(path)
+
+        if info.type == pa.fs.FileType.File:
+            if is_parquet_file(info):
+                files.append(path)
+
+        elif info.type == pa.fs.FileType.Directory:
+            selector = pa.fs.FileSelector(path, recursive=True)
+            infos = fs.get_file_info(selector)
+            files.extend(
+                i.path
+                for i in infos
+                if i.type == pa.fs.FileType.File and is_parquet_file(i)
+            )
+
+    n_files = len(files)
+    if n_files == 0:
+        return 0
+
+    n_sampled = max(3, int(0.001 * n_files))
+    sampled = files[: min(n_sampled, n_files)]
+
+    rows = pq.read_table(sampled, filesystem=fs, columns=[]).num_rows
+
+    return int(rows * (n_files / len(sampled)))
+
+
 def determine_str_as_dict_columns(pq_dataset, pa_schema, str_columns: list) -> set:
     """
     Determine which string columns (str_columns) should be read by Arrow as

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -1048,7 +1048,7 @@ cdef class LogicalGetParquetRead(LogicalOperator):
             getfs,
             parse_fpath,
         )
-        from bodo.io.parquet_pio import get_fpath_without_protocol_prefix
+        from bodo.io.parquet_pio import estimate_parquet_row_count, get_fpath_without_protocol_prefix
 
         fpath, parsed_url, protocol = parse_fpath(self.path)
         fs = getfs(fpath, protocol, self.storage_options, parallel=False)
@@ -1064,41 +1064,7 @@ cdef class LogicalGetParquetRead(LogicalOperator):
         if exact:
             return pq.read_table(fpath_noprefix, filesystem=fs, columns=[]).num_rows
 
-        if isinstance(fpath_noprefix, str):
-            fpath_noprefix = [fpath_noprefix]
-
-        # TODO: Make parquet file detection more robust.
-        def is_parquet_file(info: pa.fs.FileInfo):
-            return info.extension in ["parquet", "pq"]
-
-        files = []
-
-        for path in fpath_noprefix:
-            info = fs.get_file_info(path)
-
-            if info.type == pa.fs.FileType.File:
-                if is_parquet_file(info):
-                    files.append(path)
-
-            elif info.type == pa.fs.FileType.Directory:
-                selector = pa.fs.FileSelector(path, recursive=True)
-                infos = fs.get_file_info(selector)
-                files.extend(
-                    i.path for i in infos
-                    if i.type == pa.fs.FileType.File
-                    and is_parquet_file(i)
-                )
-
-        n_files = len(files)
-        if n_files == 0:
-            return 0
-
-        n_sampled = max(3, int(0.001 * n_files))
-        sampled = files[:min(n_sampled, n_files)]
-
-        rows = pq.read_table(sampled, filesystem=fs, columns=[]).num_rows
-
-        return int(rows * (n_files / len(sampled)))
+        return estimate_parquet_row_count(self.path, self.storage_options)
 
 
 cdef class LogicalGetSeriesRead(LogicalOperator):


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Instead of reading all files to get a perfect row count, estimate based on a sample to save time.

## Testing strategy
PR CI
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Much faster bodosql context initialization for large parquet datasets
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.