### PR TITLE
Support TRIM/LTRIM/RTRIM in C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -4017,6 +4017,21 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             return ArrowScalarFuncExpression(
                 int_empty_data, [rtrimmed_expr], "utf8_length", ()
             )
+        elif func_name in ("LTRIM", "RTRIM") and len(op_exprs) in (1, 2):
+            src = op_exprs[0]
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+
+            if len(op_exprs) == 2:
+                trim_chars_expr = op_exprs[1]
+                ensure_arg_is_const_expr_of_type(
+                    trim_chars_expr, "trim_chars_expr", (str, pa.binary())
+                )
+                trim_chars = trim_chars_expr.value
+            else:
+                trim_chars = " "
+            return ArrowScalarFuncExpression(
+                src.empty_data, [src], f"utf8_{func_name.lower()}", (trim_chars,)
+            )
         elif func_name == "INSERT" and len(op_exprs) == 4:
             src = op_exprs[0]
             start_expr = op_exprs[1]
@@ -4104,6 +4119,40 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 # We use cast to convert timezones.
                 target_timestamp_expr = CastExpression(target_timestamp_empty_data, src)
                 return target_timestamp_expr
+
+    if operator_class_name == "SqlTrimFunction":
+        operands = java_call.getOperands()
+        func_name = op.getName().upper()
+
+        if func_name == "TRIM" and len(operands) == 3:
+            # Snowflake's TRIM accepts 1 or 2 arguments but Calcite will convert it to
+            # a 3-arguments form, including using a space character as the default when
+            # trim characters are not specified.
+            trim_chars_expr = java_expr_to_python_expr(ctx, operands[1], input_plan)
+            src = java_expr_to_python_expr(ctx, operands[2], input_plan)
+            ensure_arg_is_const_expr_of_type(
+                trim_chars_expr, "trim_chars_expr", (str, pa.binary())
+            )
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+
+            # Get which side of the string to TRIM.
+            # Snowflake's TRIM always trims from both sides.
+            # LTRIM and RTRIM are instead mapped to SqlNullPolicyFunctions.
+            side_str = get_java_symbol(operands[0])
+            assert side_str in ("BOTH", "LEADING", "TRAILING")
+
+            # We support LEADING and TRAILING for completeness even
+            # though we don't expect them here.
+            if side_str == "BOTH":
+                arrow_trim_func = "utf8_trim"
+            elif side_str == "LEADING":
+                arrow_trim_func = "utf8_ltrim"
+            elif side_str == "TRAILING":
+                arrow_trim_func = "utf8_rtrim"
+
+            return ArrowScalarFuncExpression(
+                src.empty_data, [src], arrow_trim_func, (trim_chars_expr.value,)
+            )
 
     if operator_class_name == "SqlSubstringFunction":
         operands = java_call.getOperands()

--- a/BodoSQL/bodosql/tests/test_trim_ltrim_rtrim.py
+++ b/BodoSQL/bodosql/tests/test_trim_ltrim_rtrim.py
@@ -13,91 +13,135 @@ pytestmark = pytest_slow_unless_codegen
 
 
 @pytest.mark.slow
-def test_trim(trim_df, memory_leak_check):
+@pytest.mark.parametrize(
+    "query, answer",
+    [
+        pytest.param(
+            "SELECT TRIM(A) FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["A"].str.strip()}),
+            id="one_arg",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT TRIM(B, '*') FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["B"].str.strip("*")}),
+            id="two_args1",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT TRIM(C, 'asd') FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["C"].str.strip("asd")}),
+            id="two_args2",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT TRIM(C, LEFT(C, 1)) FROM table1",
+            lambda df: pd.DataFrame(
+                {
+                    0: pd.Series(
+                        ["sdafzcvdf", "sasdaads", None, "cvxcbxasd", "akjhkjhs"] * 4
+                    )
+                }
+            ),
+            id="nonconstant_trim_chars",
+        ),
+    ],
+)
+def test_trim(trim_df, query, answer, memory_leak_check):
     """
     Tests TRIM with and without optional characters (scalars/columns)
     """
-
-    queries = (
-        "SELECT TRIM(A) FROM table1",
-        "SELECT TRIM(B, '*') FROM table1",
-        "SELECT TRIM(C, 'asd') FROM table1",
-        "SELECT TRIM(C, LEFT(C, 1)) FROM table1",
+    check_query(
+        query,
+        trim_df,
+        spark=None,
+        check_dtype=False,
+        check_names=False,
+        expected_output=answer(trim_df),
     )
-    answers = (
-        pd.DataFrame({0: trim_df["TABLE1"]["A"].str.strip()}),
-        pd.DataFrame({0: trim_df["TABLE1"]["B"].str.strip("*")}),
-        pd.DataFrame({0: trim_df["TABLE1"]["C"].str.strip("asd")}),
-        pd.DataFrame(
-            {0: pd.Series(["sdafzcvdf", "sasdaads", None, "cvxcbxasd", "akjhkjhs"] * 4)}
-        ),
-    )
-
-    for query, answer in zip(queries, answers):
-        check_query(
-            query,
-            trim_df,
-            spark=None,
-            check_dtype=False,
-            check_names=False,
-            expected_output=answer,
-        )
 
 
 @pytest.mark.slow
-def test_ltrim(trim_df, memory_leak_check):
+@pytest.mark.parametrize(
+    "query, answer",
+    [
+        pytest.param(
+            "SELECT LTRIM(A) FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["A"].str.lstrip()}),
+            id="one_arg",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT LTRIM(B, '*') FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["B"].str.lstrip("*")}),
+            id="two_args1",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT LTRIM(C, 'asd') FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["C"].str.lstrip("asd")}),
+            id="two_args2",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT LTRIM(C, LEFT(C, 1)) FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["C"].str[1:]}),
+            id="nonconstant_trim_chars",
+        ),
+    ],
+)
+def test_ltrim(trim_df, query, answer, memory_leak_check):
     """
     Tests LTRIM with and without optional characters (scalars/columns)
     """
-
-    queries = (
-        "SELECT LTRIM(A) FROM table1",
-        "SELECT LTRIM(B, '*') FROM table1",
-        "SELECT LTRIM(C, 'asd') FROM table1",
-        "SELECT LTRIM(C, LEFT(C, 1)) FROM table1",
+    check_query(
+        query,
+        trim_df,
+        spark=None,
+        check_dtype=False,
+        check_names=False,
+        expected_output=answer(trim_df),
     )
-    answers = (
-        pd.DataFrame({0: trim_df["TABLE1"]["A"].str.lstrip()}),
-        pd.DataFrame({0: trim_df["TABLE1"]["B"].str.lstrip("*")}),
-        pd.DataFrame({0: trim_df["TABLE1"]["C"].str.lstrip("asd")}),
-        pd.DataFrame({0: trim_df["TABLE1"]["C"].str[1:]}),
-    )
-
-    for query, answer in zip(queries, answers):
-        check_query(
-            query,
-            trim_df,
-            spark=None,
-            check_dtype=False,
-            check_names=False,
-            expected_output=answer,
-        )
 
 
 @pytest.mark.slow
-def test_rtrim(trim_df, memory_leak_check):
+@pytest.mark.parametrize(
+    "query, answer",
+    [
+        pytest.param(
+            "SELECT RTRIM(A) FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["A"].str.rstrip()}),
+            id="one_arg",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT RTRIM(B, '*') FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["B"].str.rstrip("*")}),
+            id="two_args1",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT RTRIM(C, 'asd') FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["C"].str.rstrip("asd")}),
+            id="two_args2",
+            marks=pytest.mark.bodosql_cpp,
+        ),
+        pytest.param(
+            "SELECT RTRIM(C, RIGHT(C, 1)) FROM table1",
+            lambda df: pd.DataFrame({0: df["TABLE1"]["C"].str[:-1]}),
+            id="nonconstant_trim_chars",
+        ),
+    ],
+)
+def test_rtrim(trim_df, query, answer, memory_leak_check):
     """
     Tests RTRIM with and without optional characters (scalars/columns)
     """
-    queries = (
-        "SELECT RTRIM(A) FROM table1",
-        "SELECT RTRIM(B, '*') FROM table1",
-        "SELECT RTRIM(C, 'asd') FROM table1",
-        "SELECT RTRIM(C, RIGHT(C, 1)) FROM table1",
+    check_query(
+        query,
+        trim_df,
+        spark=None,
+        check_dtype=False,
+        check_names=False,
+        expected_output=answer(trim_df),
     )
-    answers = (
-        pd.DataFrame({0: trim_df["TABLE1"]["A"].str.rstrip()}),
-        pd.DataFrame({0: trim_df["TABLE1"]["B"].str.rstrip("*")}),
-        pd.DataFrame({0: trim_df["TABLE1"]["C"].str.rstrip("asd")}),
-        pd.DataFrame({0: trim_df["TABLE1"]["C"].str[:-1]}),
-    )
-
-    for query, answer in zip(queries, answers):
-        check_query(
-            query,
-            trim_df,
-            spark=None,
-            check_dtype=False,
-            check_names=False,
-            expected_output=answer,
-        )


### PR DESCRIPTION
## Changes included in this PR

`TRIM`/`LTRIM`/`RTRIM` are now supported in the C++ backend.
I had to parametrize the trim tests so that I could mark only the cases with constant trim characters, since that is all that the Arrow trim compute functions allow.

## Testing strategy

Might have to run the nightly because the trim tests are marked slow so PR CI won't cover them. But I've tested them locally anyway.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.