### PR TITLE
Enable unmarked tests that pass on C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -51,13 +51,16 @@ from bodosql.imported_java_classes import JavaEntryPoint, gateway
 
 _DATE_PART_ARROW_FUNCS = {
     "YEAR": "year",
+    "QUARTER": "quarter",
     "MONTH": "month",
     "DAY": "day",
     "DAYOFMONTH": "day",
     "HOUR": "hour",
     "MINUTE": "minute",
     "SECOND": "second",
-    "QUARTER": "quarter",
+    "MILLISECOND": "millisecond",
+    "MICROSECOND": "microsecond",
+    "NANOSECOND": "nanosecond",
     "WEEK": "iso_week",
     "WEEKOFYEAR": "iso_week",
     "WEEKISO": "iso_week",
@@ -67,8 +70,6 @@ _DATE_PART_ARROW_FUNCS = {
     "WEEKDAY": "day_of_week",
     "YEAROFWEEK": "iso_year",
     "YEAROFWEEKISO": "iso_year",
-    "MICROSECOND": "microsecond",
-    "NANOSECOND": "nanosecond",
     "DOW": "day_of_week",
     "DOY": "day_of_year",
 }

--- a/BodoSQL/bodosql/tests/conftest.py
+++ b/BodoSQL/bodosql/tests/conftest.py
@@ -10,6 +10,7 @@ import py4j
 import pyarrow as pa
 import pyspark
 import pytest
+from _pytest.mark.structures import ParameterSet
 from pyspark.sql.types import (
     DoubleType,
     IntegerType,
@@ -133,6 +134,180 @@ def cpp_backend_run_with_test_dataframe_library_enabled(request):
             set_config("bodo.test_dataframe_library_enabled", False)
             return
     yield
+
+
+def mark_bodosql_cpp_if(condition):
+    """
+    Decorator to conditionally add the bodosql_cpp marker to a test.
+    `condition` can be a constant or a function accepting the pytest
+    item and returning a boolean.
+
+    This decorator sets an attribute on the test function which is read
+    in the `pytest_collection_modifyitems()` hook to decide whether to
+    mark the test or not.
+    """
+
+    def decorator(test_func):
+        test_func._mark_bodosql_cpp = condition
+        return test_func
+
+    return decorator
+
+
+def fixture_value_is_in(fixture_name, values):
+    """Get a condition function that returns True if the
+    value of the fixture `fixture_name` for the input test
+    is in the list of `values`. Mainly intended for use with
+    `mark_bodosql_cpp_if()`."""
+
+    def condition(item):
+        if hasattr(item, "callspec") and fixture_name in item.callspec.params:
+            return item.callspec.params[fixture_name] in values
+        return False
+
+    return condition
+
+
+def fixture_value_not_in(fixture_name, values):
+    """Get a condition function that returns True if the
+    value of the fixture `fixture_name` for the input test
+    is not in the list of `values`. Mainly intended for use
+    with `mark_bodosql_cpp_if()`."""
+
+    def condition(item):
+        if hasattr(item, "callspec") and fixture_name in item.callspec.params:
+            return item.callspec.params[fixture_name] not in values
+        return False
+
+    return condition
+
+
+def id_of_test_is_in(included_ids):
+    """Get a condition function that returns True if the
+    final ID of a test case is in the list of `included_ids`.
+    Mainly intended for use with `mark_bodosql_cpp_if()`."""
+
+    def condition(item):
+        if hasattr(item, "callspec"):
+            return item.callspec.id in included_ids
+        return False
+
+    return condition
+
+
+def id_of_test_not_in(excluded_ids):
+    """Get a condition function that returns True if the
+    final ID of a test case is not in the list of `excluded_ids`.
+    Mainly intended for use with `mark_bodosql_cpp_if()`."""
+
+    def condition(item):
+        if hasattr(item, "callspec"):
+            return item.callspec.id not in excluded_ids
+        return False
+
+    return condition
+
+
+def mark_based_on_param_id(pytest_marker, should_mark):
+    """
+    Decorator to mark parametrized test cases based on the value
+    of the parameter ID. This decorator must sit directly
+    on top of the `pytest.mark.parametrize` marker it
+    refers to.
+
+    `should_mark` is a function accepting the parameter ID
+    and returning a boolean. The parameter ID can be `None`.
+    `pytest_marker` is the marker that should be added to the
+    item if `should_mark` returns True.
+
+    The primary variants of this decorator are `mark_if_param_id_in`
+    and `mark_if_param_id_not_in`.
+    """
+
+    def decorator(func):
+        marks = getattr(func, "pytestmark", [])
+        if not isinstance(marks, list):
+            marks = [marks]
+
+        assert len(marks) > 0, (
+            "There must be a pytest (parametrize) mark directly below the @mark_based_on_param_id decorator."
+        )
+
+        parametrize_mark = marks[-1]
+        assert parametrize_mark.name == "parametrize", (
+            "The @mark_based_on_param_id decorator must be placed directly above a parametrize mark."
+        )
+
+        params = parametrize_mark.args[1]
+
+        marked_params = []
+        for i, param in enumerate(params):
+            # The ID could be either an attribute of the pytest.param (most common),
+            # of from the `ids` list of pytest.mark.parametrize().
+            if isinstance(param, ParameterSet):
+                param_id = param.id
+            else:
+                ids = parametrize_mark.kwargs.get("ids", None)
+                param_id = ids[i] if ids else None
+
+            if should_mark(param_id):
+                if isinstance(param, ParameterSet):
+                    # If it's a pytest.param, add the new marker to the existing markers
+                    if isinstance(param.marks, (list, set, tuple)):
+                        new_param_marks = [pytest_marker]
+                        new_param_marks.extend(param.marks)
+                    else:
+                        new_param_marks = [pytest_marker, param.marks]
+                    param = pytest.param(
+                        *param.values, id=param.id, marks=new_param_marks
+                    )
+                else:
+                    # If it's a tuple or a single value, package it in a pytest.param
+                    # so we can add the new marker.
+                    if not isinstance(param, tuple):
+                        param = (param,)
+                    param = pytest.param(*param, id=param_id, marks=pytest_marker)
+
+            marked_params.append(param)
+
+        # Create new parametrize marker; the old one is frozen and cannot be modified
+        arg_names = parametrize_mark.args[0]
+        marks[-1] = pytest.mark.parametrize(arg_names, marked_params)
+
+        return func
+
+    return decorator
+
+
+def mark_if_param_id_in(pytest_marker, included_ids):
+    """
+    Decorator to mark parametrized test cases where the value
+    of the parameter ID is in `included_ids`. This decorator
+    must sit directly on top of the `pytest.mark.parametrize`
+    marker it refers to.
+
+    `pytest_marker` is the marker that should be added to the
+    item if the parameter ID is in `included_ids`.
+    """
+    return mark_based_on_param_id(
+        pytest_marker,
+        lambda param_id: param_id is not None and param_id in included_ids,
+    )
+
+
+def mark_if_param_id_not_in(pytest_marker, excluded_ids):
+    """
+    Decorator to mark parametrized test cases where the value
+    of the parameter ID is not in `excluded_ids`. This decorator
+    must sit directly on top of the `pytest.mark.parametrize`
+    marker it refers to.
+
+    `pytest_marker` is the marker that should be added to the
+    item if the parameter ID is not in `excluded_ids`.
+    """
+    return mark_based_on_param_id(
+        pytest_marker, lambda param_id: param_id is None or param_id not in excluded_ids
+    )
 
 
 @pytest.fixture(scope="module")
@@ -1900,6 +2075,15 @@ def pytest_collection_modifyitems(items):
         item.add_marker(azure_1p_marker)
         item.add_marker(azure_2p_marker)
         item.add_marker(azure_3p_marker)
+
+        # If the item function has the attribute "_mark_bodosql_cpp"
+        # (set by @mark_bodosql_cpp_if), evaluate the condition
+        # and mark the test accordingly.
+        if isinstance(item, pytest.Function):
+            if hasattr(item.function, "_mark_bodosql_cpp"):
+                condition = item.function._mark_bodosql_cpp
+                if condition(item) if callable(condition) else condition:
+                    item.add_marker(pytest.mark.bodosql_cpp)
 
 
 def group_from_hash(testname, num_groups):

--- a/BodoSQL/bodosql/tests/test_agg_groupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_groupby.py
@@ -261,7 +261,7 @@ def test_count_string(bodosql_string_types, memory_leak_check):
     )
 
 
-# @pytest.mark.bodosql_cpp   # dataframe are different
+@pytest.mark.bodosql_cpp
 def test_count_binary(bodosql_binary_types, memory_leak_check):
     """test various count queries on binary data."""
     check_query(
@@ -282,7 +282,7 @@ def test_count_binary(bodosql_binary_types, memory_leak_check):
     )
 
 
-# @pytest.mark.bodosql_cpp   # dataframe are different
+@pytest.mark.bodosql_cpp
 def test_count_boolean(bodosql_boolean_types, memory_leak_check):
     """test various count queries on boolean data."""
     check_query(
@@ -1216,7 +1216,7 @@ def test_booland_agg_having(memory_leak_check):
 
 
 @pytest.mark.slow
-# @pytest.mark.bodosql_cpp   # aggregations without group by not supported yet
+@pytest.mark.bodosql_cpp
 def test_boolor_agg_output_type(memory_leak_check):
     """Test boolor_agg to verify the output type is boolean"""
     query = """WITH TEMP AS(SELECT boolor_agg(A) as agg_A, B FROM table1 GROUP BY B)
@@ -1327,7 +1327,7 @@ def test_count_tz_aware(memory_leak_check):
 
 @pytest.mark.tz_aware
 @pytest.mark.slow
-# @pytest.mark.bodosql_cpp   # aggregation ANY_VALUE not supported yet
+@pytest.mark.bodosql_cpp
 def test_any_value_tz_aware(memory_leak_check):
     """
     Test any_value on a tz-aware timestamp column

--- a/BodoSQL/bodosql/tests/test_agg_nogroupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_nogroupby.py
@@ -16,12 +16,31 @@ from bodo.tests.utils import (
     pytest_slow_unless_groupby,
 )
 from bodo.tests.utils_jit import DistTestPipeline
+from bodosql.tests.conftest import fixture_value_is_in, mark_bodosql_cpp_if
 from bodosql.tests.utils import check_query
 
 # Skip unless any groupby-related files were changed
 pytestmark = pytest_slow_unless_groupby
 
 
+@mark_bodosql_cpp_if(
+    fixture_value_is_in(
+        "numeric_agg_builtin_funcs",
+        {
+            "AVG",
+            "COUNT",
+            "MAX",
+            "MIN",
+            "STDDEV",
+            "STDDEV_SAMP",
+            "SUM",
+            "VARIANCE",
+            "VAR_SAMP",
+            "STDDEV_POP",
+            "VAR_POP",
+        },
+    )
+)
 def test_agg_numeric(
     bodosql_numeric_types, numeric_agg_builtin_funcs, memory_leak_check
 ):
@@ -77,6 +96,24 @@ def test_median(query, memory_leak_check):
 
 
 @pytest.mark.slow
+@mark_bodosql_cpp_if(
+    fixture_value_is_in(
+        "numeric_agg_builtin_funcs",
+        {
+            "AVG",
+            "COUNT",
+            "MAX",
+            "MIN",
+            "STDDEV",
+            "STDDEV_SAMP",
+            "SUM",
+            "VARIANCE",
+            "VAR_SAMP",
+            "STDDEV_POP",
+            "VAR_POP",
+        },
+    )
+)
 def test_aliasing_agg_numeric(
     bodosql_numeric_types, numeric_agg_builtin_funcs, memory_leak_check
 ):
@@ -101,6 +138,7 @@ def test_aliasing_agg_numeric(
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_repeat_columns(basic_df, memory_leak_check):
     """
     Tests that a column that won't produce a conflicting name
@@ -118,6 +156,7 @@ def test_repeat_columns(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_count_numeric(bodosql_numeric_types, memory_leak_check):
     """test various count queries on numeric data."""
     check_query(
@@ -141,6 +180,7 @@ def test_count_numeric(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_count_nullable_numeric(bodosql_nullable_numeric_types, memory_leak_check):
     """test various count queries on nullable numeric data."""
     check_query(
@@ -164,6 +204,7 @@ def test_count_nullable_numeric(bodosql_nullable_numeric_types, memory_leak_chec
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_count_datetime(bodosql_datetime_types, memory_leak_check):
     """test various count queries on Timestamp data."""
     check_query(
@@ -187,6 +228,7 @@ def test_count_datetime(bodosql_datetime_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_count_interval(bodosql_interval_types, memory_leak_check):
     """test various count queries on Timedelta data."""
     check_query(
@@ -210,6 +252,7 @@ def test_count_interval(bodosql_interval_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_count_boolean(bodosql_boolean_types, memory_leak_check):
     """test various count queries on boolean data."""
     check_query(
@@ -233,6 +276,7 @@ def test_count_boolean(bodosql_boolean_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_count_string(bodosql_string_types, memory_leak_check):
     """test various count queries on string data."""
     check_query(
@@ -255,6 +299,7 @@ def test_count_string(bodosql_string_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_count_binary(bodosql_binary_types, memory_leak_check):
     """test various count queries on string data."""
     check_query(
@@ -278,6 +323,7 @@ def test_count_binary(bodosql_binary_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_count_numeric_alias(bodosql_numeric_types, memory_leak_check):
     """test various count queries on numeric data with aliases."""
     check_query(
@@ -300,6 +346,7 @@ def test_count_numeric_alias(bodosql_numeric_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_max_string(bodosql_string_types, memory_leak_check):
     """
     Simple test to ensure that max is working on string types
@@ -320,6 +367,7 @@ def test_max_string(bodosql_string_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_max_datetime_types(bodosql_datetime_types, memory_leak_check):
     """
     Simple test to ensure that max is working on datetime types
@@ -363,6 +411,7 @@ def test_max_interval_types(bodosql_interval_types, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_max_literal(basic_df, memory_leak_check):
     """tests that max works on a scalar value"""
     # This query does not get optimized, by manual check
@@ -416,6 +465,7 @@ def test_count_if(query, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_having(bodosql_numeric_types, comparison_ops, memory_leak_check):
     """
     Tests having with a constant
@@ -440,6 +490,7 @@ def test_having(bodosql_numeric_types, comparison_ops, memory_leak_check):
 
 
 @pytest.mark.slow
+@pytest.mark.bodosql_cpp
 def test_max_bool(bodosql_boolean_types, memory_leak_check):
     """
     Simple test to ensure that max is working on boolean types
@@ -461,6 +512,7 @@ def test_max_bool(bodosql_boolean_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_having_boolean(bodosql_boolean_types, memory_leak_check):
     """
     Tests having with a constant
@@ -565,6 +617,7 @@ def test_any_value(query, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_any_value_nulls(memory_leak_check):
     """
     Test that ANY_VALUE works when the first element is NULL.
@@ -624,6 +677,7 @@ def test_max_min_tz_aware(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_count_tz_aware(memory_leak_check):
     """
@@ -656,6 +710,7 @@ def test_count_tz_aware(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 def test_any_value_tz_aware(memory_leak_check):
     """
@@ -843,6 +898,8 @@ def test_single_value(memory_leak_check):
     )
 
 
+# NOTE: This passes on C++ backend but doesn't actually use the
+# SINGLE_VALUE aggregation unlike `test_single_value`.
 def test_single_value2(memory_leak_check):
     """Test Calcite's SINGLE_VALUE Agg function in a max query"""
     query = "select max((select max(A)-1 from t1)) from t1"

--- a/BodoSQL/bodosql/tests/test_cast.py
+++ b/BodoSQL/bodosql/tests/test_cast.py
@@ -12,6 +12,7 @@ import pytest
 import bodo
 import bodosql
 from bodo.tests.utils import pytest_slow_unless_codegen
+from bodosql.tests.conftest import fixture_value_not_in, mark_bodosql_cpp_if
 from bodosql.tests.utils import check_query
 
 # Skip unless any codegen files were changed
@@ -311,19 +312,14 @@ def test_binary_to_str(basic_df, use_sf_cast_syntax, memory_leak_check):
 
 
 @pytest.mark.slow
-@pytest.mark.usefixtures("numeric_type_names")
+@mark_bodosql_cpp_if(fixture_value_not_in("numeric_type_names", {"DECIMAL"}))
 def test_numeric_scalar_to_numeric(
-    request,
     bodosql_numeric_types,
+    numeric_type_names,
     use_sf_cast_syntax,
     memory_leak_check,
 ):
     """Tests casting int scalars (from columns) to other numeric types"""
-
-    numeric_type_names = request.getfixturevalue("numeric_type_names")
-    if numeric_type_names != "DECIMAL":
-        request.node.add_marker(pytest.mark.bodosql_cpp)
-
     spark_query = f"SELECT CASE WHEN B > 5 THEN CAST(A AS {numeric_type_names}) ELSE CAST(1 AS {numeric_type_names}) END FROM TABLE1"
 
     if use_sf_cast_syntax:
@@ -368,19 +364,14 @@ def test_numeric_nullable_scalar_to_numeric(
 
 
 @pytest.mark.slow
-@pytest.mark.usefixtures("numeric_type_names")
+@mark_bodosql_cpp_if(fixture_value_not_in("numeric_type_names", {"DECIMAL"}))
 def test_string_scalar_to_numeric(
-    request,
     bodosql_integers_string_types,
+    numeric_type_names,
     use_sf_cast_syntax,
     memory_leak_check,
 ):
     """Tests casting string scalars (from columns) to numeric types"""
-
-    numeric_type_names = request.getfixturevalue("numeric_type_names")
-    if numeric_type_names != "DECIMAL":
-        request.node.add_marker(pytest.mark.bodosql_cpp)
-
     spark_query = f"SELECT CASE WHEN B = '43' THEN CAST(A AS {numeric_type_names}) ELSE CAST (1 AS {numeric_type_names}) END FROM TABLE1"
 
     if use_sf_cast_syntax:

--- a/BodoSQL/bodosql/tests/test_conversions/test_snowflake_conversion_fns.py
+++ b/BodoSQL/bodosql/tests/test_conversions/test_snowflake_conversion_fns.py
@@ -73,10 +73,12 @@ valid_bool_params = [
     pytest.param(
         pd.DataFrame({"A": pd.Series([1, 0, 2, 0, None, -2, -400] * 3, dtype="Int64")}),
         id="valid_to_boolean_ints",
+        marks=pytest.mark.bodosql_cpp,
     ),
     pytest.param(
         pd.DataFrame({"A": [1.1, 0.0, None, 0.1, 0, -2, -400] * 3}),
         id="valid_to_boolean_floats",
+        marks=pytest.mark.bodosql_cpp,
     ),
 ]
 
@@ -92,6 +94,7 @@ invalid_bool_params = [
     pytest.param(
         pd.DataFrame({"A": [1.1, 0.0, np.inf, 0.1, np.nan, -2, -400] * 3}),
         id="invalid_to_boolean_floats",
+        marks=pytest.mark.bodosql_cpp,
     ),
 ]
 
@@ -302,6 +305,7 @@ def to_char_test_dfs(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "func",
     [
@@ -346,6 +350,7 @@ def test_to_char_cols(to_char_test_dfs, func, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "func",
     [
@@ -411,6 +416,7 @@ def test_tz_aware_datetime_to_char(tz_aware_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_timestamp_to_char(memory_leak_check):
     """simplest test for TO_CHAR on timezone-naive timestamps"""
     query = "SELECT TO_CHAR(A) as A from table1"
@@ -435,6 +441,7 @@ def test_timestamp_to_char(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_date_to_char(memory_leak_check):
     """simplest test for TO_CHAR on date inputs"""
     query = "SELECT TO_CHAR(A) as A from table1"
@@ -503,6 +510,7 @@ def test_to_char_datetime_format_str(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "use_case",
     [
@@ -787,6 +795,7 @@ def to_double_equiv(arr):
     return pd.Series(out_arr, dtype=pd.ArrowDtype(pa.float64()))
 
 
+@pytest.mark.bodosql_cpp
 def test_to_double_valid_cols(to_double_valid_test_dfs, memory_leak_check):
     df = to_double_valid_test_dfs
     query = "SELECT TO_DOUBLE(a) FROM table1"
@@ -825,6 +834,7 @@ def test_to_double_invalid_cols(to_double_invalid_test_dfs):
             bc.sql(query)
 
 
+@pytest.mark.bodosql_cpp
 def test_to_double_scalars(memory_leak_check):
     df = pd.DataFrame(
         {
@@ -897,6 +907,7 @@ def test_try_to_double_cols(to_double_all_test_dfs, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_try_to_double_scalars():
     df = pd.DataFrame(
         {

--- a/BodoSQL/bodosql/tests/test_conversions/test_snowflake_date_conversion_fns.py
+++ b/BodoSQL/bodosql/tests/test_conversions/test_snowflake_date_conversion_fns.py
@@ -68,7 +68,6 @@ def date_casting_input_type(request):
     return request.param
 
 
-@pytest.mark.bodosql_cpp
 def test_date_casting_functions(
     dt_fn_dataframe, test_fn, date_casting_input_type, memory_leak_check
 ):

--- a/BodoSQL/bodosql/tests/test_conversions/test_snowflake_date_conversion_fns.py
+++ b/BodoSQL/bodosql/tests/test_conversions/test_snowflake_date_conversion_fns.py
@@ -50,9 +50,15 @@ def test_fn(request):
 
 @pytest.fixture(
     params=[
-        pytest.param("DATETIME_STRINGS", id="valid_datetime_strings"),
+        pytest.param(
+            "DATETIME_STRINGS",
+            id="valid_datetime_strings",
+            marks=pytest.mark.bodosql_cpp,
+        ),
         pytest.param("DIGIT_STRINGS", id="valid_digit_strings"),
-        pytest.param("TIMESTAMPS", id="valid_timestamps"),
+        pytest.param(
+            "TIMESTAMPS", id="valid_timestamps", marks=pytest.mark.bodosql_cpp
+        ),
     ]
 )
 def date_casting_input_type(request):
@@ -62,6 +68,7 @@ def date_casting_input_type(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 def test_date_casting_functions(
     dt_fn_dataframe, test_fn, date_casting_input_type, memory_leak_check
 ):
@@ -563,6 +570,7 @@ _to_timestamp_timestamp_data = [
             None,
         ),
         id="naive_timestamp",
+        marks=pytest.mark.bodosql_cpp,
     ),
     pytest.param(
         (
@@ -588,6 +596,7 @@ _to_timestamp_timestamp_data = [
             "Australia/Sydney",
         ),
         id="tz_timestamp",
+        marks=pytest.mark.bodosql_cpp,
     ),
     pytest.param(
         (
@@ -612,6 +621,7 @@ _to_timestamp_timestamp_data = [
             None,
         ),
         id="date",
+        marks=pytest.mark.bodosql_cpp,
     ),
 ]
 
@@ -719,6 +729,7 @@ def test_to_timestamp_non_numeric(
                 "",
             ),
             id="integers-no_scale",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             (

--- a/BodoSQL/bodosql/tests/test_cross_join.py
+++ b/BodoSQL/bodosql/tests/test_cross_join.py
@@ -7,7 +7,7 @@ from bodo.tests.utils import pytest_slow_unless_join, temp_env_override
 from bodosql.tests.utils import check_query
 
 # Skip unless any join-related files were changed
-pytestmark = pytest_slow_unless_join
+pytestmark = pytest_slow_unless_join + [pytest.mark.bodosql_cpp]
 
 
 @pytest.mark.parametrize("broadcast", [True, False])

--- a/BodoSQL/bodosql/tests/test_date.py
+++ b/BodoSQL/bodosql/tests/test_date.py
@@ -180,6 +180,7 @@ def test_date_cast_from_date(to_type, expected, memory_leak_check):
             "DAYOFWEEKISO",
             pd.Series([5, None, 5, 7, 6], dtype=pd.Int32Dtype()),
             id="valid-dayofweekiso-regular",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "hour",

--- a/BodoSQL/bodosql/tests/test_datetime_fns.py
+++ b/BodoSQL/bodosql/tests/test_datetime_fns.py
@@ -2698,6 +2698,7 @@ def date_add_sub_date_df():
                 ),
             ),
             id="DATE_ADD-vector_scalar_date_interval_with_case",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             (
@@ -2726,6 +2727,7 @@ def date_add_sub_date_df():
                 ),
             ),
             id="ADDDATE-vector_time_interval_with_case",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             (
@@ -2831,6 +2833,7 @@ def date_add_sub_date_df():
                 ),
             ),
             id="date_add_date_interval_with_case",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             (
@@ -4877,6 +4880,7 @@ def test_current_date(fn_name, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_months_between(date_df, memory_leak_check):
     query = "SELECT MONTHS_BETWEEN(B, A) from table1"
 

--- a/BodoSQL/bodosql/tests/test_decimal.py
+++ b/BodoSQL/bodosql/tests/test_decimal.py
@@ -12,6 +12,7 @@ import pytest
 import bodo
 import bodosql
 from bodo.tests.utils import pytest_mark_one_rank, temp_config_override
+from bodosql.tests.conftest import mark_if_param_id_not_in
 from bodosql.tests.utils import check_query
 
 
@@ -1906,6 +1907,7 @@ def test_decimal_trunc(df, expr, memory_leak_check):
         )
 
 
+@mark_if_param_id_not_in(pytest.mark.bodosql_cpp, {"log_onearg_vector"})
 @pytest.mark.parametrize(
     "df, expr, answer",
     [
@@ -2493,6 +2495,7 @@ def test_decimal_to_float_functions(df, expr, answer, memory_leak_check):
         )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "df, expr, answer",
     [

--- a/BodoSQL/bodosql/tests/test_distinct.py
+++ b/BodoSQL/bodosql/tests/test_distinct.py
@@ -7,6 +7,8 @@ import pytest
 
 from bodosql.tests.utils import check_query
 
+pytestmark = pytest.mark.bodosql_cpp
+
 
 def test_distinct_numeric(bodosql_numeric_types, memory_leak_check):
     """

--- a/BodoSQL/bodosql/tests/test_identifier_sensitivity.py
+++ b/BodoSQL/bodosql/tests/test_identifier_sensitivity.py
@@ -40,6 +40,7 @@ def test_spark_name_matching_invalid(memory_leak_check):
             )
 
 
+@pytest.mark.bodosql_cpp
 def test_spark_name_matching_valid(memory_leak_check):
     """
     Same setup as test_spark_name_matching_invalid but with a correct

--- a/BodoSQL/bodosql/tests/test_join.py
+++ b/BodoSQL/bodosql/tests/test_join.py
@@ -25,6 +25,7 @@ from bodo.tests.utils import (
     temp_env_override,
 )
 from bodo.utils.typing import BodoError
+from bodosql.tests.conftest import fixture_value_is_in, mark_bodosql_cpp_if
 from bodosql.tests.utils import check_query
 
 # Skip unless any join-related files were changed
@@ -335,6 +336,7 @@ def test_nested_and_join(join_dataframes, memory_leak_check):
     )
 
 
+@mark_bodosql_cpp_if(fixture_value_is_in("join_type", {"INNER", "RIGHT"}))
 def test_join_boolean(bodosql_boolean_types, join_type, memory_leak_check):
     """test all possible join types on boolean table"""
 
@@ -503,6 +505,7 @@ def test_tz_aware_join(representative_tz, memory_leak_check):
     )
 
 
+@mark_bodosql_cpp_if(fixture_value_is_in("join_type", "INNER"))
 def test_join_pow(join_type, memory_leak_check):
     """
     Make sure pow() works inside join conditions

--- a/BodoSQL/bodosql/tests/test_limit.py
+++ b/BodoSQL/bodosql/tests/test_limit.py
@@ -5,6 +5,7 @@ from bodo.tests.timezone_common import representative_tz  # noqa
 from bodosql.tests.utils import check_query
 
 
+@pytest.mark.bodosql_cpp
 def test_limit_numeric(bodosql_numeric_types, memory_leak_check):
     """test queries with limit"""
     query = "select B,C from table1 limit 4"
@@ -90,6 +91,7 @@ def test_fetch(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_top(basic_df, memory_leak_check):
     """test queries with top"""

--- a/BodoSQL/bodosql/tests/test_literals.py
+++ b/BodoSQL/bodosql/tests/test_literals.py
@@ -41,6 +41,7 @@ def timedelta_equivalent_values(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 def test_timestamp_literals(basic_df, timestamp_literal_strings, memory_leak_check):
     """
     tests that timestamp literals are correctly parsed by BodoSQL
@@ -62,6 +63,7 @@ def test_timestamp_literals(basic_df, timestamp_literal_strings, memory_leak_che
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_timestamp_literal_pd_error(basic_df, memory_leak_check):
     """This is a specific test case that is parsed correctly by calcite, but generates a runtime pandas error.
     If we want to support this, it'll probably be a quicker fix then the other ones
@@ -155,6 +157,7 @@ def test_timestamptz_literal(basic_df, memory_leak_check):
         )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_date_literal(basic_df, memory_leak_check):
     """
@@ -175,6 +178,7 @@ def test_date_literal(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_time_literal(basic_df, memory_leak_check):
     """
@@ -380,6 +384,7 @@ def test_interval_literals_addition(interval_addition_values, memory_leak_check)
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_boolean_literals(basic_df, memory_leak_check):
     """
     tests that boolean literals are correctly parsed by BodoSQL
@@ -401,6 +406,7 @@ def test_boolean_literals(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_boolean_literals_case_insensitivity(basic_df, memory_leak_check):
     """
@@ -423,6 +429,7 @@ def test_boolean_literals_case_insensitivity(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_string_literals(basic_df, memory_leak_check):
     """
     tests that string literals are correctly parsed by BodoSQL
@@ -467,6 +474,7 @@ def test_binary_literals(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_integer_literals(basic_df, memory_leak_check):
     """
@@ -488,6 +496,7 @@ def test_integer_literals(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_float_literals(basic_df, memory_leak_check):
     """
@@ -509,6 +518,7 @@ def test_float_literals(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_timestamp_null_literal(basic_df, memory_leak_check):
     """
@@ -530,6 +540,7 @@ def test_timestamp_null_literal(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_boolean_null_literals(bodosql_boolean_types, memory_leak_check):
     """
     tests that boolean literals are correctly parsed by BodoSQL
@@ -599,6 +610,7 @@ def test_integer_null_literals(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_backslash_literals(memory_leak_check):
     """
     tests that integer literals are correctly parsed by BodoSQL

--- a/BodoSQL/bodosql/tests/test_named_agg.py
+++ b/BodoSQL/bodosql/tests/test_named_agg.py
@@ -6,6 +6,8 @@ import pytest
 
 from bodosql.tests.utils import check_query
 
+pytestmark = pytest.mark.bodosql_cpp
+
 
 @pytest.mark.slow
 def test_named_agg(bodosql_numeric_types, memory_leak_check):

--- a/BodoSQL/bodosql/tests/test_null.py
+++ b/BodoSQL/bodosql/tests/test_null.py
@@ -9,6 +9,8 @@ import pytest
 
 from bodosql.tests.utils import check_query
 
+pytestmark = pytest.mark.bodosql_cpp
+
 
 @pytest.fixture(
     params=[

--- a/BodoSQL/bodosql/tests/test_null_case.py
+++ b/BodoSQL/bodosql/tests/test_null_case.py
@@ -7,6 +7,8 @@ import pytest
 
 from bodosql.tests.utils import check_query
 
+pytestmark = pytest.mark.bodosql_cpp
+
 
 @pytest.mark.slow
 def test_null_then(bodosql_nullable_numeric_types, memory_leak_check):

--- a/BodoSQL/bodosql/tests/test_numeric_fns.py
+++ b/BodoSQL/bodosql/tests/test_numeric_fns.py
@@ -953,14 +953,23 @@ def test_div0null_scalars(df, ans, request):
 @pytest.mark.parametrize(
     "values, expected_output",
     [
-        pytest.param(["1"], 1, id="int", marks=pytest.mark.slow),
-        pytest.param(["1.0"], 1, id="float"),
+        pytest.param(
+            ["1"], 1, id="int", marks=[pytest.mark.slow, pytest.mark.bodosql_cpp]
+        ),
+        pytest.param(["1.0"], 1, id="float", marks=pytest.mark.bodosql_cpp),
         pytest.param(
             ["1.5", "1", "0"], 2, id="float_with_scale", marks=pytest.mark.slow
         ),
-        pytest.param(["'1.23456789'"], 1, id="str", marks=pytest.mark.slow),
+        pytest.param(
+            ["'1.23456789'"],
+            1,
+            id="str",
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
+        ),
         pytest.param(["'1.23456789'", "5", "4"], 1.2346, id="str_with_scale"),
-        pytest.param(["NULL"], None, id="null", marks=pytest.mark.slow),
+        pytest.param(
+            ["NULL"], None, id="null", marks=[pytest.mark.slow, pytest.mark.bodosql_cpp]
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_aggregate_join_transpose.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_aggregate_join_transpose.py
@@ -56,6 +56,7 @@ def aggregate_join_transpose_queries(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_aggregate_join_transpose(
     simple_join_fixture, aggregate_join_transpose_queries

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_alias_preserving_project_join_transpose.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_alias_preserving_project_join_transpose.py
@@ -44,6 +44,7 @@ def alias_preserving_project_join_transpose_queries(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_alias_preserving_project_join_transpose(
     simple_join_fixture, alias_preserving_project_join_transpose_queries

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_aggregate_transpose.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_aggregate_transpose.py
@@ -45,6 +45,7 @@ def filter_aggregate_transpose_queries(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_filter_aggregate_transpose(basic_df, filter_aggregate_transpose_queries):
     """checks for bugs with filter aggregate transpose"""

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_into_join.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_into_join.py
@@ -31,6 +31,7 @@ def filter_into_join_queries(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_filter_into_join(simple_join_fixture, filter_into_join_queries):
     """checks for bugs with the Filter into Join rule"""

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_merge.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_merge.py
@@ -31,6 +31,7 @@ def filter_merge_queries(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_filter_merge(basic_df, filter_merge_queries):
     """checking for alias bugs with filter_merge"""

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_or_rules.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_filter_or_rules.py
@@ -9,6 +9,7 @@ import pytest
 from bodosql.tests.utils import check_query
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "query_info",
@@ -90,6 +91,7 @@ def test_logical_filter_rule(basic_df, query_info, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "query_info",

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_project_merge.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_project_merge.py
@@ -37,6 +37,7 @@ def project_merge_queries(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_project_merge(simple_join_fixture, project_merge_queries, memory_leak_check):
     """checks for bugs with project_merge"""

--- a/BodoSQL/bodosql/tests/test_optimization_rules/test_project_unaliased_remove_rule.py
+++ b/BodoSQL/bodosql/tests/test_optimization_rules/test_project_unaliased_remove_rule.py
@@ -37,6 +37,7 @@ def project_unaliased_remove_rule_queries(request):
     return request.param
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_project_unaliased_remove_rule(
     basic_df, project_unaliased_remove_rule_queries, memory_leak_check

--- a/BodoSQL/bodosql/tests/test_orderby.py
+++ b/BodoSQL/bodosql/tests/test_orderby.py
@@ -10,7 +10,7 @@ from bodo.tests.utils import pytest_slow_unless_codegen, temp_config_override
 from bodosql.tests.utils import check_query
 
 # Skip unless any codegen files were changed
-pytestmark = pytest_slow_unless_codegen
+pytestmark = pytest_slow_unless_codegen + [pytest.mark.bodosql_cpp]
 
 
 @pytest.fixture(
@@ -39,7 +39,6 @@ def col_a_identical_tables(request):
 
 
 @pytest.mark.slow
-@pytest.mark.bodosql_cpp
 def test_orderby_numeric_scalar(bodosql_numeric_types, memory_leak_check):
     """tests that orderby works with scalar values in the Select statement"""
     query = "SELECT A, 1, 2, 3, 4 as Y FROM table1 ORDER BY Y, A"
@@ -55,7 +54,6 @@ def test_orderby_numeric_scalar(bodosql_numeric_types, memory_leak_check):
 
 
 @pytest.mark.slow
-@pytest.mark.bodosql_cpp
 def test_orderby_numeric(bodosql_numeric_types, memory_leak_check):
     """
     Tests orderby works in the simple case for numeric types

--- a/BodoSQL/bodosql/tests/test_pivot.py
+++ b/BodoSQL/bodosql/tests/test_pivot.py
@@ -3,6 +3,8 @@ import pytest
 
 from bodosql.tests.utils import check_query
 
+pytestmark = pytest.mark.bodosql_cpp
+
 
 def test_basic_pivot(basic_df, memory_leak_check):
     """
@@ -92,7 +94,6 @@ def test_multi_col_null_pivot(basic_df, memory_leak_check):
     )
 
 
-@pytest.mark.bodosql_cpp
 @pytest.mark.tz_aware
 @pytest.mark.slow
 def test_tz_aware_pivot(memory_leak_check):

--- a/BodoSQL/bodosql/tests/test_projection.py
+++ b/BodoSQL/bodosql/tests/test_projection.py
@@ -54,6 +54,7 @@ def test_literal_project(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_project_numeric(bodosql_numeric_types, memory_leak_check):
     """test projection queries"""
     query = "select B, C from table1"
@@ -67,6 +68,7 @@ def test_project_numeric(bodosql_numeric_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_project_null(memory_leak_check):
     """
     Test select based on a simple null array.
@@ -84,6 +86,7 @@ def test_project_null(memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_multi_table(join_dataframes, memory_leak_check):
     """test selecting columns from multiple tables"""
     check_query(
@@ -94,6 +97,7 @@ def test_select_multi_table(join_dataframes, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_select_multi_table_order_by(join_dataframes, memory_leak_check):
     """test selecting and sorting columns from multiple tables"""
@@ -105,6 +109,7 @@ def test_select_multi_table_order_by(join_dataframes, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_all_numerics(bodosql_numeric_types, memory_leak_check):
     """
     Simplest query possible on numeric types.
@@ -119,6 +124,7 @@ def test_select_all_numerics(bodosql_numeric_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_all_large_numerics(bodosql_large_numeric_types, memory_leak_check):
     """
     Simplest query possible on large numeric types.
@@ -134,6 +140,7 @@ def test_select_all_large_numerics(bodosql_large_numeric_types, memory_leak_chec
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_all_datetime(bodosql_datetime_types, memory_leak_check):
     """
     Simplest query possible on datetime/timedelta types.
@@ -142,6 +149,7 @@ def test_select_all_datetime(bodosql_datetime_types, memory_leak_check):
     check_query(query, bodosql_datetime_types, None, use_duckdb=True)
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_select_all_interval(bodosql_interval_types, memory_leak_check):
     """
@@ -157,6 +165,7 @@ def test_select_all_interval(bodosql_interval_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_all_boolean(bodosql_boolean_types, memory_leak_check):
     """
     Simplest query possible on boolean tables.
@@ -171,6 +180,7 @@ def test_select_all_boolean(bodosql_boolean_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_select_all_string(bodosql_string_types, memory_leak_check):
     """
@@ -185,6 +195,7 @@ def test_select_all_string(bodosql_string_types, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_expand_literal(basic_df, memory_leak_check):
     """
     Tests select with all literals is expanded to
@@ -200,6 +211,7 @@ def test_select_expand_literal(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_select_literal_no_table(basic_df, memory_leak_check):
     """
@@ -216,6 +228,7 @@ def test_select_literal_no_table(basic_df, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_all_nullable_numeric(bodosql_nullable_numeric_types, memory_leak_check):
     """
     Simplest query possible on nullable numeric tables.
@@ -230,6 +243,7 @@ def test_select_all_nullable_numeric(bodosql_nullable_numeric_types, memory_leak
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_select_from_simple(join_dataframes, memory_leak_check):
     """
     tests that the select and from operators are working correctly for simple cases
@@ -271,6 +285,7 @@ def test_select_from_simple(join_dataframes, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_nested_select_from(join_dataframes, memory_leak_check):
     """
@@ -301,6 +316,7 @@ def test_nested_select_from(join_dataframes, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_heavily_nested_select_from(join_dataframes, memory_leak_check):
     """
@@ -340,6 +356,7 @@ def test_heavily_nested_select_from(join_dataframes, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_decimal(memory_leak_check):
     """
     Verify we can pass decimal columns to BodoSQL.

--- a/BodoSQL/bodosql/tests/test_reversed_import.py
+++ b/BodoSQL/bodosql/tests/test_reversed_import.py
@@ -11,6 +11,7 @@ from bodosql.tests.utils import check_query
 import bodo  # noqa
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_simple(memory_leak_check):
     dataframe_dict = {"TABLE1": pd.DataFrame({"A": [1, 2, 3]})}

--- a/BodoSQL/bodosql/tests/test_select_special.py
+++ b/BodoSQL/bodosql/tests/test_select_special.py
@@ -3,10 +3,12 @@ Test correctness of special SELECT operators
 """
 
 import pandas as pd
+import pytest
 
 from bodosql.tests.utils import check_query
 
 
+@pytest.mark.bodosql_cpp
 def test_exclude(memory_leak_check):
     """
     Test selecting all columns except some excluded names

--- a/BodoSQL/bodosql/tests/test_set_ops.py
+++ b/BodoSQL/bodosql/tests/test_set_ops.py
@@ -19,9 +19,13 @@ pytestmark = pytest_slow_unless_codegen
 
 @pytest.fixture(
     params=[
-        pytest.param("UNION", id="union_op"),
-        pytest.param("UNION DISTINCT", id="union_distinct", marks=pytest.mark.slow),
-        pytest.param("UNION ALL", id="union_all"),
+        pytest.param("UNION", id="union_op", marks=pytest.mark.bodosql_cpp),
+        pytest.param(
+            "UNION DISTINCT",
+            id="union_distinct",
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
+        ),
+        pytest.param("UNION ALL", id="union_all", marks=pytest.mark.bodosql_cpp),
     ]
 )
 def union_cmds(request) -> str:
@@ -55,9 +59,13 @@ def except_cmds(request) -> str:
 
 @pytest.fixture(
     params=[
-        pytest.param("UNION", id="union_op"),
-        pytest.param("UNION DISTINCT", id="union_distinct", marks=pytest.mark.slow),
-        pytest.param("UNION ALL", id="union_all"),
+        pytest.param("UNION", id="union_op", marks=pytest.mark.bodosql_cpp),
+        pytest.param(
+            "UNION DISTINCT",
+            id="union_distinct",
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
+        ),
+        pytest.param("UNION ALL", id="union_all", marks=pytest.mark.bodosql_cpp),
         pytest.param("INTERSECT", id="intersect_op"),
         pytest.param(
             "INTERSECT DISTINCT", id="intersect_distinct", marks=pytest.mark.slow

--- a/BodoSQL/bodosql/tests/test_set_ops.py
+++ b/BodoSQL/bodosql/tests/test_set_ops.py
@@ -19,13 +19,13 @@ pytestmark = pytest_slow_unless_codegen
 
 @pytest.fixture(
     params=[
-        pytest.param("UNION", id="union_op", marks=pytest.mark.bodosql_cpp),
+        pytest.param("UNION", id="union_op"),
         pytest.param(
             "UNION DISTINCT",
             id="union_distinct",
-            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
+            marks=pytest.mark.slow,
         ),
-        pytest.param("UNION ALL", id="union_all", marks=pytest.mark.bodosql_cpp),
+        pytest.param("UNION ALL", id="union_all"),
     ]
 )
 def union_cmds(request) -> str:
@@ -422,6 +422,7 @@ def test_set_ops_binary_cols(bodosql_binary_types, set_ops_cmds, memory_leak_che
 # ===== String Restrictions
 
 
+@pytest.mark.bodosql_cpp
 def test_union_string_restrictions(bodosql_string_types, union_cmds, memory_leak_check):
     """
     Test that UNION [ALL/DISTINCT] works for string columns when used with restrictions
@@ -488,6 +489,7 @@ def test_except_string_restrictions(
 # ===== Timezone-Aware Cols
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.slow
 def test_union_tz_aware_cols(union_cmds, representative_tz, memory_leak_check):
     """

--- a/BodoSQL/bodosql/tests/test_string_ops_second_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_second_half.py
@@ -438,6 +438,26 @@ def mk_broadcasted_string_queries():
                     reason=f"Cannot test {name} until next mini release",
                 ),
             )
+        if tag in [
+            "LPAD-scalar_int-2args",
+            "LPAD-all_scalar-2args",
+            "RPAD-scalar_int-2args",
+            "RPAD-all_scalar-2args",
+            "LPAD-all_scalar",
+            "LEFT_scalar_int",
+            "LEFT_all_scalar",
+            "RIGHT_scalar_int",
+            "RIGHT_all_scalar",
+            "REPEAT_scalar_int",
+            "REPEAT_all_scalar",
+            "REVERSE_vector",
+            "REPLACE_scalar_str_2",
+            "REPLACE_all_scalar",
+            "SPACE_scalar",
+            "INSTR_vector_scalar",
+            "INSTR_all_scalar",
+        ]:
+            marks += (pytest.mark.bodosql_cpp,)
         param = pytest.param(query, id=tag, marks=marks)
         result.append(param)
     return result

--- a/BodoSQL/bodosql/tests/test_time_fns.py
+++ b/BodoSQL/bodosql/tests/test_time_fns.py
@@ -80,6 +80,7 @@ def test_time_box_array_unbox(precision, memory_leak_check):
             pd.Series([12, 1, 9, 20, 23]),
             None,
             id="valid-hour-date_part",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "minute",
@@ -87,6 +88,7 @@ def test_time_box_array_unbox(precision, memory_leak_check):
             pd.Series([30, 2, 59, 45, 50]),
             None,
             id="valid-minute-regular",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "second",
@@ -94,6 +96,7 @@ def test_time_box_array_unbox(precision, memory_leak_check):
             pd.Series([15, 3, 0, 1, 59]),
             None,
             id="valid-second-date_part",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "millisecond",
@@ -101,6 +104,7 @@ def test_time_box_array_unbox(precision, memory_leak_check):
             pd.Series([0, 4, 100, 123, 500]),
             None,
             id="valid-millisecond-extract",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "microsecond",
@@ -108,6 +112,7 @@ def test_time_box_array_unbox(precision, memory_leak_check):
             pd.Series([0, 0, 250, 456, 0]),
             None,
             id="valid-microsecond-regular",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "nanosecond",
@@ -115,6 +120,7 @@ def test_time_box_array_unbox(precision, memory_leak_check):
             pd.Series([0, 0, 0, 789, 999]),
             None,
             id="valid-nanosecond-extract",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "day",

--- a/BodoSQL/bodosql/tests/test_type_conversions.py
+++ b/BodoSQL/bodosql/tests/test_type_conversions.py
@@ -5,11 +5,11 @@ Test correctness of SQL casting
 import pandas as pd
 import pytest
 
+from bodosql.tests.conftest import fixture_value_not_in, mark_bodosql_cpp_if
 from bodosql.tests.utils import check_query
 
-pytestmark = pytest.mark.bodosql_cpp
 
-
+@pytest.mark.bodosql_cpp
 def test_simple_cast(basic_df, memory_leak_check):
     """
     Checks that integer casting of constants behaves as expected
@@ -25,6 +25,7 @@ def test_simple_cast(basic_df, memory_leak_check):
     )
 
 
+@mark_bodosql_cpp_if(fixture_value_not_in("sql_numeric_typestrings", {"DECIMAL"}))
 @pytest.mark.slow
 def test_float_to_int_cast(
     basic_df, numeric_values, sql_numeric_typestrings, memory_leak_check
@@ -47,6 +48,7 @@ def test_float_to_int_cast(
     )
 
 
+@mark_bodosql_cpp_if(fixture_value_not_in("sql_numeric_typestrings", {"DECIMAL"}))
 def test_numeric_column_casting(
     bodosql_numeric_types, sql_numeric_typestrings, memory_leak_check
 ):
@@ -113,6 +115,7 @@ def test_interval_numeric_column_casting(
     )
 
 
+@mark_bodosql_cpp_if(fixture_value_not_in("sql_numeric_typestrings", {"DECIMAL"}))
 @pytest.mark.slow
 def test_varchar_to_numeric_cast(sql_numeric_typestrings, memory_leak_check):
     """
@@ -138,6 +141,7 @@ def test_varchar_to_numeric_cast(sql_numeric_typestrings, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 def test_numeric_to_varchar_nullable(bodosql_nullable_numeric_types, memory_leak_check):
     """
     Checks that casting numeric values to strings behaves as expected

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -191,12 +191,16 @@ getDefaultValueForDuckdbValueType(const duckdb::Value &value) {
                 arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
             return arrow::MakeNullScalar(timestamp_type);
         } break;
+        case duckdb::LogicalTypeId::BLOB: {
+            auto binary_type = arrow::binary();
+            return arrow::MakeNullScalar(binary_type);
+        } break;
         case duckdb::LogicalTypeId::SQLNULL: {
             return arrow::MakeNullScalar(arrow::null());
         } break;
         default:
             throw std::runtime_error(
-                "getDefaultValueForDuckdbValueType unhandled type." +
+                "getDefaultValueForDuckdbValueType unhandled type: " +
                 std::to_string(static_cast<int>(type)));
     }
 }


### PR DESCRIPTION
## Changes included in this PR

Enable the majority of currently unmarked tests that are passing with the C++ backend.
Also adds some utility functions to `BodoSQL/bodosql/tests/conftest.py` so that we can more easily mark parametrized test cases. We could probably generalize it further (e.g. add markers other than `pytest.mark.bodosql_cpp`), but I didn't want to over-engineer before we have a real use case.

## Testing strategy

PR CI and Nightly. I'll make sure to review the Nightly closely in case I accidentally enabled a failing test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.