### PR TITLE
[BSE-5509] Support IS FALSE and IS NOT FALSE in C++ backend

### DIFF
--- a/BodoSQL/bodosql/context.py
+++ b/BodoSQL/bodosql/context.py
@@ -728,6 +728,7 @@ class BodoSQLContext:
             # filter translation during conversion to Python plan.
             self.join_filter_info = {}
             plan = java_plan_to_python_plan(self, java_plan)
+            print(plan)
             if isinstance(plan, self.NewTable):
                 out = bodo.pandas.plan.execute_plan(
                     plan.internal_plan, optimize=False, use_sql_rules=True

--- a/BodoSQL/bodosql/context.py
+++ b/BodoSQL/bodosql/context.py
@@ -728,7 +728,6 @@ class BodoSQLContext:
             # filter translation during conversion to Python plan.
             self.join_filter_info = {}
             plan = java_plan_to_python_plan(self, java_plan)
-            print(plan)
             if isinstance(plan, self.NewTable):
                 out = bodo.pandas.plan.execute_plan(
                     plan.internal_plan, optimize=False, use_sql_rules=True

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -1930,6 +1930,14 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             return UnaryOpExpression(bool_empty_data, input, "isnottrue")
 
+        if kind.equals(SqlKind.IS_FALSE):
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            return UnaryOpExpression(bool_empty_data, input, "isfalse")
+
+        if kind.equals(SqlKind.IS_NOT_FALSE):
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            return UnaryOpExpression(bool_empty_data, input, "isnotfalse")
+
     if operator_class_name == "SqlCaseOperator":
         operands = java_call.getOperands()
         kind = op.getKind()

--- a/BodoSQL/bodosql/tests/test_logical_comparisons.py
+++ b/BodoSQL/bodosql/tests/test_logical_comparisons.py
@@ -6,6 +6,8 @@ import pytest
 
 from bodosql.tests.utils import check_query
 
+pytestmark = pytest.mark.bodosql_cpp
+
 
 def test_logical_or_columns(bodosql_boolean_types, memory_leak_check):
     """insures that logical logical or works  correctly for columns of boolean values"""
@@ -97,7 +99,6 @@ def test_logical_is_scalars(
     )
 
 
-@pytest.mark.slow
 def test_is_logical_not_columns(
     bodosql_boolean_types, is_clause_literal_values, memory_leak_check
 ):

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -400,8 +400,6 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
         client_context->transaction.BeginTransaction();
         started_transaction = true;
     }
-    std::cout << "make_unaryop_expr: looking up function for operator " << opstr
-              << std::endl;
     duckdb::EntryLookupInfo function_lookup(
         duckdb::CatalogType::SCALAR_FUNCTION_ENTRY, opstr, error_context);
     duckdb::shared_ptr<duckdb::Binder> binder = get_duckdb_binder();

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -400,6 +400,8 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
         client_context->transaction.BeginTransaction();
         started_transaction = true;
     }
+    std::cout << "make_unaryop_expr: looking up function for operator " << opstr
+              << std::endl;
     duckdb::EntryLookupInfo function_lookup(
         duckdb::CatalogType::SCALAR_FUNCTION_ENTRY, opstr, error_context);
     duckdb::shared_ptr<duckdb::Binder> binder = get_duckdb_binder();
@@ -492,6 +494,8 @@ duckdb::unique_ptr<duckdb::Expression> make_unary_expr(
         case duckdb::ExpressionType::OPERATOR_NOT:
         case duckdb::ExpressionType::OPERATOR_IS_TRUE:
         case duckdb::ExpressionType::OPERATOR_IS_NOT_TRUE:
+        case duckdb::ExpressionType::OPERATOR_IS_FALSE:
+        case duckdb::ExpressionType::OPERATOR_IS_NOT_FALSE:
         case duckdb::ExpressionType::OPERATOR_IS_NULL:
         case duckdb::ExpressionType::OPERATOR_IS_NOT_NULL: {
             auto ret = duckdb::make_uniq<duckdb::BoundOperatorExpression>(

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -612,7 +612,7 @@ arrow::Datum do_arrow_compute_unary(
         }
 
         // is_not_true: Invert so that null/false -> true and true -> false.
-        // is_false: Invert so that null/true -> true and true -> false.
+        // is_false: Invert so that null/true -> false and true -> false.
         if (invert) {
             result =
                 arrow::compute::CallFunction("invert", {result.ValueOrDie()});

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -592,27 +592,37 @@ arrow::Datum do_arrow_compute_unary(
         return is_true_res.ValueOrDie();
     }
 
-    // Special handling for is_not_true since it is not supported directly
-    // by Arrow compute.
-    if (comparator == "is_not_true") {
-        auto arrow_false = arrow::MakeScalar(false);
-        arrow::Result<arrow::Datum> coalesce_res = arrow::compute::CallFunction(
-            "coalesce", {src1, arrow_false}, func_options);
-        if (!coalesce_res.ok()) [[unlikely]] {
+    // Special handling for is_true, is_not_true, is_false, is_not_false since
+    // they are not supported directly by Arrow compute.
+    if (comparator == "is_true" || comparator == "is_not_true" ||
+        comparator == "is_false" || comparator == "is_not_false") {
+        const bool test_true =
+            comparator == "is_true" || comparator == "is_not_true";
+        const bool invert =
+            comparator == "is_not_true" || comparator == "is_false";
+
+        auto na_fill_value = arrow::MakeScalar(test_true ? false : true);
+
+        arrow::Result<arrow::Datum> result = arrow::compute::CallFunction(
+            "coalesce", {src1, na_fill_value}, func_options);
+        if (!result.ok()) [[unlikely]] {
             throw std::runtime_error(
                 "do_arrow_compute_unary: Error in Arrow compute: " +
-                coalesce_res.status().message());
+                result.status().message());
         }
 
-        // Invert so that null/false -> true and true -> false.
-        arrow::Result<arrow::Datum> invert_res =
-            arrow::compute::CallFunction("invert", {coalesce_res.ValueOrDie()});
-        if (!invert_res.ok()) [[unlikely]] {
-            throw std::runtime_error(
-                "do_arrow_compute_unary: Error in Arrow compute Invert: " +
-                invert_res.status().message());
+        // is_not_true: Invert so that null/false -> true and true -> false.
+        // is_false: Invert so that null/true -> true and true -> false.
+        if (invert) {
+            result =
+                arrow::compute::CallFunction("invert", {result.ValueOrDie()});
+            if (!result.ok()) [[unlikely]] {
+                throw std::runtime_error(
+                    "do_arrow_compute_unary: Error in Arrow compute Invert: " +
+                    result.status().message());
+            }
         }
-        return invert_res.ValueOrDie();
+        return result.ValueOrDie();
     }
 
     arrow::Result<arrow::Datum> cmp_res =

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -578,20 +578,6 @@ arrow::Datum do_arrow_compute_unary(
         return invert_res.ValueOrDie();
     }
 
-    // Special handling for is_true since it is not supported directly
-    // by Arrow compute.
-    if (comparator == "is_true") {
-        auto arrow_false = arrow::MakeScalar(false);
-        arrow::Result<arrow::Datum> is_true_res = arrow::compute::CallFunction(
-            "coalesce", {src1, arrow_false}, func_options);
-        if (!is_true_res.ok()) [[unlikely]] {
-            throw std::runtime_error(
-                "do_arrow_compute_unary: Error in Arrow compute: " +
-                is_true_res.status().message());
-        }
-        return is_true_res.ValueOrDie();
-    }
-
     // Special handling for is_true, is_not_true, is_false, is_not_false since
     // they are not supported directly by Arrow compute.
     if (comparator == "is_true" || comparator == "is_not_true" ||

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -888,6 +888,12 @@ class PhysicalUnaryExpression : public PhysicalExpression {
             case duckdb::ExpressionType::OPERATOR_IS_NOT_TRUE:
                 comparator = "is_not_true";
                 break;
+            case duckdb::ExpressionType::OPERATOR_IS_FALSE:
+                comparator = "is_false";
+                break;
+            case duckdb::ExpressionType::OPERATOR_IS_NOT_FALSE:
+                comparator = "is_not_false";
+                break;
             case duckdb::ExpressionType::OPERATOR_NEG:
                 comparator = "negate";
                 break;

--- a/bodo/pandas/physical/project_utils.h
+++ b/bodo/pandas/physical/project_utils.h
@@ -3,7 +3,6 @@
 #include <arrow/api.h>
 #include <arrow/type.h>
 #include <arrow/type_traits.h>
-#include <stdexcept>
 #include "../_util.h"
 
 /**

--- a/bodo/pandas/physical/project_utils.h
+++ b/bodo/pandas/physical/project_utils.h
@@ -3,6 +3,7 @@
 #include <arrow/api.h>
 #include <arrow/type.h>
 #include <arrow/type_traits.h>
+#include <stdexcept>
 #include "../_util.h"
 
 /**
@@ -208,6 +209,36 @@ inline std::shared_ptr<bodo::Schema> getProjectionOutputSchema(
                 col_names.emplace_back(input_schema->column_names[0]);
             } else {
                 col_names.emplace_back("NEGATE");
+            }
+        } else if (expr->type == duckdb::ExpressionType::OPERATOR_IS_TRUE ||
+                   expr->type == duckdb::ExpressionType::OPERATOR_IS_NOT_TRUE ||
+                   expr->type == duckdb::ExpressionType::OPERATOR_IS_FALSE ||
+                   expr->type ==
+                       duckdb::ExpressionType::OPERATOR_IS_NOT_FALSE) {
+            auto col_type = arrow_type_to_bodo_data_type(
+                                duckdbTypeToArrow(duckdb::LogicalType::BOOLEAN))
+                                ->copy();
+            output_schema->append_column(std::move(col_type));
+
+            if (!input_schema->column_names.empty()) {
+                col_names.emplace_back(input_schema->column_names[0]);
+            } else {
+                switch (expr->type) {
+                    case duckdb::ExpressionType::OPERATOR_IS_TRUE:
+                        col_names.emplace_back("is_true");
+                        break;
+                    case duckdb::ExpressionType::OPERATOR_IS_NOT_TRUE:
+                        col_names.emplace_back("is_not_true");
+                        break;
+                    case duckdb::ExpressionType::OPERATOR_IS_FALSE:
+                        col_names.emplace_back("is_false");
+                        break;
+                    case duckdb::ExpressionType::OPERATOR_IS_NOT_FALSE:
+                        col_names.emplace_back("is_not_false");
+                        break;
+                    default:
+                        throw std::runtime_error("Unexpected expression type");
+                }
             }
         } else {
             throw std::runtime_error(

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -154,6 +154,8 @@ cdef extern from "duckdb/common/enums/expression_type.hpp" namespace "duckdb" no
         BOUND_EXPANDED "duckdb::ExpressionType::BOUND_EXPANDED"
         OPERATOR_IS_TRUE "duckdb::ExpressionType::OPERATOR_IS_TRUE"
         OPERATOR_IS_NOT_TRUE "duckdb::ExpressionType::OPERATOR_IS_NOT_TRUE"
+        OPERATOR_IS_FALSE "duckdb::ExpressionType::OPERATOR_IS_FALSE"
+        OPERATOR_IS_NOT_FALSE "duckdb::ExpressionType::OPERATOR_IS_NOT_FALSE"
         OPERATOR_NEG "duckdb::ExpressionType::OPERATOR_NEG"
 
 
@@ -186,6 +188,10 @@ def str_to_expr_type(val):
         return CExpressionType.OPERATOR_IS_TRUE
     elif val == "isnottrue":
         return CExpressionType.OPERATOR_IS_NOT_TRUE
+    elif val == "isfalse":
+        return CExpressionType.OPERATOR_IS_FALSE
+    elif val == "isnotfalse":
+        return CExpressionType.OPERATOR_IS_NOT_FALSE
     else:
         raise NotImplementedError(f"Unhandled case {str(val)} in str_to_expr_type")
 

--- a/bodo/pandas/vendor/duckdb/src/common/enums/expression_type.cpp
+++ b/bodo/pandas/vendor/duckdb/src/common/enums/expression_type.cpp
@@ -158,6 +158,10 @@ string ExpressionTypeToString(ExpressionType type) {
 		return "NEG";
 	case ExpressionType::OPERATOR_IS_NOT_TRUE:
 		return "IS_NOT_TRUE";
+	case ExpressionType::OPERATOR_IS_FALSE:
+		return "IS_FALSE";
+	case ExpressionType::OPERATOR_IS_NOT_FALSE:
+		return "IS_NOT_FALSE";
 	case ExpressionType::INVALID:
 		break;
 	}

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/common/enums/expression_type.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/common/enums/expression_type.hpp
@@ -157,6 +157,8 @@ enum class ExpressionType : uint8_t {
 	OPERATOR_IS_TRUE = 250,
 	OPERATOR_NEG = 251,
 	OPERATOR_IS_NOT_TRUE = 252,
+	OPERATOR_IS_FALSE = 253,
+	OPERATOR_IS_NOT_FALSE = 254,
 };
 
 //===--------------------------------------------------------------------===//

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/parser/expression/operator_expression.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/parser/expression/operator_expression.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/string_util.hpp"
+#include <iostream>
 
 namespace duckdb {
 //! Represents a built-in operator expression
@@ -38,6 +39,7 @@ public:
 public:
 	template <class T, class BASE>
 	static string ToString(const T &entry) {
+		std::cout << "OP EXP" << (int)entry.GetExpressionType() << '\n';
 		auto op = ExpressionTypeToOperator(entry.GetExpressionType());
 		if (!op.empty()) {
 			// use the operator string to represent the operator
@@ -90,6 +92,14 @@ public:
 		// Bodo change: add new operator
 		case ExpressionType::OPERATOR_NEG:
 			return "(-" + entry.children[0]->ToString() + ")";
+		case ExpressionType::OPERATOR_IS_TRUE:
+			return "(" + entry.children[0]->ToString() + " IS TRUE)";
+		case ExpressionType::OPERATOR_IS_NOT_TRUE:
+			return "(" + entry.children[0]->ToString() + " IS NOT TRUE)";
+		case ExpressionType::OPERATOR_IS_FALSE:
+			return "(" + entry.children[0]->ToString() + " IS FALSE)";
+		case ExpressionType::OPERATOR_IS_NOT_FALSE:
+			return "(" + entry.children[0]->ToString() + " IS NOT FALSE)";
 		case ExpressionType::ARRAY_EXTRACT:
 			return entry.children[0]->ToString() + "[" + entry.children[1]->ToString() + "]";
 		case ExpressionType::ARRAY_SLICE: {

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/parser/expression/operator_expression.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/parser/expression/operator_expression.hpp
@@ -11,7 +11,6 @@
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/string_util.hpp"
-#include <iostream>
 
 namespace duckdb {
 //! Represents a built-in operator expression
@@ -39,7 +38,6 @@ public:
 public:
 	template <class T, class BASE>
 	static string ToString(const T &entry) {
-		std::cout << "OP EXP" << (int)entry.GetExpressionType() << '\n';
 		auto op = ExpressionTypeToOperator(entry.GetExpressionType());
 		if (!op.empty()) {
 			// use the operator string to represent the operator


### PR DESCRIPTION
## Changes included in this PR

Add support for `IS FALSE` and `IS NOT FALSE` in C++ backend. 

Enables `test_logical_comparison.py` to run entirely on C++ backend. 

## Testing strategy

Enabled more tests on C++ backend

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.