### PR TITLE
Fix SQL GPU reduction functions for all-NULL data [GPU]

### DIFF
--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -304,10 +304,12 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalAggregate& op) {
         bool run_on_gpu = node_run_on_gpu(op);
         if (run_on_gpu) {
             physical_op = std::make_shared<PhysicalGPUReduce>(
-                bodo_schema, function_names, input_column_indices);
+                bodo_schema, function_names, input_column_indices,
+                use_sql_rules);
         } else {
             physical_op = std::make_shared<PhysicalReduce>(
-                bodo_schema, function_names, input_column_indices);
+                bodo_schema, function_names, input_column_indices,
+                use_sql_rules);
         }
         std::visit([&](auto& vop) { FinishPipelineOneOperator(vop); },
                    physical_op);

--- a/bodo/pandas/physical/gpu_expression.h
+++ b/bodo/pandas/physical/gpu_expression.h
@@ -1004,7 +1004,19 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
             // cudf::strings::strip()
             str_scalar_in = std::make_shared<cudf::string_scalar>("", true);
         } else if (scalar_func_data.arrow_func_name == "round") {
-            round_ndigits = get_py_round_arg(scalar_func_data.args);
+            arrow::compute::RoundMode arrow_round_mode;
+            std::tie(round_ndigits, arrow_round_mode) =
+                get_py_round_args(scalar_func_data.args);
+            if (arrow_round_mode == arrow::compute::RoundMode::HALF_TO_EVEN) {
+                round_mode = cudf::rounding_method::HALF_EVEN;
+            } else if (arrow_round_mode ==
+                       arrow::compute::RoundMode::HALF_TOWARDS_INFINITY) {
+                round_mode = cudf::rounding_method::HALF_UP;
+            } else {
+                throw std::invalid_argument(
+                    "Only half-to-even and half-away-from-zero rounding modes "
+                    "supported on GPU.");
+            }
         } else if (scalar_func_data.arrow_func_name == "utf8_slice_codeunits") {
             extract_slice_arg_from_python();
         } else if (scalar_func_data.arrow_func_name == "is_in") {
@@ -1062,7 +1074,7 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             result = cudf::round(in_as_array->result->view(), round_ndigits,
-                                 cudf::rounding_method::HALF_EVEN, se->stream);
+                                 round_mode, se->stream);
 #pragma GCC diagnostic pop
         } else if (scalar_func_data.arrow_func_name == "is_null") {
             result = cudf::is_null(in_as_array->result->view(), se->stream);
@@ -1179,6 +1191,7 @@ class PhysicalGPUArrowExpression : public PhysicalGPUExpression {
     std::shared_ptr<cudf::strings::regex_program> regex_prog;
 
     int32_t round_ndigits = 0;
+    cudf::rounding_method round_mode = cudf::rounding_method::HALF_EVEN;
 
     // str.slice() arguments
     int64_t start = 0;

--- a/bodo/pandas/physical/gpu_reduce.cpp
+++ b/bodo/pandas/physical/gpu_reduce.cpp
@@ -230,13 +230,13 @@ OperatorResult PhysicalGPUReduce::ConsumeBatchGPU(
             } else if (func_name == "sum") {
                 reduction_functions.push_back(
                     std::make_unique<GPUReductionFunctionSum>(
-                        input_col_idx,
+                        input_col_idx, use_sql_rules,
                         this->out_schema->column_types[i]->ToArrowDataType(),
                         se->stream));
             } else if (func_name == "product") {
                 reduction_functions.push_back(
                     std::make_unique<GPUReductionFunctionProduct>(
-                        input_col_idx,
+                        input_col_idx, use_sql_rules,
                         this->out_schema->column_types[i]->ToArrowDataType(),
                         se->stream));
             } else if (func_name == "count") {

--- a/bodo/pandas/physical/gpu_reduce.h
+++ b/bodo/pandas/physical/gpu_reduce.h
@@ -128,25 +128,29 @@ struct GPUReductionFunctionMin : public GPUReductionFunction {
 };
 
 struct GPUReductionFunctionSum : public GPUReductionFunction {
-    GPUReductionFunctionSum(int input_col_idx,
+    GPUReductionFunctionSum(int input_col_idx, bool use_sql_rules,
                             std::shared_ptr<arrow::DataType> dt,
                             rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(
               input_col_idx, {"sum"}, {"add"}, {GPUReductionType::AGGREGATION},
               make_vector_of_cudf_scalar(arrow_scalar_to_cudf(
-                  arrow::MakeScalar(dt, 0).ValueOrDie(), output_stream)),
+                  use_sql_rules ? arrow::MakeNullScalar(dt)
+                                : arrow::MakeScalar(dt, 0).ValueOrDie(),
+                  output_stream)),
               dt, MPI_SUM) {}
 };
 
 struct GPUReductionFunctionProduct : public GPUReductionFunction {
-    GPUReductionFunctionProduct(int input_col_idx,
+    GPUReductionFunctionProduct(int input_col_idx, bool use_sql_rules,
                                 std::shared_ptr<arrow::DataType> dt,
                                 rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(
               input_col_idx, {"product"}, {"multiply"},
               {GPUReductionType::AGGREGATION},
               make_vector_of_cudf_scalar(arrow_scalar_to_cudf(
-                  arrow::MakeScalar(dt, 1).ValueOrDie(), output_stream)),
+                  use_sql_rules ? arrow::MakeNullScalar(dt)
+                                : arrow::MakeScalar(dt, 1).ValueOrDie(),
+                  output_stream)),
               dt, MPI_PROD) {}
 };
 
@@ -186,10 +190,12 @@ class PhysicalGPUReduce : public PhysicalGPUSource, public PhysicalGPUSink {
    public:
     explicit PhysicalGPUReduce(std::shared_ptr<bodo::Schema> out_schema,
                                std::vector<std::string> function_names,
-                               std::vector<int> input_column_indices)
+                               std::vector<int> input_column_indices,
+                               bool use_sql_rules = false)
         : out_schema(std::move(out_schema)),
           function_names(std::move(function_names)),
-          input_column_indices(std::move(input_column_indices)) {
+          input_column_indices(std::move(input_column_indices)),
+          use_sql_rules(use_sql_rules) {
         PhysicalGPUSource::EnsureNoNumpyColumns(this->out_schema);
     }
 
@@ -279,6 +285,7 @@ class PhysicalGPUReduce : public PhysicalGPUSource, public PhysicalGPUSink {
     std::vector<std::unique_ptr<GPUReductionFunction>> reduction_functions;
     std::vector<std::string> function_names;
     std::vector<int> input_column_indices;
+    bool use_sql_rules = false;
 
     int64_t iter = 0;
     PhysicalGPUReduceMetrics metrics;


### PR DESCRIPTION
## Changes included in this PR

Use SQL semantics for returning NULL for SUM and PRODUCT aggregations when all the rows are NULL.
Also fixed GPU build failure related to previous `round` changes, not sure how I didn't catch it before.

## Testing strategy

Tested locally to ensure SUM was the only function that needed changing. Theoretically this issue would apply to PRODUCT too, but that's not a standard SQL aggregation.

## User facing changes

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.