### PR TITLE
[BSE-5040] Enable gcs testing on CI

### DIFF
--- a/.github/workflows/_test_nightly_python_source.yml
+++ b/.github/workflows/_test_nightly_python_source.yml
@@ -95,7 +95,8 @@ jobs:
       - name: Configure GCP Credentials
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WIP_PROVIDER }}
           access_token_lifetime: 14400
 
       - name: Install Oracle Instant Client

--- a/.github/workflows/_test_nightly_python_source.yml
+++ b/.github/workflows/_test_nightly_python_source.yml
@@ -92,6 +92,12 @@ jobs:
           role-skip-session-tagging: true
           role-duration-seconds: 14400 # Max duration: 4 hours
 
+      - name: Configure GCP Credentials
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          access_token_lifetime: 14400
+
       - name: Install Oracle Instant Client
         if: runner.os != 'Windows' && !startsWith(inputs.test-type, 'sql')
         run: |

--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -71,7 +71,8 @@ jobs:
         - name: Configure GCP Credentials
           uses: google-github-actions/auth@v3
           with:
-            credentials_json: ${{ secrets.GCP_SA_KEY }}
+            service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+            workload_identity_provider: ${{ secrets.GCP_WIP_PROVIDER }}
             access_token_lifetime: 10800
         - name: Install Extra Test dependencies
           if: ${{ inputs.test-type != 'DF_LIB_GPU' }}

--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -68,6 +68,10 @@ jobs:
             role-session-name: BodoEnginePrCiSession
             role-skip-session-tagging: true
             role-duration-seconds: 10800
+        - name: Configure GCP Credentials
+          uses: google-github-actions/auth@v3
+          with:
+            credentials_json: ${{ secrets.GCP_SA_KEY }}
         - name: Install Extra Test dependencies
           if: ${{ inputs.test-type != 'DF_LIB_GPU' }}
           run: |

--- a/.github/workflows/_test_python_source.yml
+++ b/.github/workflows/_test_python_source.yml
@@ -72,6 +72,7 @@ jobs:
           uses: google-github-actions/auth@v3
           with:
             credentials_json: ${{ secrets.GCP_SA_KEY }}
+            access_token_lifetime: 10800
         - name: Install Extra Test dependencies
           if: ${{ inputs.test-type != 'DF_LIB_GPU' }}
           run: |

--- a/bodo/tests/test_gcs.py
+++ b/bodo/tests/test_gcs.py
@@ -5,8 +5,6 @@ import pytest
 
 from bodo.tests.utils import check_func
 
-pytestmark = pytest.mark.skip(reason="BSE-5040: Fix GCS anonymous access in tests")
-
 
 @pytest.mark.parquet
 def test_read_parquet_gcs():


### PR DESCRIPTION
## Changes included in this PR

Reading from GCS now requires ADC, even when using public datasets. I set up a minimal service account and created an Workload Identity Pool + Provider following: https://github.com/google-github-actions/auth#workload-identity-federation-through-a-service-account

More information about the specifics of this setup can be found in the wiki page: https://bodo.atlassian.net/wiki/spaces/B/pages/2565537793/GCP+Testing+on+Github+Actions+CI

## Testing strategy
PR CI
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.