### PR TITLE
Use JIT kernels for next_day/previous_day with tz-aware data

### DIFF
--- a/BodoSQL/bodosql/kernels/datetime_array_kernels.py
+++ b/BodoSQL/bodosql/kernels/datetime_array_kernels.py
@@ -2540,6 +2540,36 @@ def next_day_util(arr0, arr1):
     )
 
 
+def next_day_wrapper(df):
+    """Wrapper for next_day_util kernel for BodoSQL C++ backend to use for tz-aware
+    data.
+    Not using a general wrapper for all kernels since creating a function from text is
+    fragile in JIT caching.
+    """
+
+    @bodo.jit(cache=True, spawn=False, distributed=False)
+    def wrapper_inner(A, B):
+        return next_day_util(A, B)
+
+    out = wrapper_inner(df.iloc[:, 0].array, df.iloc[:, 1].array)
+    return pd.Series(out)
+
+
+def previous_day_wrapper(df):
+    """Wrapper for previous_day_util kernel for BodoSQL C++ backend to use for tz-aware
+    data.
+    Not using a general wrapper for all kernels since creating a function from text is
+    fragile in JIT caching.
+    """
+
+    @bodo.jit(cache=True, spawn=False, distributed=False)
+    def wrapper_inner(A, B):
+        return previous_day_util(A, B)
+
+    out = wrapper_inner(df.iloc[:, 0].array, df.iloc[:, 1].array)
+    return pd.Series(out)
+
+
 @numba.generated_jit(nopython=True)
 def previous_day_util(arr0, arr1):
     """A dedicated kernel for the SQL function PREVIOUS_DAY which takes in a datetime

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -41,6 +41,7 @@ from bodo.pandas.plan import (
     LogicalSetOperation,
     LogicalTopN,
     NullExpression,
+    PythonScalarFuncExpression,
     UnaryOpExpression,
     arrow_to_empty_df,
     make_col_ref_exprs,
@@ -967,6 +968,25 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 ctx, java_call.getOperands()[1], input_plan
             )
             ensure_type_of_expr(dow_string_expr, "dow_string_expr", str)
+
+            # Arrow and DuckDB don't support timezone-aware compute so we fall back
+            # to our JIT kernel.
+            pa_type = date_expr.empty_data.iloc[:, 0].dtype.pyarrow_dtype
+            if pa.types.is_timestamp(pa_type) and pa_type.tz is not None:
+                return PythonScalarFuncExpression(
+                    pd.Series(dtype=pd.ArrowDtype(pa.date32())),
+                    [date_expr, dow_string_expr],
+                    (
+                        f"bodosql.kernels.datetime_array_kernels.{func_name.lower()}_wrapper",
+                        False,  # is_series
+                        False,  # is_method
+                        (),  # args
+                        {},  # kwargs
+                        True,  # use_arrow_dtypes
+                    ),
+                    False,  # is_cfunc
+                    False,  # has_state
+                )
 
             int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
 

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -3835,6 +3835,7 @@ def test_tz_aware_weekofyear_case(memory_leak_check):
     check_query(query, ctx, None, expected_output=py_output, check_dtype=False)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 @pytest.mark.slow
 def test_tz_aware_next_day(memory_leak_check):
@@ -3864,6 +3865,7 @@ def test_tz_aware_next_day(memory_leak_check):
 
 
 @pytest.mark.tz_aware
+@pytest.mark.bodosql_cpp
 def test_tz_aware_next_day_case(
     memory_leak_check,
 ):
@@ -3894,6 +3896,7 @@ def test_tz_aware_next_day_case(
     check_query(query, ctx, None, expected_output=py_output, check_dtype=False)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 @pytest.mark.slow
 def test_tz_aware_previous_day(memory_leak_check):
@@ -3918,6 +3921,7 @@ def test_tz_aware_previous_day(memory_leak_check):
     check_query(query, ctx, None, expected_output=py_output, check_dtype=False)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_tz_aware_previous_day_case(
     memory_leak_check,


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. This is an example to hopefully follow for other kernels.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.