### PR TITLE
More decimal support.

### DIFF
--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1837,6 +1837,21 @@ cudf::data_type duckdb_logicaltype_to_cudf(const duckdb::LogicalType &dtype) {
             // on your convention)
             return cudf::data_type{type_id::INT64};
 
+        case LogicalTypeId::DECIMAL: {
+            uint8_t precision = 0;
+            uint8_t scale = 0;
+
+            dtype.GetDecimalProperties(precision, scale);
+
+            if (precision <= 0 || precision > 38) {
+                throw std::runtime_error(
+                    "duckdbTypeToArrow invalid DECIMAL precision " +
+                    std::to_string(precision));
+            }
+
+            return cudf::data_type{type_id::DECIMAL128, scale};
+        } break;
+
         // Fallback for unknown/unsupported types
         default:
             throw std::runtime_error(

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1845,7 +1845,7 @@ cudf::data_type duckdb_logicaltype_to_cudf(const duckdb::LogicalType &dtype) {
 
             if (precision <= 0 || precision > 38) {
                 throw std::runtime_error(
-                    "duckdbTypeToArrow invalid DECIMAL precision " +
+                    "duckdb_logicaltype_to_cudf: invalid DECIMAL precision " +
                     std::to_string(precision));
             }
 

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -601,6 +601,20 @@ std::shared_ptr<arrow::DataType> duckdbTypeToArrow(
             // NOTE: using ns by default but DuckDB interval type loses
             // precision in Arrow type roundtrips
             return arrow::duration(arrow::TimeUnit::NANO);
+        case duckdb::LogicalTypeId::DECIMAL: {
+            uint8_t precision = 0;
+            uint8_t scale = 0;
+
+            type.GetDecimalProperties(precision, scale);
+
+            if (precision <= 0 || precision > 38) {
+                throw std::runtime_error(
+                    "duckdbTypeToArrow invalid DECIMAL precision " +
+                    std::to_string(precision));
+            }
+
+            return arrow::decimal128(precision, scale);
+        } break;
         default:
             throw std::runtime_error(
                 "duckdbTypeToArrow unsupported LogicalType conversion " +
@@ -681,6 +695,19 @@ duckdb::LogicalType arrowTypeToDuckDB(
                         std::to_string(static_cast<int>(dur_type->unit())));
             }
         } break;
+        case arrow::Type::DECIMAL128: {
+            auto dec_type =
+                std::static_pointer_cast<arrow::Decimal128Type>(type);
+            int32_t precision = dec_type->precision();
+            int32_t scale = dec_type->scale();
+            // DuckDB typically supports up to 38 digits of precision
+            if (precision < 1 || precision > 38) {
+                throw std::runtime_error(
+                    "arrowTypeToDuckDB unsupported Decimal128 precision " +
+                    std::to_string(precision));
+            }
+            return duckdb::LogicalType::DECIMAL(precision, scale);
+        }
         default:
             throw std::runtime_error(
                 "arrowTypeToDuckDB unsupported Arrow type conversion " +

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1253,6 +1253,32 @@ def test_set_df_column_arith(datapath, index_val):
     _test_equal(bdf, pdf, check_pandas_types=False)
 
 
+@pytest.mark.parametrize(
+    "arith_ops",
+    [
+        pytest.param(operator.add, id="add"),
+        pytest.param(operator.sub, id="sub"),
+        pytest.param(operator.mul, id="mul"),
+    ],
+)
+def test_set_df_column_arith_decimal(datapath, arith_ops):
+    """Test setting a dataframe column with a Series function of the same dataframe."""
+
+    with assert_executed_plan_count(0):
+        df = pd.DataFrame(
+            {
+                "A": [Decimal("1.10"), Decimal("2.25"), Decimal("3.333")],
+                "B": [Decimal("0.90"), Decimal("1.75"), Decimal("0.667")],
+            }
+        )
+
+        bdf = bd.from_pandas(df)
+        bdf["D"] = arith_ops(bdf["A"], bdf["B"])
+        pdf = df.copy()
+        pdf["D"] = arith_ops(pdf["A"], pdf["B"])
+    _test_equal(bdf, pdf, check_pandas_types=False)
+
+
 def test_set_df_column_extra_proj(datapath, index_val):
     """Test setting a dataframe column with a Series function of the same dataframe to
     a dataframe that has column projections on top of the source dataframe.
@@ -2342,7 +2368,7 @@ def test_series_astype(astype_case):
         check_pandas_types=False,
     )
 
-    
+
 def test_decimal_cmp(index_val):
     """Test comparison operation on decimal columns."""
     df = pd.DataFrame(

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -1254,14 +1254,14 @@ def test_set_df_column_arith(datapath, index_val):
 
 
 @pytest.mark.parametrize(
-    "arith_ops",
+    "arith_op",
     [
         pytest.param(operator.add, id="add"),
         pytest.param(operator.sub, id="sub"),
         pytest.param(operator.mul, id="mul"),
     ],
 )
-def test_set_df_column_arith_decimal(datapath, arith_ops):
+def test_set_df_column_arith_decimal(datapath, arith_op):
     """Test setting a dataframe column with a Series function of the same dataframe."""
 
     with assert_executed_plan_count(0):
@@ -1273,9 +1273,9 @@ def test_set_df_column_arith_decimal(datapath, arith_ops):
         )
 
         bdf = bd.from_pandas(df)
-        bdf["D"] = arith_ops(bdf["A"], bdf["B"])
+        bdf["D"] = arith_op(bdf["A"], bdf["B"])
         pdf = df.copy()
-        pdf["D"] = arith_ops(pdf["A"], pdf["B"])
+        pdf["D"] = arith_op(pdf["A"], pdf["B"])
     _test_equal(bdf, pdf, check_pandas_types=False)
 
 


### PR DESCRIPTION


## Changes included in this PR

Support arrow<=>duckdb decimal type conversions.  Add test for decimal arith.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [X] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.