### PR TITLE
[GPU] Fix GPU Platform build with MPICH

### DIFF
--- a/bodo/pandas/physical/gpu_reduce.h
+++ b/bodo/pandas/physical/gpu_reduce.h
@@ -125,7 +125,8 @@ struct GPUReductionFunctionFirst : public GPUReductionFunction {
         : GPUReductionFunction(input_col_idx, {"first"}, {"first"},
                                {GPUReductionType::COMPARISON},
                                make_vector_of_one_nullptr(), dt,
-                               nullptr /* handled specially in Finalize*/) {}
+                               MPI_OP_NULL /* handled specially in Finalize*/) {
+    }
 };
 
 struct GPUReductionFunctionMin : public GPUReductionFunction {


### PR DESCRIPTION
## Changes included in this PR

As title, uses MPI_NULL_OP instead of nullptr as the sentinel value. Note that we don't actually do anything with this value in the first path. 

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.