### PR TITLE
Fix all-NA sum for SQL

### DIFF
--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -314,7 +314,7 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalAggregate& op) {
 #else   // USE_CUDF
         // Otherwise, create a PhysicalReduce operator
         auto physical_op = std::make_shared<PhysicalReduce>(
-            bodo_schema, function_names, input_column_indices);
+            bodo_schema, function_names, input_column_indices, use_sql_rules);
         FinishPipelineOneOperator(physical_op);
 #endif  // USE_CUDF
         return;

--- a/bodo/pandas/physical/reduce.cpp
+++ b/bodo/pandas/physical/reduce.cpp
@@ -164,12 +164,12 @@ OperatorResult PhysicalReduce::ConsumeBatch(
             } else if (func_name == "sum") {
                 reduction_functions.push_back(
                     std::make_unique<ReductionFunctionSum>(
-                        input_col_idx,
+                        input_col_idx, use_sql_rules,
                         this->out_schema->column_types[i]->ToArrowDataType()));
             } else if (func_name == "product") {
                 reduction_functions.push_back(
                     std::make_unique<ReductionFunctionProduct>(
-                        input_col_idx,
+                        input_col_idx, use_sql_rules,
                         this->out_schema->column_types[i]->ToArrowDataType()));
             } else if (func_name == "count") {
                 reduction_functions.push_back(

--- a/bodo/pandas/physical/reduce.h
+++ b/bodo/pandas/physical/reduce.h
@@ -75,18 +75,22 @@ struct ReductionFunctionMin : public ReductionFunction {
 };
 
 struct ReductionFunctionSum : public ReductionFunction {
-    ReductionFunctionSum(int input_col_idx, std::shared_ptr<arrow::DataType> dt)
-        : ReductionFunction(input_col_idx, {"sum"}, {"add"},
-                            {ReductionType::AGGREGATION},
-                            {arrow::MakeScalar(dt, 0).ValueOrDie()}) {}
+    ReductionFunctionSum(int input_col_idx, bool use_sql_rules,
+                         std::shared_ptr<arrow::DataType> dt)
+        : ReductionFunction(
+              input_col_idx, {"sum"}, {"add"}, {ReductionType::AGGREGATION},
+              {use_sql_rules ? arrow::MakeNullScalar(dt)
+                             : arrow::MakeScalar(dt, 0).ValueOrDie()}) {}
 };
 
 struct ReductionFunctionProduct : public ReductionFunction {
-    ReductionFunctionProduct(int input_col_idx,
+    ReductionFunctionProduct(int input_col_idx, bool use_sql_rules,
                              std::shared_ptr<arrow::DataType> dt)
-        : ReductionFunction(input_col_idx, {"product"}, {"multiply"},
-                            {ReductionType::AGGREGATION},
-                            {arrow::MakeScalar(dt, 1).ValueOrDie()}) {}
+        : ReductionFunction(
+              input_col_idx, {"product"}, {"multiply"},
+              {ReductionType::AGGREGATION},
+              {use_sql_rules ? arrow::MakeNullScalar(dt)
+                             : arrow::MakeScalar(dt, 1).ValueOrDie()}) {}
 };
 
 struct ReductionFunctionCount : public ReductionFunction {
@@ -134,11 +138,13 @@ class PhysicalReduce : public PhysicalSource, public PhysicalSink {
    public:
     explicit PhysicalReduce(std::shared_ptr<bodo::Schema> out_schema,
                             std::vector<std::string> function_names,
-                            std::vector<int> input_column_indices)
+                            std::vector<int> input_column_indices,
+                            bool use_sql_rules = false)
         // Drop Index columns since not necessary in output
         : out_schema(std::move(out_schema)),
           function_names(std::move(function_names)),
-          input_column_indices(std::move(input_column_indices)) {}
+          input_column_indices(std::move(input_column_indices)),
+          use_sql_rules(use_sql_rules) {}
 
     virtual ~PhysicalReduce() = default;
 
@@ -220,6 +226,7 @@ class PhysicalReduce : public PhysicalSource, public PhysicalSink {
     std::vector<std::unique_ptr<ReductionFunction>> reduction_functions;
     std::vector<std::string> function_names;
     std::vector<int> input_column_indices;
+    bool use_sql_rules = false;
 
     int64_t iter = 0;
     PhysicalReduceMetrics metrics;


### PR DESCRIPTION
Makes sure SQL rules are used for sum and product reductions. Fixes `test_multi_col_null_pivot` on nightly. Will open follow ups for other reductions and GPU case.