### PR TITLE
Fix ANY_VALUE with nulls test on nightly

### DIFF
--- a/BodoSQL/bodosql/tests/test_agg_nogroupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_nogroupby.py
@@ -13,13 +13,12 @@ from bodo.tests.utils import (
     check_func,
     count_array_REPs,
     dist_IR_contains,
-    pytest_slow_unless_groupby,
 )
 from bodo.tests.utils_jit import DistTestPipeline
 from bodosql.tests.utils import check_query
 
 # Skip unless any groupby-related files were changed
-pytestmark = pytest_slow_unless_groupby
+# pytestmark = pytest_slow_unless_groupby
 
 
 def test_agg_numeric(

--- a/BodoSQL/bodosql/tests/test_agg_nogroupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_nogroupby.py
@@ -587,7 +587,7 @@ def test_any_value_nulls(memory_leak_check):
         check_names=False,
         is_out_distributed=False,
         expected_output=pd.DataFrame(
-            {0: pd.array([None], dtype=pd.ArrowDtype(pa.int64()))}
+            {0: pd.array([1], dtype=pd.ArrowDtype(pa.int64()))}
         ),
     )
 

--- a/BodoSQL/bodosql/tests/test_agg_nogroupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_nogroupby.py
@@ -13,12 +13,13 @@ from bodo.tests.utils import (
     check_func,
     count_array_REPs,
     dist_IR_contains,
+    pytest_slow_unless_groupby,
 )
 from bodo.tests.utils_jit import DistTestPipeline
 from bodosql.tests.utils import check_query
 
 # Skip unless any groupby-related files were changed
-# pytestmark = pytest_slow_unless_groupby
+pytestmark = pytest_slow_unless_groupby
 
 
 def test_agg_numeric(


### PR DESCRIPTION
## Changes included in this PR

We recently updated ANY_VALUE to run on C++ backend, which returns the first non-null value (or null if all values are null). 

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.