### PR TITLE
Support decimal constants in DuckDB plans

### DIFF
--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -129,6 +129,30 @@ extractValue(const duckdb::Value &value) {
             auto dur_type = arrow::duration(arrow::TimeUnit::NANO);
             return arrow::MakeScalar(dur_type, total_nanos).ValueOrDie();
         } break;
+        case duckdb::LogicalTypeId::DECIMAL: {
+            // Similar to DuckDB's DECIMAL Value creation function here:
+            // https://github.com/bodo-ai/Bodo/blob/b6831ac9551f6cbb7fd6a4a50bb281021d0265e7/bodo/pandas/vendor/duckdb/src/common/types/value.cpp#L606
+            uint8_t width = duckdb::DecimalType::GetWidth(value.type());
+            uint8_t scale = duckdb::DecimalType::GetScale(value.type());
+            switch (value.type().InternalType()) {
+                case duckdb::PhysicalType::INT128: {
+                    duckdb::hugeint_t val =
+                        value.GetValueUnsafe<duckdb::hugeint_t>();
+                    return arrow::MakeScalar(
+                               arrow::decimal128(width, scale),
+                               arrow::Decimal128(val.upper, val.lower))
+                        .ValueOrDie();
+                } break;
+                default: {
+                    // TODO[BSE-5532]: Handle other physical types for DECIMAL
+                    throw std::runtime_error(
+                        "Unhandled DuckDB physical type for DECIMAL Value: " +
+                        std::to_string(
+                            static_cast<int>(value.type().InternalType())));
+                } break;
+            }
+        } break;
+
         default:
             throw std::runtime_error("extractValue unhandled type: " +
                                      std::to_string(static_cast<int>(type)));

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -3,6 +3,7 @@ import operator
 import os
 import tempfile
 import warnings
+from decimal import Decimal
 
 import numba  # noqa TID253
 import numpy as np
@@ -2255,6 +2256,30 @@ def test_series_cmp_binops(datapath, index_val):
     with assert_executed_plan_count(0):
         S = df["A"] + 1 > df["C"].sum()
         bodo_S = bdf["A"] + 1 > bdf["C"].sum()
+
+    _test_equal(
+        bodo_S.execute_plan(),
+        S,
+        check_pandas_types=False,
+    )
+
+
+def test_decimal_cmp(index_val):
+    """Test comparison operation on decimal columns."""
+    df = pd.DataFrame(
+        {
+            "A": pd.Series(
+                [Decimal("1.1"), Decimal("2.2"), Decimal("3.3")],
+                dtype=pd.ArrowDtype(pa.decimal128(38, 2)),
+            )
+        }
+    )
+    df.index = index_val[: len(df)]
+    bdf = bd.from_pandas(df)
+
+    with assert_executed_plan_count(0):
+        S = df.A > 2.1
+        bodo_S = bdf.A > 2.1
 
     _test_equal(
         bodo_S.execute_plan(),


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Needed to support decimal comparison.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit test.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Decimal comparison now works.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.