### PR TITLE
Set timezone properly for timestamp reductions

### DIFF
--- a/BodoSQL/bodosql/tests/test_pivot.py
+++ b/BodoSQL/bodosql/tests/test_pivot.py
@@ -92,6 +92,7 @@ def test_multi_col_null_pivot(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 @pytest.mark.slow
 def test_tz_aware_pivot(memory_leak_check):

--- a/bodo/libs/_shuffle.cpp
+++ b/bodo/libs/_shuffle.cpp
@@ -1923,6 +1923,12 @@ std::shared_ptr<array_info> broadcast_array(
             "broadcast_array: MPI error on MPI_Bcast:");
     }
 
+    // Preserve timezone for datetime arrays
+    if (ref_arr && arr_type == bodo_array_type::NULLABLE_INT_BOOL &&
+        dtype == Bodo_CTypes::DATETIME) {
+        out_arr->timezone = ref_arr->timezone;
+    }
+
     // Free communicator if created
     if (comm_ranks && comm_ranks->size() > 0) {
         MPI_Comm_free(&comm);

--- a/bodo/libs/_shuffle.h
+++ b/bodo/libs/_shuffle.h
@@ -138,8 +138,8 @@ std::shared_ptr<table_info> reverse_shuffle_table_kernel(
 /**
  * @brief Broadcast an array (including child arrays).
  *
- * @param ref_arr : the reference array used for the dictionaries if available
- * (can be nullptr)
+ * @param ref_arr : the reference array used for the dictionaries and timezone
+ * if available (can be nullptr)
  * @param in_arr : the array to broadcast
  * @param comm_ranks : target ranks to send data to (can be nullptr if sending
  * to all)

--- a/bodo/pandas/physical/reduce.cpp
+++ b/bodo/pandas/physical/reduce.cpp
@@ -119,13 +119,15 @@ void ReductionFunction::Finalize() {
         arrow_array = array_res.ValueOrDie();
     }
     // Broadcast local reduction from each rank to all other ranks
+    std::shared_ptr<array_info> bodo_array =
+        arrow_array_to_bodo(arrow_array, bodo::BufferPool::DefaultPtr());
     for (int i = 0; i < n_ranks; i++) {
         std::shared_ptr<array_info> send_array =
-            i == rank ? arrow_array_to_bodo(arrow_array,
-                                            bodo::BufferPool::DefaultPtr())
-                      : nullptr;
+            (i == rank) ? bodo_array : nullptr;
+        // Setting ref_arr is needed to ensure that the timezone is preserved
+        // for datetime arrays
         std::shared_ptr<array_info> array =
-            broadcast_array(nullptr, send_array, nullptr, false, i, rank);
+            broadcast_array(bodo_array, send_array, nullptr, false, i, rank);
         std::shared_ptr<arrow::Array> received_arrow_array =
             bodo_array_to_arrow(bodo::BufferPool::DefaultPtr(), array,
                                 false /*convert_timedelta_to_int64*/, "",


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes errors and hangs in `test_tz_aware_pivot`.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Enabled unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.