### PR TITLE
[BSE-5476] Enable Runtime Join Filter Logging for Iceberg IO [GPU]

### DIFF
--- a/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog_runtime_join.py
+++ b/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog_runtime_join.py
@@ -116,12 +116,16 @@ def test_multiple_filter_join(
     else:
         limit = 0
         log_msg = (
-            "Runtime join filter expression: ((ds.field('{A}') >= 2) & (ds.field('{A}') <= 2) & (ds.field('{A}') >= 1) & (ds.field('{A}') <= 5))"
-            if (join_same_col and bodosql.use_cpp_backend)
-            else "Runtime join filter expression: ((ds.field('{A}') >= 1) & (ds.field('{A}') <= 5) & (ds.field('{A}') >= 2) & (ds.field('{A}') <= 2))"
+            "Runtime join filter expression: ((ds.field('{A}') >= 1) & (ds.field('{A}') <= 5) & (ds.field('{A}') >= 2) & (ds.field('{A}') <= 2))"
             if join_same_col
             else "Runtime join filter expression: ((ds.field('{A}') >= 2) & (ds.field('{A}') <= 2) & (ds.field('{G}') >= 1) & (ds.field('{G}') <= 5))"
         )
+        if bodosql.use_cpp_backend:
+            log_msg = (
+                "Runtime join filter expression: ((ds.field('{A}') >= 2) & (ds.field('{A}') <= 2) & (ds.field('{A}') >= 1) & (ds.field('{A}') <= 5))"
+                if join_same_col
+                else "Runtime join filter expression: ((ds.field('{G}') >= 1) & (ds.field('{G}') <= 5) & (ds.field('{A}') >= 2) & (ds.field('{A}') <= 2))"
+            )
 
     query = f'SELECT EVOLVED.A FROM (SELECT * FROM {table_names[0]}) EVOLVED, (SELECT * FROM "{table_names[1]}" LIMIT 10) PARTITIONED, (SELECT * FROM "{table_names[2]}" LIMIT 10) SIMPLE WHERE EVOLVED.A = PARTITIONED.A AND EVOLVED.{second_key} = SIMPLE.A'
 

--- a/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog_runtime_join.py
+++ b/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog_runtime_join.py
@@ -64,8 +64,7 @@ def test_simple_join(iceberg_database, allow_low_ndv_filter, memory_leak_check):
         log_msg = "Runtime join filter expression: ((ds.field('{A}') >= 1) & (ds.field('{A}') <= 1))"
 
         if bodosql.use_cpp_backend:
-            # TODO BSE-5476: Check logs in BodoSQL backend C++ tests
-            log_msg = ""
+            log_msg = "Runtime join filter expression: (ds.field('A') >= 1 & ds.field('A') <= 1)"
 
     with temp_env_override({"BODO_JOIN_UNIQUE_VALUES_LIMIT": str(limit)}):
         with temp_config_override("dataframe_library_run_parallel", False):

--- a/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog_runtime_join.py
+++ b/BodoSQL/bodosql/tests/test_types/test_filesystem_catalog_runtime_join.py
@@ -63,9 +63,6 @@ def test_simple_join(iceberg_database, allow_low_ndv_filter, memory_leak_check):
         limit = 0
         log_msg = "Runtime join filter expression: ((ds.field('{A}') >= 1) & (ds.field('{A}') <= 1))"
 
-        if bodosql.use_cpp_backend:
-            log_msg = "Runtime join filter expression: (ds.field('A') >= 1 & ds.field('A') <= 1)"
-
     with temp_env_override({"BODO_JOIN_UNIQUE_VALUES_LIMIT": str(limit)}):
         with temp_config_override("dataframe_library_run_parallel", False):
             with set_logging_stream(logger, 2):
@@ -88,7 +85,7 @@ def test_simple_join(iceberg_database, allow_low_ndv_filter, memory_leak_check):
     "allow_low_ndv_filter",
     [
         pytest.param(True, id="low_ndv"),
-        pytest.param(False, id="min_max"),
+        pytest.param(False, id="min_max", marks=pytest.mark.bodosql_cpp),
     ],
 )
 @pytest.mark.parametrize("join_same_col", [True, False])
@@ -119,7 +116,9 @@ def test_multiple_filter_join(
     else:
         limit = 0
         log_msg = (
-            "Runtime join filter expression: ((ds.field('{A}') >= 1) & (ds.field('{A}') <= 5) & (ds.field('{A}') >= 2) & (ds.field('{A}') <= 2))"
+            "Runtime join filter expression: ((ds.field('{A}') >= 2) & (ds.field('{A}') <= 2) & (ds.field('{A}') >= 1) & (ds.field('{A}') <= 5))"
+            if (join_same_col and bodosql.use_cpp_backend)
+            else "Runtime join filter expression: ((ds.field('{A}') >= 1) & (ds.field('{A}') <= 5) & (ds.field('{A}') >= 2) & (ds.field('{A}') <= 2))"
             if join_same_col
             else "Runtime join filter expression: ((ds.field('{A}') >= 2) & (ds.field('{A}') <= 2) & (ds.field('{G}') >= 1) & (ds.field('{G}') <= 5))"
         )
@@ -132,22 +131,24 @@ def test_multiple_filter_join(
     logger = create_string_io_logger(stream)
     py_output = pd.DataFrame({"A": [2] * 200})
     with temp_env_override({"BODO_JOIN_UNIQUE_VALUES_LIMIT": str(limit)}):
-        with set_logging_stream(logger, 2):
-            check_func(
-                impl,
-                (bc, query),
-                py_output=py_output,
-                only_1DVar=True,
-                sort_output=True,
-                reset_index=True,
-            )
+        with temp_config_override("dataframe_library_run_parallel", False):
+            with set_logging_stream(logger, 2):
+                check_func(
+                    impl,
+                    (bc, query),
+                    py_output=py_output,
+                    only_1DVar=True,
+                    sort_output=True,
+                    reset_index=True,
+                )
 
-            check_logger_msg(
-                stream,
-                log_msg,
-            )
+                check_logger_msg(
+                    stream,
+                    log_msg,
+                )
 
 
+@pytest.mark.bodosql_cpp
 @temp_env_override({"BODO_JOIN_UNIQUE_VALUES_LIMIT": "0"})
 def test_rtjf_schema_evolved(memory_leak_check, iceberg_database):
     """
@@ -171,20 +172,21 @@ def test_rtjf_schema_evolved(memory_leak_check, iceberg_database):
     stream = io.StringIO()
     logger = create_string_io_logger(stream)
     py_output = pd.DataFrame({"A": [1, 2, 3, 4, 5] * 1100})
-    with set_logging_stream(logger, 2):
-        check_func(
-            impl,
-            (bc, query),
-            py_output=py_output,
-            only_1DVar=True,
-            sort_output=True,
-            reset_index=True,
-        )
+    with temp_config_override("dataframe_library_run_parallel", False):
+        with set_logging_stream(logger, 2):
+            check_func(
+                impl,
+                (bc, query),
+                py_output=py_output,
+                sort_output=True,
+                only_1DVar=True,
+                reset_index=True,
+            )
 
-        check_logger_msg(
-            stream,
-            "Runtime join filter expression: ((ds.field('{C}') >= 1) & (ds.field('{C}') <= 5))",
-        )
+            check_logger_msg(
+                stream,
+                "Runtime join filter expression: ((ds.field('{C}') >= 1) & (ds.field('{C}') <= 5))",
+            )
 
 
 @temp_env_override({"BODO_JOIN_UNIQUE_VALUES_LIMIT": "0"})
@@ -518,7 +520,7 @@ def test_merged_rtjf(
     "allow_low_ndv_filter",
     [
         pytest.param(True, id="low_ndv"),
-        pytest.param(False, id="min_max"),
+        pytest.param(False, id="min_max", marks=pytest.mark.bodosql_cpp),
     ],
 )
 def test_date_keys(allow_low_ndv_filter, iceberg_database, memory_leak_check):
@@ -588,30 +590,35 @@ def test_date_keys(allow_low_ndv_filter, iceberg_database, memory_leak_check):
         log_msg = "Runtime join filter expression: ((ds.field('{DAY}').isin([pa.scalar(18672, pa.date32()), pa.scalar(18778, pa.date32()), pa.scalar(18797, pa.date32()), pa.scalar(18812, pa.date32()), pa.scalar(18876, pa.date32()), pa.scalar(18931, pa.date32()), pa.scalar(18956, pa.date32()), pa.scalar(18986, pa.date32())])))"
     else:
         limit = 0
-        log_msg = "Runtime join filter expression: ((ds.field('{DAY}') >= pa.scalar(18672, pa.date32())) & (ds.field('{DAY}') <= pa.scalar(18986, pa.date32())))"
+        log_msg = (
+            "((ds.field('{DAY}') >= 2021-02-14) & (ds.field('{DAY}') <= 2021-12-25))"
+            if bodosql.use_cpp_backend
+            else "Runtime join filter expression: ((ds.field('{DAY}') >= pa.scalar(18672, pa.date32())) & (ds.field('{DAY}') <= pa.scalar(18986, pa.date32())))"
+        )
 
     with temp_env_override({"BODO_JOIN_UNIQUE_VALUES_LIMIT": str(limit)}):
-        with set_logging_stream(logger, 2):
-            check_func(
-                impl,
-                (bc, query),
-                py_output=py_output,
-                only_1DVar=True,
-                sort_output=True,
-                reset_index=True,
-            )
-            check_logger_msg(
-                stream,
-                log_msg,
-            )
-            check_logger_msg(stream, "Total number of files is 3. Reading 1 files:")
+        with temp_config_override("dataframe_library_run_parallel", False):
+            with set_logging_stream(logger, 2):
+                check_func(
+                    impl,
+                    (bc, query),
+                    py_output=py_output,
+                    only_1DVar=True,
+                    sort_output=True,
+                    reset_index=True,
+                )
+                check_logger_msg(
+                    stream,
+                    log_msg,
+                )
+                check_logger_msg(stream, "Total number of files is 3. Reading 1 files:")
 
 
 @pytest.mark.parametrize(
     "allow_low_ndv_filter",
     [
         pytest.param(True, id="low_ndv"),
-        pytest.param(False, id="min_max"),
+        pytest.param(False, id="min_max", marks=pytest.mark.bodosql_cpp),
     ],
 )
 def test_float_keys(allow_low_ndv_filter, iceberg_database, memory_leak_check):
@@ -699,22 +706,27 @@ def test_float_keys(allow_low_ndv_filter, iceberg_database, memory_leak_check):
         log_msg = "Runtime join filter expression: ((ds.field('{BALANCE}').isin([0.0, 375000.81, 488000.09, 78125.42])))"
     else:
         limit = 0
-        log_msg = "Runtime join filter expression: ((ds.field('{BALANCE}') >= 0.0) & (ds.field('{BALANCE}') <= 488000.09))"
+        log_msg = (
+            "Runtime join filter expression: ((ds.field('{BALANCE}') >= 0) & (ds.field('{BALANCE}') <= 488000.09))"
+            if bodosql.use_cpp_backend
+            else "Runtime join filter expression: ((ds.field('{BALANCE}') >= 0.0) & (ds.field('{BALANCE}') <= 488000.09))"
+        )
 
     with temp_env_override({"BODO_JOIN_UNIQUE_VALUES_LIMIT": str(limit)}):
-        with set_logging_stream(logger, 2):
-            check_func(
-                impl,
-                (bc, query),
-                py_output=py_output,
-                only_1DVar=True,
-                sort_output=True,
-                reset_index=True,
-            )
-            check_logger_msg(
-                stream,
-                log_msg,
-            )
+        with temp_config_override("dataframe_library_run_parallel", False):
+            with set_logging_stream(logger, 2):
+                check_func(
+                    impl,
+                    (bc, query),
+                    py_output=py_output,
+                    only_1DVar=True,
+                    sort_output=True,
+                    reset_index=True,
+                )
+                check_logger_msg(
+                    stream,
+                    log_msg,
+                )
 
 
 def test_interval_join_rtjf(memory_leak_check, iceberg_database):

--- a/bodo/io/iceberg/common.py
+++ b/bodo/io/iceberg/common.py
@@ -256,11 +256,14 @@ def pyiceberg_filter_to_pyarrow_format_str_and_scalars(
     return visit(bound_expr, _ConvertToArrowExpressionStringAndScalar())
 
 
-def log_filter_expressions(
+def log_rtjf_expressions(
     filter_cols: list[int],
     min_max_values: list[tuple[pa.Scalar, pa.Scalar]],
     schema: pa.Schema,
 ) -> None:
+    """
+    Log Iceberg runtime join filter expressions for DataFrame library and C++ backend.
+    """
     named_cols: list[str] = [schema.field(i).name for i in filter_cols]
 
     print("Received filter_cols:", named_cols, min_max_values)

--- a/bodo/io/iceberg/common.py
+++ b/bodo/io/iceberg/common.py
@@ -16,6 +16,7 @@ from bodo.spawn.utils import run_rank0
 if pt.TYPE_CHECKING:  # pragma: no cover
     from typing import Any
 
+    import pyarrow as pa
     from pyiceberg.expressions import BooleanExpression
     from pyiceberg.io import FileIO
     from pyiceberg.schema import Schema
@@ -253,3 +254,13 @@ def pyiceberg_filter_to_pyarrow_format_str_and_scalars(
     bound_expr = bind(schema, expr, case_sensitive=case_sensitive)
 
     return visit(bound_expr, _ConvertToArrowExpressionStringAndScalar())
+
+
+def log_filter_expressions(
+    filter_cols: list[int],
+    min_max_values: list[tuple[pa.Scalar, pa.Scalar]],
+    schema: pa.Schema,
+) -> None:
+    named_cols: list[str] = [schema.field(i).name for i in filter_cols]
+
+    print("Received filter_cols:", named_cols, min_max_values)

--- a/bodo/io/iceberg/common.py
+++ b/bodo/io/iceberg/common.py
@@ -16,7 +16,6 @@ from bodo.spawn.utils import run_rank0
 if pt.TYPE_CHECKING:  # pragma: no cover
     from typing import Any
 
-    import pyarrow as pa
     from pyiceberg.expressions import BooleanExpression
     from pyiceberg.io import FileIO
     from pyiceberg.schema import Schema
@@ -254,16 +253,3 @@ def pyiceberg_filter_to_pyarrow_format_str_and_scalars(
     bound_expr = bind(schema, expr, case_sensitive=case_sensitive)
 
     return visit(bound_expr, _ConvertToArrowExpressionStringAndScalar())
-
-
-def log_rtjf_expressions(
-    filter_cols: list[int],
-    min_max_values: list[tuple[pa.Scalar, pa.Scalar]],
-    schema: pa.Schema,
-) -> None:
-    """
-    Log Iceberg runtime join filter expressions for DataFrame library and C++ backend.
-    """
-    named_cols: list[str] = [schema.field(i).name for i in filter_cols]
-
-    print("Received filter_cols:", named_cols, min_max_values)

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1298,6 +1298,86 @@ duckdb::unique_ptr<duckdb::TableFilterSet> JoinFilterColStats::insert_filters(
     return filters;
 }
 
+void log_rtjf_expressions(JoinFilterColStats &join_filter_col_stats,
+                          const std::shared_ptr<arrow::Schema> &schema,
+                          std::string header) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank != 0) {
+        return;
+    }
+
+    auto [filter_cols, filter_col_stats] =
+        join_filter_col_stats.get_col_stats_for_join_filter_cols();
+
+    std::ostringstream expr_stream;
+    expr_stream << "Runtime join filter expression: ";
+    bool first_expr = true;
+
+    for (size_t i = 0; i < filter_cols.size(); ++i) {
+        const auto column_index = filter_cols[i];
+        const std::string &column_name = schema->field(column_index)->name();
+
+        for (const auto &[min_value, max_value] : filter_col_stats[i]) {
+            if (!first_expr) {
+                expr_stream << " & ";
+            }
+            first_expr = false;
+
+            expr_stream << "(ds.field('" << column_name
+                        << "') >= " << min_value->ToString() << " & ds.field('"
+                        << column_name << "') <= " << max_value->ToString()
+                        << ")";
+        }
+    }
+
+    if (first_expr) {
+        expr_stream << "True";
+    }
+    const std::string rtjf_str = expr_stream.str();
+
+    PyGILState_STATE gil = PyGILState_Ensure();
+
+    try {
+        PyObjectPtr module(PyImport_ImportModule("bodo.user_logging"));
+        if (!module) {
+            throw std::runtime_error("Failed to import bodo.user_logging");
+        }
+
+        PyObjectPtr func(
+            PyObject_GetAttrString(module.get(), "log_if_verbose"));
+        if (!func || !PyCallable_Check(func.get())) {
+            throw std::runtime_error(
+                "bodo.user_logging.log_if_verbose is not callable");
+        }
+
+        PyObjectPtr py_level(PyLong_FromLongLong(2));
+        PyObjectPtr py_header(PyUnicode_FromString(header.c_str()));
+        PyObjectPtr py_message(PyUnicode_FromStringAndSize(
+            rtjf_str.data(), static_cast<Py_ssize_t>(rtjf_str.size())));
+
+        if (!py_level || !py_header || !py_message) {
+            throw std::runtime_error("Failed to create logging arguments");
+        }
+
+        PyObjectPtr result(PyObject_CallFunctionObjArgs(
+            func.get(), py_level.get(), py_header.get(), py_message.get(),
+            nullptr));
+
+        if (!result) {
+            throw std::runtime_error("log_if_verbose() failed");
+        }
+    } catch (...) {
+        if (PyErr_Occurred()) {
+            PyErr_Print();
+        }
+        PyGILState_Release(gil);
+        throw;
+    }
+
+    PyGILState_Release(gil);
+}
+
 void assert_py_args_is_tuple(PyObject *args, const char *err_context) {
     if (!PyTuple_Check(args)) {
         throw std::runtime_error(fmt::format("Args for {} is not a tuple.",

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1183,6 +1183,18 @@ JoinFilterColStats::col_stats_collector::collect_min_max() const {
         join_state);
 }
 
+std::pair<std::vector<int>,
+          std::vector<std::vector<JoinFilterColStats::col_min_max_t>>>
+JoinFilterColStats::get_col_stats_for_join_filter_cols() {
+    std::vector<int> filter_cols;
+    std::vector<std::vector<col_min_max_t>> filter_col_stats;
+    for (const auto &[col_idx, min_max_vec] : this->collect_all()) {
+        filter_cols.push_back(col_idx);
+        filter_col_stats.push_back(min_max_vec);
+    }
+    return std::make_pair(filter_cols, filter_col_stats);
+}
+
 std::unordered_map<int, std::vector<JoinFilterColStats::col_min_max_t>>
 JoinFilterColStats::collect_all() {
     // Cache the collection

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1300,6 +1300,7 @@ duckdb::unique_ptr<duckdb::TableFilterSet> JoinFilterColStats::insert_filters(
 
 void log_rtjf_expressions(JoinFilterColStats &join_filter_col_stats,
                           const std::shared_ptr<arrow::Schema> &schema,
+                          const std::vector<int> column_projection,
                           std::string header) {
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -1311,11 +1312,11 @@ void log_rtjf_expressions(JoinFilterColStats &join_filter_col_stats,
         join_filter_col_stats.get_col_stats_for_join_filter_cols();
 
     std::ostringstream expr_stream;
-    expr_stream << "Runtime join filter expression: ";
+    std::string expr_prefix = "Runtime join filter expression: ";
     bool first_expr = true;
 
     for (size_t i = 0; i < filter_cols.size(); ++i) {
-        const auto column_index = filter_cols[i];
+        const auto column_index = column_projection[filter_cols[i]];
         const std::string &column_name = schema->field(column_index)->name();
 
         for (const auto &[min_value, max_value] : filter_col_stats[i]) {
@@ -1324,17 +1325,15 @@ void log_rtjf_expressions(JoinFilterColStats &join_filter_col_stats,
             }
             first_expr = false;
 
-            expr_stream << "(ds.field('" << column_name
-                        << "') >= " << min_value->ToString() << " & ds.field('"
-                        << column_name << "') <= " << max_value->ToString()
-                        << ")";
+            expr_stream << "(ds.field('{" << column_name
+                        << "}') >= " << min_value->ToString()
+                        << ") & (ds.field('{" << column_name
+                        << "}') <= " << max_value->ToString() << ")";
         }
     }
 
-    if (first_expr) {
-        expr_stream << "True";
-    }
-    const std::string rtjf_str = expr_stream.str();
+    const std::string rtjf_str =
+        expr_prefix + (first_expr ? "True" : "(" + expr_stream.str() + ")");
 
     PyGILState_STATE gil = PyGILState_Ensure();
 

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -457,6 +457,17 @@ class JoinFilterColStats {
 };
 
 /**
+ * @brief Log runtime join filter expressions on rank 0.
+ *
+ * @param join_filter_col_stats JoinFilterColStats object containing the column
+ * statistics
+ * @param schema Arrow schema associated with the join filter columns
+ */
+void log_rtjf_expressions(JoinFilterColStats &join_filter_col_stats,
+                          const std::shared_ptr<arrow::Schema> &schema,
+                          std::string header = "Iceberg I/O");
+
+/**
  * @brief Assert that the Python objects arguments is a tuple
  *
  * @param args Python tuple containing the function arguments

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -462,10 +462,13 @@ class JoinFilterColStats {
  * @param join_filter_col_stats JoinFilterColStats object containing the column
  * statistics
  * @param schema Arrow schema associated with the join filter columns
+ * @param column_projection Column projection mapping to align filters with
+ * @param header Header string for the log message
  */
 void log_rtjf_expressions(JoinFilterColStats &join_filter_col_stats,
                           const std::shared_ptr<arrow::Schema> &schema,
-                          std::string header = "Iceberg I/O");
+                          const std::vector<int> column_projection,
+                          std::string header);
 
 /**
  * @brief Assert that the Python objects arguments is a tuple

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -432,6 +432,17 @@ class JoinFilterColStats {
           join_filter_program_state(std::move(rtjf_state_map)) {}
     JoinFilterColStats() = default;
 
+    /** @brief Get the column statistics for join filter columns
+     *
+     * @return A tuple containing two vectors:
+     *         - The first vector contains the column indices of the join filter
+     * columns.
+     *         - The second vector contains the corresponding min/max statistics
+     * for each column.
+     */
+    std::pair<std::vector<int>, std::vector<std::vector<col_min_max_t>>>
+    get_col_stats_for_join_filter_cols();
+
     /**
      * @brief Insert collected min/max statistics as table filters into the
      * provided duckdb TableFilterSet for the specified column projection.

--- a/bodo/pandas/physical/gpu_read_iceberg.cpp
+++ b/bodo/pandas/physical/gpu_read_iceberg.cpp
@@ -1249,7 +1249,8 @@ void PhysicalGPUReadIceberg::init_batch_gen() {
     this->filter_exprs = this->join_filter_col_stats.insert_filters(
         std::move(this->filter_exprs), this->selected_columns);
 
-    log_rtjf_expressions(join_filter_col_stats, arrow_schema);
+    log_rtjf_expressions(join_filter_col_stats, arrow_schema, selected_columns,
+                         "Iceberg I/O");
 
     batch_gen = std::make_shared<GPUIcebergRankBatchGenerator>(
         catalog, table_id, iceberg_filter, iceberg_schema, arrow_schema,

--- a/bodo/pandas/physical/gpu_read_iceberg.cpp
+++ b/bodo/pandas/physical/gpu_read_iceberg.cpp
@@ -1248,6 +1248,9 @@ void PhysicalGPUReadIceberg::init_batch_gen() {
     int batch_size = get_gpu_streaming_batch_size();
     this->filter_exprs = this->join_filter_col_stats.insert_filters(
         std::move(this->filter_exprs), this->selected_columns);
+
+    log_rtjf_expressions(join_filter_col_stats, arrow_schema);
+
     batch_gen = std::make_shared<GPUIcebergRankBatchGenerator>(
         catalog, table_id, iceberg_filter, iceberg_schema, arrow_schema,
         snapshot_id, selected_columns, std::move(filter_exprs), batch_size,

--- a/bodo/pandas/physical/read_iceberg.cpp
+++ b/bodo/pandas/physical/read_iceberg.cpp
@@ -108,6 +108,16 @@ std::vector<std::string> PhysicalReadIceberg::create_out_column_names(
     return out_column_names;
 }
 
+void log_filter_expressions(JoinFilterColStats &join_filter_col_stats,
+                            const std::shared_ptr<arrow::Schema> &schema) {
+    auto [filter_cols, filter_col_stats] =
+        join_filter_col_stats.get_col_stats_for_join_filter_cols();
+
+    // convert filter cols and filter col stats to PyObjects
+    // call Python logging function
+    /// ...
+}
+
 std::unique_ptr<IcebergParquetReader>
 PhysicalReadIceberg::create_internal_reader() {
     // Pipeline buffers assume everything is nullable
@@ -116,6 +126,8 @@ PhysicalReadIceberg::create_internal_reader() {
     // Insert join filter min/max stats into the duckdb table filters
     this->filter_exprs = join_filter_col_stats.insert_filters(
         std::move(this->filter_exprs), this->selected_columns);
+
+    log_filter_expressions(join_filter_col_stats, arrow_schema);
 
     // We need to & the iceberg_filter with converted duckdb table filters
     // to apply the filters at the file level.

--- a/bodo/pandas/physical/read_iceberg.cpp
+++ b/bodo/pandas/physical/read_iceberg.cpp
@@ -108,103 +108,6 @@ std::vector<std::string> PhysicalReadIceberg::create_out_column_names(
     return out_column_names;
 }
 
-void log_filter_expressions(JoinFilterColStats &join_filter_col_stats,
-                            const std::shared_ptr<arrow::Schema> &schema) {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if (rank != 0) {
-        return;
-    }
-
-    auto [filter_cols, filter_col_stats] =
-        join_filter_col_stats.get_col_stats_for_join_filter_cols();
-
-    PyObjectPtr pyarrow_schema = arrow::py::wrap_schema(schema);
-    if (!pyarrow_schema) {
-        throw std::runtime_error("Failed to wrap Arrow schema");
-    }
-
-    // convert filter cols and filter col stats to PyObjects
-    // call Python logging function
-    PyObjectPtr py_cols = PyList_New(filter_cols.size());
-    if (!py_cols) {
-        throw std::runtime_error("Failed to allocate py_cols");
-    }
-
-    for (size_t i = 0; i < filter_cols.size(); ++i) {
-        PyObjectPtr item = PyLong_FromLongLong(filter_cols[i]);
-        if (!item) {
-            throw std::runtime_error("Failed to create int");
-        }
-        PyList_SET_ITEM(py_cols.get(), i, item.release());
-    }
-
-    PyObjectPtr py_pairs_lists = PyList_New(filter_col_stats.size());
-    if (!py_pairs_lists) {
-        throw std::runtime_error("Failed to allocate py_pairs_lists");
-    }
-
-    for (size_t i = 0; i < filter_col_stats.size(); ++i) {
-        const auto &min_max_pairs = filter_col_stats[i];
-        PyObjectPtr py_pairs = PyList_New(min_max_pairs.size());
-        if (!py_pairs) {
-            throw std::runtime_error("Failed to allocate py_pairs");
-        }
-
-        for (size_t j = 0; j < min_max_pairs.size(); ++j) {
-            const auto &min_max = min_max_pairs[j];
-
-            PyObjectPtr left = arrow::py::wrap_scalar(min_max.first);
-            PyObjectPtr right = arrow::py::wrap_scalar(min_max.second);
-
-            if (!left || !right) {
-                throw std::runtime_error("Failed to wrap Arrow scalar");
-            }
-
-            PyObjectPtr tuple = PyTuple_New(2);
-            if (!tuple) {
-                throw std::runtime_error("Failed to allocate tuple");
-            }
-
-            PyTuple_SET_ITEM(tuple.get(), 0, left.release());
-            PyTuple_SET_ITEM(tuple.get(), 1, right.release());
-
-            PyList_SET_ITEM(py_pairs.get(), j, tuple.release());
-        }
-        PyList_SET_ITEM(py_pairs_lists.get(), i, py_pairs.release());
-    }
-
-    PyGILState_STATE gil = PyGILState_Ensure();
-    try {
-        PyObjectPtr module(PyImport_ImportModule("bodo.io.iceberg.common"));
-        if (!module) {
-            PyErr_Print();
-            throw std::runtime_error("Failed to import bodo.io.iceberg.common");
-        }
-
-        PyObjectPtr func(
-            PyObject_GetAttrString(module.get(), "log_rtjf_expressions"));
-        if (!func || !PyCallable_Check(func.get())) {
-            PyErr_Print();
-            throw std::runtime_error(
-                "bodo.io.iceberg.common.log_rtjf_expressions is not callable");
-        }
-
-        PyObjectPtr result(PyObject_CallFunctionObjArgs(
-            func.get(), py_cols.get(), py_pairs_lists.get(),
-            pyarrow_schema.get(), nullptr));
-
-        if (!result) {
-            PyErr_Print();
-            throw std::runtime_error("log_rtjf_expressions() failed");
-        }
-    } catch (...) {
-        PyGILState_Release(gil);
-        throw;
-    }
-    PyGILState_Release(gil);
-}
-
 std::unique_ptr<IcebergParquetReader>
 PhysicalReadIceberg::create_internal_reader() {
     // Pipeline buffers assume everything is nullable
@@ -214,7 +117,7 @@ PhysicalReadIceberg::create_internal_reader() {
     this->filter_exprs = join_filter_col_stats.insert_filters(
         std::move(this->filter_exprs), this->selected_columns);
 
-    log_filter_expressions(join_filter_col_stats, arrow_schema);
+    log_rtjf_expressions(join_filter_col_stats, arrow_schema);
 
     // We need to & the iceberg_filter with converted duckdb table filters
     // to apply the filters at the file level.

--- a/bodo/pandas/physical/read_iceberg.cpp
+++ b/bodo/pandas/physical/read_iceberg.cpp
@@ -115,7 +115,54 @@ void log_filter_expressions(JoinFilterColStats &join_filter_col_stats,
 
     // convert filter cols and filter col stats to PyObjects
     // call Python logging function
-    /// ...
+    // TODO(scott): Avoid passing Pyarrow objects to Python
+    PyObjectPtr py_cols = PyList_New(filter_cols.size());
+    if (!py_cols) {
+        throw std::runtime_error("Failed to allocate py_cols");
+    }
+
+    for (size_t i = 0; i < filter_cols.size(); ++i) {
+        PyObjectPtr item = PyLong_FromLongLong(filter_cols[i]);
+        if (!item) {
+            throw std::runtime_error("Failed to create int");
+        }
+        PyList_SET_ITEM(py_cols.get(), i, item.release());
+    }
+
+    PyObjectPtr py_pairs_lists = PyList_New(filter_col_stats.size());
+    if (!py_pairs_lists) {
+        throw std::runtime_error("Failed to allocate py_pairs_lists");
+    }
+
+    for (size_t i = 0; i < filter_col_stats.size(); ++i) {
+        const auto &min_max_pairs = filter_col_stats[i];
+        PyObjectPtr py_pairs = PyList_New(min_max_pairs.size());
+        if (!py_pairs) {
+            throw std::runtime_error("Failed to allocate py_pairs");
+        }
+
+        for (size_t j = 0; j < min_max_pairs.size(); ++j) {
+            const auto &min_max = min_max_pairs[j];
+
+            PyObjectPtr left = arrow::py::wrap_scalar(min_max.first);
+            PyObjectPtr right = arrow::py::wrap_scalar(min_max.second);
+
+            if (!left || !right) {
+                throw std::runtime_error("Failed to wrap Arrow scalar");
+            }
+
+            PyObjectPtr tuple = PyTuple_New(2);
+            if (!tuple) {
+                throw std::runtime_error("Failed to allocate tuple");
+            }
+
+            PyTuple_SET_ITEM(tuple.get(), 0, left.release());
+            PyTuple_SET_ITEM(tuple.get(), 1, right.release());
+
+            PyList_SET_ITEM(py_pairs.get(), j, tuple.release());
+        }
+        PyList_SET_ITEM(py_pairs_lists.get(), i, py_pairs.release());
+    }
 }
 
 std::unique_ptr<IcebergParquetReader>

--- a/bodo/pandas/physical/read_iceberg.cpp
+++ b/bodo/pandas/physical/read_iceberg.cpp
@@ -110,12 +110,22 @@ std::vector<std::string> PhysicalReadIceberg::create_out_column_names(
 
 void log_filter_expressions(JoinFilterColStats &join_filter_col_stats,
                             const std::shared_ptr<arrow::Schema> &schema) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank != 0) {
+        return;
+    }
+
     auto [filter_cols, filter_col_stats] =
         join_filter_col_stats.get_col_stats_for_join_filter_cols();
 
+    PyObjectPtr pyarrow_schema = arrow::py::wrap_schema(schema);
+    if (!pyarrow_schema) {
+        throw std::runtime_error("Failed to wrap Arrow schema");
+    }
+
     // convert filter cols and filter col stats to PyObjects
     // call Python logging function
-    // TODO(scott): Avoid passing Pyarrow objects to Python
     PyObjectPtr py_cols = PyList_New(filter_cols.size());
     if (!py_cols) {
         throw std::runtime_error("Failed to allocate py_cols");
@@ -163,6 +173,36 @@ void log_filter_expressions(JoinFilterColStats &join_filter_col_stats,
         }
         PyList_SET_ITEM(py_pairs_lists.get(), i, py_pairs.release());
     }
+
+    PyGILState_STATE gil = PyGILState_Ensure();
+    try {
+        PyObjectPtr module(PyImport_ImportModule("bodo.io.iceberg.common"));
+        if (!module) {
+            PyErr_Print();
+            throw std::runtime_error("Failed to import bodo.io.iceberg.common");
+        }
+
+        PyObjectPtr func(
+            PyObject_GetAttrString(module.get(), "log_rtjf_expressions"));
+        if (!func || !PyCallable_Check(func.get())) {
+            PyErr_Print();
+            throw std::runtime_error(
+                "bodo.io.iceberg.common.log_rtjf_expressions is not callable");
+        }
+
+        PyObjectPtr result(PyObject_CallFunctionObjArgs(
+            func.get(), py_cols.get(), py_pairs_lists.get(),
+            pyarrow_schema.get(), nullptr));
+
+        if (!result) {
+            PyErr_Print();
+            throw std::runtime_error("log_rtjf_expressions() failed");
+        }
+    } catch (...) {
+        PyGILState_Release(gil);
+        throw;
+    }
+    PyGILState_Release(gil);
 }
 
 std::unique_ptr<IcebergParquetReader>

--- a/bodo/pandas/physical/read_iceberg.cpp
+++ b/bodo/pandas/physical/read_iceberg.cpp
@@ -117,7 +117,8 @@ PhysicalReadIceberg::create_internal_reader() {
     this->filter_exprs = join_filter_col_stats.insert_filters(
         std::move(this->filter_exprs), this->selected_columns);
 
-    log_rtjf_expressions(join_filter_col_stats, arrow_schema);
+    log_rtjf_expressions(join_filter_col_stats, arrow_schema, selected_columns,
+                         "Iceberg I/O");
 
     // We need to & the iceberg_filter with converted duckdb table filters
     // to apply the filters at the file level.

--- a/bodo/tests/test_iceberg/conftest.py
+++ b/bodo/tests/test_iceberg/conftest.py
@@ -443,7 +443,7 @@ def polaris_connection(
         raise ValueError(f"Unknown polaris warehouse: {request.param}")
 
 
-# For cases where we can't used parameterized fixuteres like the ddl test harness
+# For cases where we can't used parameterized fixtures like the ddl test harness
 @pytest.fixture
 def aws_polaris_connection(polaris_server, aws_polaris_warehouse):
     host, port, user, password = polaris_server

--- a/bodo/user_logging.py
+++ b/bodo/user_logging.py
@@ -120,3 +120,12 @@ def log_message(header, msg, *args, **kws):
         equal_str = "\n" + ("=" * 80)
         final_msg = "\n".join([equal_str, header.center(80, "-"), msg, equal_str])
         logger.info(final_msg, *args, **kws)
+
+
+def log_if_verbose(level, header, msg, *args, **kws):
+    """
+    Logs a message to the Bodo logger using logger.info if the
+    current verbose level is >= level.
+    """
+    if get_verbose_level() >= level:
+        log_message(header, msg, *args, **kws)


### PR DESCRIPTION
## Changes included in this PR

Turn min/max filters pushed down to Iceberg I/O into strings we log messages and check for in join filter tests of the C++ backend.

## Testing strategy

Most runtime join filter for filesystem catalog are now enabled. 

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.