### PR TITLE
Merge test report files after Nightly

### DIFF
--- a/.github/workflows/_test_nightly_python_source.yml
+++ b/.github/workflows/_test_nightly_python_source.yml
@@ -294,5 +294,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: junit-reports-${{ inputs.test-type }}-${{ inputs.runner-id }}-${{ inputs.partition }}
+          name: junit-reports-${{ inputs.test-type }}-${{ inputs.runner-id }}-${{ inputs.partition }}-${{ inputs.num-workers }}
           path: '**/pytest-report*.xml'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,35 +61,35 @@ jobs:
           echo "pytest-marker=$MARKER" >> "$GITHUB_OUTPUT"
         shell: bash
 
-  bodo-compiler-1p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      partition: bodo_${{ matrix.batch }}of22
-      test-type: compiler
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 1
-    secrets: inherit
+  # bodo-compiler-1p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     partition: bodo_${{ matrix.batch }}of22
+  #     test-type: compiler
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 1
+  #   secrets: inherit
 
-  bodo-compiler-2p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      test-type: compiler
-      partition: bodo_${{ matrix.batch }}of30
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 2
-    secrets: inherit
+  # bodo-compiler-2p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     test-type: compiler
+  #     partition: bodo_${{ matrix.batch }}of30
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 2
+  #   secrets: inherit
 
   bodo-cache:
     needs: create-test-marker
@@ -145,35 +145,35 @@ jobs:
       num-workers: 2
     secrets: inherit
 
-  bodosql-1p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      partition: bodosql_${{ matrix.batch }}of12
-      test-type: sql
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 1
-    secrets: inherit
+  # bodosql-1p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     partition: bodosql_${{ matrix.batch }}of12
+  #     test-type: sql
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 1
+  #   secrets: inherit
 
-  bodosql-2p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      partition: bodosql_${{ matrix.batch }}of22
-      test-type: sql
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 2
-    secrets: inherit
+  # bodosql-2p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     partition: bodosql_${{ matrix.batch }}of22
+  #     test-type: sql
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 2
+  #   secrets: inherit
 
   bodosql-cache:
     needs: create-test-marker
@@ -206,3 +206,63 @@ jobs:
       runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
       num-workers: 2
     secrets: inherit
+
+  merge-junit:
+    needs: [
+      # bodo-compiler-1p,
+      # bodo-compiler-2p,
+      bodo-cache,
+      bodo-spawn-1p,
+      bodo-spawn-2p,
+      bodo-df-lib-1p,
+      bodo-df-lib-2p,
+      # bodosql-1p,
+      # bodosql-2p,
+      bodosql-cache,
+      bodosql-spawn-1p,
+      bodosql-spawn-2p
+    ]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - run: |
+          pip install junitparser junit2html
+
+      - name: Download Bodo reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: junit-reports-compiler-*
+          path: bodo-reports
+          merge-multiple: true
+
+      - name: Download BodoSQL reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: junit-reports-sql-*
+          path: bodosql-reports
+          merge-multiple: true
+
+      - name: Merge XML
+        run: |
+          junitparser merge bodo-reports/*.xml bodo.xml
+          junit2html bodo.xml bodo.html
+
+          junitparser merge bodosql-reports/*.xml bodosql.xml
+          junit2html bodosql.xml bodosql.html
+
+      - name: Upload merged reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: merged-junit-reports
+          path: |
+            bodo.xml
+            bodo.html
+            bodosql.xml
+            bodosql.html

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -226,43 +226,64 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.14"
 
-      - run: |
-          pip install junitparser junit2html
+    - name: Install report tools
+      run: pip install junitparser junit2html
 
-      - name: Download Bodo reports
-        uses: actions/download-artifact@v4
-        with:
-          pattern: junit-reports-compiler-*
-          path: bodo-reports
-          merge-multiple: true
+    - name: Download Bodo reports
+      uses: actions/download-artifact@v4
+      with:
+        pattern: "junit-reports-{compiler,spawn,df_lib}-*"
+        path: bodo-reports
+        merge-multiple: true
 
-      - name: Download BodoSQL reports
-        uses: actions/download-artifact@v4
-        with:
-          pattern: junit-reports-sql-*
-          path: bodosql-reports
-          merge-multiple: true
+    - name: Download BodoSQL reports
+      uses: actions/download-artifact@v4
+      with:
+        pattern: "junit-reports-{sql,sql_spawn}-*"
+        path: bodosql-reports
+        merge-multiple: true
 
-      - name: Merge XML
-        run: |
-          junitparser merge bodo-reports/*.xml bodo.xml
-          junit2html bodo.xml bodo.html
+    - name: Merge XML and generate HTML
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s globstar nullglob
 
-          junitparser merge bodosql-reports/*.xml bodosql.xml
-          junit2html bodosql.xml bodosql.html
+        bodo_reports=(bodo-reports/**/*.xml)
+        bodosql_reports=(bodosql-reports/**/*.xml)
 
-      - name: Upload merged reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: merged-junit-reports
-          path: |
-            bodo.xml
-            bodo.html
-            bodosql.xml
-            bodosql.html
+        if (( ${#bodo_reports[@]} == 0 )); then
+          echo "No Bodo JUnit XML reports found"
+          exit 1
+        fi
+
+        if (( ${#bodosql_reports[@]} == 0 )); then
+          echo "No BodoSQL JUnit XML reports found"
+          exit 1
+        fi
+
+        echo "Merging ${#bodo_reports[@]} Bodo reports"
+        junitparser merge "${bodo_reports[@]}" bodo.xml
+        junit2html bodo.xml bodo.html
+
+        echo "Merging ${#bodosql_reports[@]} BodoSQL reports"
+        junitparser merge "${bodosql_reports[@]}" bodosql.xml
+        junit2html bodosql.xml bodosql.html
+
+    - name: Upload merged reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: merged-junit-reports
+        path: |
+          bodo.xml
+          bodo.html
+          bodosql.xml
+          bodosql.html
+        if-no-files-found: warn

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,35 +61,35 @@ jobs:
           echo "pytest-marker=$MARKER" >> "$GITHUB_OUTPUT"
         shell: bash
 
-  bodo-compiler-1p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      partition: bodo_${{ matrix.batch }}of22
-      test-type: compiler
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 1
-    secrets: inherit
+  # bodo-compiler-1p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     partition: bodo_${{ matrix.batch }}of22
+  #     test-type: compiler
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 1
+  #   secrets: inherit
 
-  bodo-compiler-2p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      test-type: compiler
-      partition: bodo_${{ matrix.batch }}of30
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 2
-    secrets: inherit
+  # bodo-compiler-2p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     test-type: compiler
+  #     partition: bodo_${{ matrix.batch }}of30
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 2
+  #   secrets: inherit
 
   bodo-cache:
     needs: create-test-marker
@@ -145,35 +145,35 @@ jobs:
       num-workers: 2
     secrets: inherit
 
-  bodosql-1p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      partition: bodosql_${{ matrix.batch }}of12
-      test-type: sql
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 1
-    secrets: inherit
+  # bodosql-1p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     partition: bodosql_${{ matrix.batch }}of12
+  #     test-type: sql
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 1
+  #   secrets: inherit
 
-  bodosql-2p:
-    needs: create-test-marker
-    strategy:
-      matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-      fail-fast: false
-    uses: ./.github/workflows/_test_nightly_python_source.yml
-    with:
-      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-      partition: bodosql_${{ matrix.batch }}of22
-      test-type: sql
-      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-      num-workers: 2
-    secrets: inherit
+  # bodosql-2p:
+  #   needs: create-test-marker
+  #   strategy:
+  #     matrix:
+  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/_test_nightly_python_source.yml
+  #   with:
+  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+  #     partition: bodosql_${{ matrix.batch }}of22
+  #     test-type: sql
+  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+  #     num-workers: 2
+  #   secrets: inherit
 
   bodosql-cache:
     needs: create-test-marker
@@ -209,15 +209,15 @@ jobs:
 
   merge-junit:
     needs: [
-      bodo-compiler-1p,
-      bodo-compiler-2p,
+      # bodo-compiler-1p,
+      # bodo-compiler-2p,
       bodo-cache,
       bodo-spawn-1p,
       bodo-spawn-2p,
       bodo-df-lib-1p,
       bodo-df-lib-2p,
-      bodosql-1p,
-      bodosql-2p,
+      # bodosql-1p,
+      # bodosql-2p,
       bodosql-cache,
       bodosql-spawn-1p,
       bodosql-spawn-2p

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1]
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:
@@ -80,7 +80,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1]
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:
@@ -149,7 +149,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1]
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:
@@ -164,7 +164,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1]
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,35 +61,35 @@ jobs:
           echo "pytest-marker=$MARKER" >> "$GITHUB_OUTPUT"
         shell: bash
 
-  # bodo-compiler-1p:
-  #   needs: create-test-marker
-  #   strategy:
-  #     matrix:
-  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/_test_nightly_python_source.yml
-  #   with:
-  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-  #     partition: bodo_${{ matrix.batch }}of22
-  #     test-type: compiler
-  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-  #     num-workers: 1
-  #   secrets: inherit
+  bodo-compiler-1p:
+    needs: create-test-marker
+    strategy:
+      matrix:
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+      fail-fast: false
+    uses: ./.github/workflows/_test_nightly_python_source.yml
+    with:
+      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+      partition: bodo_${{ matrix.batch }}of22
+      test-type: compiler
+      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+      num-workers: 1
+    secrets: inherit
 
-  # bodo-compiler-2p:
-  #   needs: create-test-marker
-  #   strategy:
-  #     matrix:
-  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/_test_nightly_python_source.yml
-  #   with:
-  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-  #     test-type: compiler
-  #     partition: bodo_${{ matrix.batch }}of30
-  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-  #     num-workers: 2
-  #   secrets: inherit
+  bodo-compiler-2p:
+    needs: create-test-marker
+    strategy:
+      matrix:
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+      fail-fast: false
+    uses: ./.github/workflows/_test_nightly_python_source.yml
+    with:
+      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+      test-type: compiler
+      partition: bodo_${{ matrix.batch }}of30
+      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+      num-workers: 2
+    secrets: inherit
 
   bodo-cache:
     needs: create-test-marker
@@ -145,35 +145,35 @@ jobs:
       num-workers: 2
     secrets: inherit
 
-  # bodosql-1p:
-  #   needs: create-test-marker
-  #   strategy:
-  #     matrix:
-  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/_test_nightly_python_source.yml
-  #   with:
-  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-  #     partition: bodosql_${{ matrix.batch }}of12
-  #     test-type: sql
-  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-  #     num-workers: 1
-  #   secrets: inherit
+  bodosql-1p:
+    needs: create-test-marker
+    strategy:
+      matrix:
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+      fail-fast: false
+    uses: ./.github/workflows/_test_nightly_python_source.yml
+    with:
+      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+      partition: bodosql_${{ matrix.batch }}of12
+      test-type: sql
+      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+      num-workers: 1
+    secrets: inherit
 
-  # bodosql-2p:
-  #   needs: create-test-marker
-  #   strategy:
-  #     matrix:
-  #       batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/_test_nightly_python_source.yml
-  #   with:
-  #     pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
-  #     partition: bodosql_${{ matrix.batch }}of22
-  #     test-type: sql
-  #     runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
-  #     num-workers: 2
-  #   secrets: inherit
+  bodosql-2p:
+    needs: create-test-marker
+    strategy:
+      matrix:
+        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+      fail-fast: false
+    uses: ./.github/workflows/_test_nightly_python_source.yml
+    with:
+      pytest-marker: ${{ needs.create-test-marker.outputs.pytest-marker }}
+      partition: bodosql_${{ matrix.batch }}of22
+      test-type: sql
+      runner-id: ${{ inputs.runner-id || 'ubuntu-latest' }}
+      num-workers: 2
+    secrets: inherit
 
   bodosql-cache:
     needs: create-test-marker
@@ -209,15 +209,15 @@ jobs:
 
   merge-junit:
     needs: [
-      # bodo-compiler-1p,
-      # bodo-compiler-2p,
+      bodo-compiler-1p,
+      bodo-compiler-2p,
       bodo-cache,
       bodo-spawn-1p,
       bodo-spawn-2p,
       bodo-df-lib-1p,
       bodo-df-lib-2p,
-      # bodosql-1p,
-      # bodosql-2p,
+      bodosql-1p,
+      bodosql-2p,
       bodosql-cache,
       bodosql-spawn-1p,
       bodosql-spawn-2p

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+        batch: [1]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:
@@ -80,7 +80,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+        batch: [1]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:
@@ -149,7 +149,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        batch: [1]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:
@@ -164,7 +164,7 @@ jobs:
     needs: create-test-marker
     strategy:
       matrix:
-        batch: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+        batch: [1]
       fail-fast: false
     uses: ./.github/workflows/_test_nightly_python_source.yml
     with:


### PR DESCRIPTION
## Changes included in this PR
Creates a single report for bodo/bodosql tests that consolidates test failures and can be viewed in a browser. For example: 

<img width="1349" height="546" alt="Screenshot 2026-07-16 at 12 52 53 PM" src="https://github.com/user-attachments/assets/77be4d56-74ce-4c83-9178-39dc0422725a" />


## Testing strategy
Ran nightly with a subset of tests
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.