### PR TITLE
Reject types not supported by first.

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -4643,12 +4643,20 @@ def java_agg_to_python_agg(ctx, java_plan):
             "var_pop",
             "skew",
             "kurtosis",
-            "first",
         ]:
             assert len(arg_cols) == 1, (
                 f"Only single-argument {func_name} aggregations are supported"
             )
             in_type = input_plan.pa_schema.field(arg_cols[0]).type
+            out_type = _get_agg_output_type(
+                GroupbyAggFunc("dummy", func_name), in_type, "dummy"
+            )
+        elif func_name == "first":
+            assert len(arg_cols) == 1, (
+                f"Only single-argument {func_name} aggregations are supported"
+            )
+            in_type = input_plan.pa_schema.field(arg_cols[0]).type
+            assert not isinstance(in_type, pa.lib.LargeListType)
             out_type = _get_agg_output_type(
                 GroupbyAggFunc("dummy", func_name), in_type, "dummy"
             )


### PR DESCRIPTION
## Changes included in this PR

Fix nightly problem by explicitly rejecting unsupported types for any that result in segfault.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.