### PR TITLE
[GPU][BSE-5418] Enable storage options in df lib 

### DIFF
--- a/bodo/io/fs_io.py
+++ b/bodo/io/fs_io.py
@@ -203,11 +203,9 @@ def get_gcs_fs(path, storage_options=None):
     options = {"retry_time_limit": datetime.timedelta(seconds=GCS_RETRY_LIMIT_SECONDS)}
 
     anon = False
-    if storage_options:
-        anon = storage_options.pop("anon", anon)
-        anon = storage_options.pop("anonymous", anon)
-        options.update(storage_options)
-
+    options = storage_options.copy() if storage_options else {}
+    anon = options.pop("anon", anon)
+    anon = options.pop("anonymous", anon)
     fs = GcsFileSystem(anonymous=anon, **options)
 
     if anon:
@@ -338,8 +336,10 @@ def pa_fs_list_dir_fnames(fs, path):
 def abfs_get_fs(storage_options: dict[str, str] | None):  # pragma: no cover
     from pyarrow.fs import AzureFileSystem
 
+    options = storage_options.copy() if storage_options else {}
+
     def get_attr(opt_key: str, env_key: str) -> str | None:
-        opt_val = storage_options.pop(opt_key) if storage_options else None
+        opt_val = options.pop(opt_key, None)
         if (
             opt_val is not None
             and os.environ.get(env_key) is not None
@@ -370,9 +370,7 @@ def abfs_get_fs(storage_options: dict[str, str] | None):  # pragma: no cover
 
     # Note, Azure validates credentials at use-time instead of at
     # initialization
-    return AzureFileSystem(
-        account_name, account_key=account_key, **(storage_options or {})
-    )
+    return AzureFileSystem(account_name, account_key=account_key, **(options or {}))
 
 
 """
@@ -561,8 +559,8 @@ def getfs(
         raise ValueError(
             f"ParquetReader: `storage_options` is not supported for protocol {protocol}"
         )
-    else:
-        return pa.fs.LocalFileSystem()
+
+    return pa.fs.LocalFileSystem()
 
 
 def get_uri_scheme(path):

--- a/bodo/io/fs_io.py
+++ b/bodo/io/fs_io.py
@@ -203,9 +203,11 @@ def get_gcs_fs(path, storage_options=None):
     options = {"retry_time_limit": datetime.timedelta(seconds=GCS_RETRY_LIMIT_SECONDS)}
 
     anon = False
-    options = storage_options.copy() if storage_options else {}
-    anon = options.pop("anon", anon)
-    anon = options.pop("anonymous", anon)
+    if storage_options:
+        options.update(storage_options)
+        anon = options.pop("anon", anon)
+        anon = options.pop("anonymous", anon)
+
     fs = GcsFileSystem(anonymous=anon, **options)
 
     if anon:

--- a/bodo/io/fs_io.py
+++ b/bodo/io/fs_io.py
@@ -243,7 +243,7 @@ def get_hf_fs(storage_options=None):
 
 # hdfs related functions should be included in
 # coverage once hdfs tests are included in CI
-def get_hdfs_fs(path):  # pragma: no cover
+def get_hdfs_fs(path, storage_options=None):  # pragma: no cover
     """
     initialize pyarrow.fs.HadoopFileSystem from path
     """
@@ -264,7 +264,7 @@ def get_hdfs_fs(path):  # pragma: no cover
         port = options.port
     # creates a new Hadoop file system from uri
     try:
-        fs = HdFS(host=host, port=port, user=user)
+        fs = HdFS(host=host, port=port, user=user, **(storage_options or {}))
     except Exception as e:
         raise ValueError(f"Hadoop file system cannot be created: {e}")
 
@@ -339,7 +339,7 @@ def abfs_get_fs(storage_options: dict[str, str] | None):  # pragma: no cover
     from pyarrow.fs import AzureFileSystem
 
     def get_attr(opt_key: str, env_key: str) -> str | None:
-        opt_val = storage_options.get(opt_key) if storage_options else None
+        opt_val = storage_options.pop(opt_key) if storage_options else None
         if (
             opt_val is not None
             and os.environ.get(env_key) is not None
@@ -370,7 +370,9 @@ def abfs_get_fs(storage_options: dict[str, str] | None):  # pragma: no cover
 
     # Note, Azure validates credentials at use-time instead of at
     # initialization
-    return AzureFileSystem(account_name, account_key=account_key)
+    return AzureFileSystem(
+        account_name, account_key=account_key, **(storage_options or {})
+    )
 
 
 """
@@ -531,7 +533,9 @@ def getfs(
     elif protocol == "http":
         import fsspec
 
-        return PyFileSystem(FSSpecHandler(fsspec.filesystem("http")))
+        return PyFileSystem(
+            FSSpecHandler(fsspec.filesystem("http", **(storage_options or {})))
+        )
     elif protocol in {"abfs", "abfss"}:  # pragma: no cover
         if not storage_options:
             storage_options = {}
@@ -546,11 +550,17 @@ def getfs(
         return abfs_get_fs(storage_options)
     elif protocol == "hdfs":  # pragma: no cover
         return (
-            get_hdfs_fs(fpath) if not isinstance(fpath, list) else get_hdfs_fs(fpath[0])
+            get_hdfs_fs(fpath, storage_options)
+            if not isinstance(fpath, list)
+            else get_hdfs_fs(fpath[0], storage_options)
         )
     # HuggingFace datasets
     elif protocol == "hf":
         return get_hf_fs(storage_options)
+    elif storage_options is not None and len(storage_options) > 0:
+        raise ValueError(
+            f"ParquetReader: `storage_options` is not supported for protocol {protocol}"
+        )
     else:
         return pa.fs.LocalFileSystem()
 

--- a/bodo/io/fs_io.py
+++ b/bodo/io/fs_io.py
@@ -485,8 +485,7 @@ def getfs(
         fpath (str | list[str]): Filename or list of filenames.
         protocol (str): Protocol for the filesystem. e.g. "" (for local), "s3", etc.
         storage_options (Optional[dict], optional): Optional storage_options to
-            use when building the filesystem. Only supported in the S3 case
-            at this time. Defaults to None.
+            use when building the filesystem. Defaults to None.
         parallel (bool, optional): Whether this function is being called in parallel.
             Defaults to False.
 
@@ -527,12 +526,7 @@ def getfs(
                 storage_options=storage_options,
             )
         )
-    if storage_options is not None and len(storage_options) > 0:
-        raise ValueError(
-            f"ParquetReader: `storage_options` is not supported for protocol {protocol}"
-        )
-
-    if protocol in {"gcs", "gs"}:
+    elif protocol in {"gcs", "gs"}:
         return get_gcs_fs(fpath, storage_options=storage_options)
     elif protocol == "http":
         import fsspec

--- a/bodo/io/fs_io.py
+++ b/bodo/io/fs_io.py
@@ -372,7 +372,7 @@ def abfs_get_fs(storage_options: dict[str, str] | None):  # pragma: no cover
 
     # Note, Azure validates credentials at use-time instead of at
     # initialization
-    return AzureFileSystem(account_name, account_key=account_key, **(options or {}))
+    return AzureFileSystem(account_name, account_key=account_key, **options)
 
 
 """

--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -179,7 +179,7 @@ def from_pandas(df):
     return wrap_plan(plan=plan, nrows=n_rows, res_id=res_id)
 
 
-@check_args_fallback(supported=["dtype_backend"])
+@check_args_fallback(supported=["dtype_backend", "storage_options"])
 def read_parquet(
     path,
     engine="auto",

--- a/bodo/pandas/physical/gpu_read_parquet.h
+++ b/bodo/pandas/physical/gpu_read_parquet.h
@@ -258,6 +258,8 @@ class RankBatchGenerator {
         chunked_reader_se = make_stream_and_event(g_use_async);
     }
 
+    ~RankBatchGenerator() { Py_XDECREF(storage_options); }
+
     std::pair<std::unique_ptr<cudf::table>, bool> next(
         std::shared_ptr<StreamAndEvent> se) {
         if (parts_.empty()) {
@@ -608,8 +610,6 @@ class RankBatchGenerator {
         return result;
     }
 
-    ~RankBatchGenerator() { Py_XDECREF(storage_options); }
-
    private:
     PyObject *path_;
     std::shared_ptr<arrow::fs::FileSystem> filesystem_;
@@ -855,6 +855,6 @@ class PhysicalGPUReadParquet : public PhysicalGPUSource {
 
         batch_gen = std::make_shared<RankBatchGenerator>(
             path, filter_exprs, batch_size, output_schema->column_names,
-            arrow_schema, output_arrow_schema, comm);
+            arrow_schema, output_arrow_schema, comm, storage_options);
     }
 };

--- a/bodo/pandas/physical/gpu_read_parquet.h
+++ b/bodo/pandas/physical/gpu_read_parquet.h
@@ -212,13 +212,15 @@ class RankBatchGenerator {
                        const std::vector<std::string> &_selected_columns,
                        std::shared_ptr<arrow::Schema> _arrow_schema,
                        std::shared_ptr<arrow::Schema> _output_arrow_schema,
-                       MPI_Comm comm)
+                       MPI_Comm comm, PyObject *storage_options)
         : path_(dataset_path),
           filesystem_(nullptr),
+          storage_options(storage_options),
           target_rows_(target_rows),
           selected_columns(_selected_columns),
           arrow_schema(std::move(_arrow_schema)),
           output_arrow_schema(std::move(_output_arrow_schema)) {
+        Py_INCREF(storage_options);
         get_dataset();
 
         // Only assign parts to GPU-pinned ranks
@@ -507,10 +509,11 @@ class RankBatchGenerator {
 
         // ds = bodo.io.parquet_pio.get_parquet_dataset(path,
         // get_row_counts=False)
-        // TODO(Ehsan): pass other options filters, storage_options,
+        // TODO(Ehsan): pass other options filters,
         // read_categories, tot_rows_to_read, schema, partitioning
         PyObjectPtr ds = PyObject_CallMethod(pq_mod, "get_parquet_dataset",
-                                             "OO", this->path_, Py_False);
+                                             "OOOO", this->path_, Py_False,
+                                             Py_None, this->storage_options);
         if (ds == nullptr && PyErr_Occurred()) {
             throw std::runtime_error("python");
         }
@@ -605,9 +608,12 @@ class RankBatchGenerator {
         return result;
     }
 
+    ~RankBatchGenerator() { Py_XDECREF(storage_options); }
+
    private:
     PyObject *path_;
     std::shared_ptr<arrow::fs::FileSystem> filesystem_;
+    PyObject *storage_options;
     std::size_t target_rows_;
     int rank_{0}, size_{1};
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -4690,6 +4690,7 @@ def test_join_filter_pushdown_aggregate_split_keys():
     )
 
 
+@pytest.mark.gpu
 def test_read_parquet_s3_storage_options():
     """Tests that Bodo can use storage options to read from a requester pays S3 bucket."""
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -4688,24 +4688,3 @@ def test_join_filter_pushdown_aggregate_split_keys():
         sort_output=True,
         reset_index=True,
     )
-
-
-@pytest.mark.gpu
-def test_read_parquet_s3_storage_options():
-    """Tests that Bodo can use storage options to read from a requester pays S3 bucket."""
-
-    storage_options = {"requester_pays": True}
-    s3_path = "s3://bodo-example-data/tpch/SF1/nation.pq"
-
-    bdf = bd.read_parquet(s3_path, storage_options=storage_options)
-    pdf = pd.read_parquet(
-        s3_path, storage_options=storage_options, dtype_backend="pyarrow"
-    )
-
-    _test_equal(
-        bdf,
-        pdf,
-        check_pandas_types=False,
-        sort_output=True,
-        reset_index=True,
-    )

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -4688,3 +4688,23 @@ def test_join_filter_pushdown_aggregate_split_keys():
         sort_output=True,
         reset_index=True,
     )
+
+
+def test_read_parquet_s3_storage_options():
+    """Tests that Bodo can use storage options to read from a requester pays S3 bucket."""
+
+    storage_options = {"requester_pays": True}
+    s3_path = "s3://bodo-example-data/tpch/SF1/nation.pq"
+
+    bdf = bd.read_parquet(s3_path, storage_options=storage_options)
+    pdf = pd.read_parquet(
+        s3_path, storage_options=storage_options, dtype_backend="pyarrow"
+    )
+
+    _test_equal(
+        bdf,
+        pdf,
+        check_pandas_types=False,
+        sort_output=True,
+        reset_index=True,
+    )

--- a/docs/docs/api_docs/dataframe_lib/io.md
+++ b/docs/docs/api_docs/dataframe_lib/io.md
@@ -24,6 +24,8 @@ Creates a BodoDataFrame object for reading from parquet file(s) lazily.
 Refer to [`pandas.read_parquet`](https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html#pandas.read_parquet) for more details.
 The type of this argument differs from Pandas.
 
+: __storage_options : *dict, optional* :__ Extra options that make sense for a particular storage connection.
+
 : All other parameters will trigger a fallback to [`pandas.read_parquet`](https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html#pandas.read_parquet) if a non-default value is provided.
 
 <p class="api-header">Returns</p>

--- a/docs/docs/api_docs/dataframe_lib/io.md
+++ b/docs/docs/api_docs/dataframe_lib/io.md
@@ -24,7 +24,7 @@ Creates a BodoDataFrame object for reading from parquet file(s) lazily.
 Refer to [`pandas.read_parquet`](https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html#pandas.read_parquet) for more details.
 The type of this argument differs from Pandas.
 
-: __storage_options : *dict, optional* :__ Extra options that make sense for a particular storage connection.
+: __storage_options : *dict, optional* :__ Extra options that make sense for a particular storage connections. Storage options are not supported for local paths.
 
 : All other parameters will trigger a fallback to [`pandas.read_parquet`](https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html#pandas.read_parquet) if a non-default value is provided.
 


### PR DESCRIPTION
## Changes included in this PR

Enabled `storage_options` argument and added support on GPU. 

This PR also passes storage options in more cases where it makes sense (http, hdfs, azure). 

Note that our storage options aren't 1:1 with Pandas for Azure and GCS. For GCS and Azure, Bodo passes storage options to the corresponding arrow class (pyarrow.fs.GcSFileSystem, pyarrow.fs.AzureFileSystem), while Pandas passes options to gcfs.GCSFileSystem and adlfs.AzureBlobFileSystem respectively when supplied. 

## Testing strategy

Some manual testing for each filesystems to make sure they were receiving the storage options (filesystems tested: http, hdfs, gcs, s3, azure). 

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

storage_options argument is now supported in DF library for read_parquet in both CPU and GPU paths.

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.