### PR TITLE
Support REGEXP_INSTR in BodoSQL C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -680,7 +680,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         )
         return timestamp_expr
 
-    def clean_regex_params(regex_params_expr):
+    def clean_regex_params(regex_params_expr, func_name):
         """Verify the raw regex parameters passed into functions such as REGEXP_SUBSTR
         or REGEXP_INSTR and turn them into a standard form."""
         if "c" in regex_params_expr.value and "i" in regex_params_expr.value:
@@ -3107,8 +3107,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
                 if start_expr.value > 0:
                     start = start_expr.value - 1
+                elif start_expr.value == 0:
+                    start = 0
                 else:
-                    start = start_expr.value
+                    raise ValueError("Start index must be positive for REGEXP_SUBSTR.")
             else:
                 start = 0
 
@@ -3131,7 +3133,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 ensure_arg_is_const_expr_of_type(
                     regex_params_expr, "regex_params_expr", str
                 )
-                regex_params = clean_regex_params(regex_params_expr)
+                regex_params = clean_regex_params(regex_params_expr, func_name)
             else:
                 regex_params = "c"
 
@@ -3962,8 +3964,10 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
                 if start_expr.value > 0:
                     start = start_expr.value - 1
+                elif start_expr.value == 0:
+                    start = 0
                 else:
-                    start = start_expr.value
+                    raise ValueError("Start index must be positive for REGEXP_INSTR.")
             else:
                 start = 0
 
@@ -3999,7 +4003,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 ensure_arg_is_const_expr_of_type(
                     regex_params_expr, "regex_params_expr", str
                 )
-                regex_params = clean_regex_params(regex_params_expr)
+                regex_params = clean_regex_params(regex_params_expr, func_name)
             else:
                 regex_params = "c"
 

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -680,6 +680,38 @@ def java_call_to_python_call(ctx, java_call, input_plan):
         )
         return timestamp_expr
 
+    def clean_regex_params(regex_params_expr):
+        """Verify the raw regex parameters passed into functions such as REGEXP_SUBSTR
+        or REGEXP_INSTR and turn them into a standard form."""
+        if "c" in regex_params_expr.value and "i" in regex_params_expr.value:
+            # Both case sensitive and case insensitive params provided; find which appears latest in the string
+            latest_index = max(
+                regex_params_expr.value.rfind(char) for char in ("c", "i")
+            )
+            latest_char = regex_params_expr.value[latest_index]
+            # Remove occurrences of the other parameter to make the identification easier on the C++ side
+            regex_params = regex_params_expr.value.replace(
+                "c" if latest_char == "i" else "i", ""
+            )
+        else:
+            if (
+                "c" not in regex_params_expr.value
+                and "i" not in regex_params_expr.value
+            ):
+                regex_params = regex_params_expr.value + "c"
+            else:
+                regex_params = regex_params_expr.value
+        for character in regex_params:
+            if character not in ("c", "i", "m", "e", "s"):
+                raise ValueError(
+                    f"{func_name} regex parameter {character} does not exist"
+                )
+            if character in ("i", "m", "s"):
+                raise ValueError(
+                    f"{func_name} regex parameter {character} is not yet supported in the C++ backend"
+                )
+        return regex_params
+
     if operator_class_name == "SqlNullPolicyFunction":
         func_name = op.getName().upper()
         num_operands = len(java_call.getOperands())
@@ -3063,37 +3095,6 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
 
         if func_name == "REGEXP_SUBSTR" and len(op_exprs) in (2, 3, 4, 5, 6):
-
-            def clean_regex_params(regex_params_expr):
-                if "c" in regex_params_expr.value and "i" in regex_params_expr.value:
-                    # Both case sensitive and case insensitive params provided; find which appears latest in the string
-                    latest_index = max(
-                        regex_params_expr.value.rfind(char) for char in ("c", "i")
-                    )
-                    latest_char = regex_params_expr.value[latest_index]
-                    # Remove occurrences of the other parameter to make the identification easier on the C++ side
-                    regex_params = regex_params_expr.value.replace(
-                        "c" if latest_char == "i" else "i", ""
-                    )
-                else:
-                    if (
-                        "c" not in regex_params_expr.value
-                        and "i" not in regex_params_expr.value
-                    ):
-                        regex_params = regex_params_expr.value + "c"
-                    else:
-                        regex_params = regex_params_expr.value
-                for character in regex_params:
-                    if character not in ("c", "i", "m", "e", "s"):
-                        raise ValueError(
-                            f"{func_name} regex parameter {character} does not exist"
-                        )
-                    if character in ("i", "m", "s"):
-                        raise ValueError(
-                            f"{func_name} regex parameter {character} is not yet supported in the C++ backend"
-                        )
-                return regex_params
-
             src = op_exprs[0]
             regexp = op_exprs[1]
 
@@ -3144,9 +3145,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 group_num = group_num_expr.value
                 if group_num > 0:
                     group_num -= 1  # Convert from 1-based to 0-based
-                regex_params = (
-                    regex_params + "e"
-                )  # 'e' is implied if group_num is passed
+                # 'e' is implied if group_num is passed
+                regex_params += "e"
             else:
                 group_num = 0
 
@@ -3163,7 +3163,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
             # Remove earlier occurrences so that extract_regex can find the correct occurrence/substring matching the regexp
             if occurrence_num > 1:
-                occurences_replaced_expr = ArrowScalarFuncExpression(
+                occurrences_replaced_expr = ArrowScalarFuncExpression(
                     src.empty_data,
                     [without_start_expr],
                     "replace_substring_regex",
@@ -3174,11 +3174,11 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                     ),
                 )
             else:
-                occurences_replaced_expr = without_start_expr
+                occurrences_replaced_expr = without_start_expr
 
             return ArrowScalarFuncExpression(
                 src.empty_data,
-                [occurences_replaced_expr],
+                [occurrences_replaced_expr],
                 "regexp_substr",  # Made up function, will redirect to extract_regex with the right group extracted
                 (regexp.value, regex_params, group_num),
             )
@@ -3947,6 +3947,165 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             one_expr = ConstantExpression(int_empty_data, input_plan, 1)
             return ArithOpExpression(
                 int_empty_data, adjusted_substring_pos_expr, one_expr, "__add__"
+            )
+
+        elif func_name == "REGEXP_INSTR" and len(op_exprs) in (2, 3, 4, 5, 6, 7):
+            src = op_exprs[0]
+            regexp = op_exprs[1]
+
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(regexp, "regexp", (str, pa.binary()))
+
+            if len(op_exprs) >= 3:
+                start_expr = op_exprs[2]
+                ensure_arg_is_const_expr_of_type(start_expr, "start_expr", int)
+
+                if start_expr.value > 0:
+                    start = start_expr.value - 1
+                else:
+                    start = start_expr.value
+            else:
+                start = 0
+
+            if len(op_exprs) >= 4:
+                # Need to search for the substring that is the op_exprs[3]-th occurrence / regex match
+                occurrence_expr = op_exprs[3]
+                ensure_arg_is_const_expr_of_type(
+                    occurrence_expr, "occurrence_expr", int
+                )
+                occurrence_num = occurrence_expr.value
+                if occurrence_num < 1:
+                    raise ValueError(
+                        f"{func_name} occurences argument must be 1 or greater"
+                    )
+            else:
+                occurrence_num = 1
+
+            # The "option" parameter specifies whether to return the offset of the first character of the match (0) or the offset of the first character following the end of the match (1).
+            if len(op_exprs) >= 5:
+                start_or_end_index_expr = op_exprs[4]
+                ensure_arg_is_const_expr_of_type(
+                    start_or_end_index_expr, "start_or_end_index_expr", int
+                )
+                start_or_end_index = start_or_end_index_expr.value
+                assert start_or_end_index in (0, 1), (
+                    "The 'option' parameter must be 0 or 1."
+                )
+            else:
+                start_or_end_index = 0
+
+            if len(op_exprs) >= 6:
+                regex_params_expr = op_exprs[5]
+                ensure_arg_is_const_expr_of_type(
+                    regex_params_expr, "regex_params_expr", str
+                )
+                regex_params = clean_regex_params(regex_params_expr)
+            else:
+                regex_params = "c"
+
+            if len(op_exprs) == 7:
+                group_num_expr = op_exprs[6]
+                ensure_arg_is_const_expr_of_type(group_num_expr, "group_num_expr", int)
+                if group_num_expr.value < 0:
+                    raise ValueError(
+                        f"Negative value for group_num argument of {func_name} is not permitted"
+                    )
+                group_num = group_num_expr.value
+                if group_num > 0:
+                    group_num -= 1  # Convert from 1-based to 0-based
+                # 'e' is implied if group_num is passed
+                regex_params += "e"
+            else:
+                group_num = 0
+
+            # Chop off the start so that searching begins after the provided position
+            if start > 0:
+                without_start_expr = ArrowScalarFuncExpression(
+                    src.empty_data,
+                    [src],
+                    "utf8_slice_codeunits",
+                    (start, None, 1),
+                )
+            else:
+                without_start_expr = src
+
+            # Remove earlier occurrences so that extract_regex_span can find the correct occurrence/substring matching the regexp
+            if occurrence_num > 1:
+                occurrences_replaced_expr = ArrowScalarFuncExpression(
+                    src.empty_data,
+                    [without_start_expr],
+                    "replace_substring_regex",
+                    (
+                        regexp.value,
+                        "",
+                        occurrence_num - 1,
+                    ),
+                )
+            else:
+                occurrences_replaced_expr = without_start_expr
+
+            # 0-based index of the match in the shortened string with earlier occurrences removed.
+            # If index = -1, no match was found.
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            zero_based_index = ArrowScalarFuncExpression(
+                int_empty_data,
+                [occurrences_replaced_expr],
+                "regexp_instr",  # Bodo function implemented using Arrow's extract_regex_span
+                (regexp.value, start_or_end_index == 0, regex_params, group_num),
+            )
+            # Add 1 to convert to 1-based index. -1 also becomes 0 which is what Snowflake returns for the invalid cases
+            index = ArithOpExpression(
+                int_empty_data,
+                zero_based_index,
+                ConstantExpression(int_empty_data, input_plan, 1),
+                "__add__",
+            )
+
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+
+            # We need to compensate for the lengths of the occurrences that were removed (as well as the start_expr-1 characters that were cut off at the beginning).
+            if start > 0 or occurrence_num > 1:
+                if occurrence_num > 1:
+                    # We can find the total lost length by subtracting the current string length from the original string length.
+                    cur_length = ArrowScalarFuncExpression(
+                        int_empty_data, [occurrences_replaced_expr], "utf8_length", ()
+                    )
+                    original_length = ArrowScalarFuncExpression(
+                        int_empty_data, [src], "utf8_length", ()
+                    )
+                    lost_length = ArithOpExpression(
+                        int_empty_data, original_length, cur_length, "__sub__"
+                    )
+                else:
+                    # If occurrence_num = 1, we know in advance how many characters were removed
+                    lost_length = ConstantExpression(int_empty_data, input_plan, start)
+
+                # Add back the lost length to the index
+                compensated_index = ArithOpExpression(
+                    int_empty_data, index, lost_length, "__add__"
+                )
+
+                # Only return the compensated index if a match was found, because we want to return 0 otherwise
+                match_found = ComparisonOpExpression(
+                    bool_empty_data,
+                    index,
+                    ConstantExpression(int_empty_data, input_plan, 0),
+                    operator.ne,
+                )
+                new_index = CaseExpression(
+                    int_empty_data, match_found, compensated_index, index
+                )
+            else:
+                # Nothing was removed from the string so we can just return the raw index
+                new_index = index
+
+            # Make sure we return NULL for NULL strings instead of 0
+            string_is_null = UnaryOpExpression(bool_empty_data, src, "isnull")
+            return CaseExpression(
+                int_empty_data,
+                string_is_null,
+                NullExpression(int_empty_data, input_plan, 0),
+                new_index,
             )
 
         elif func_name == "INITCAP" and len(op_exprs) in (1, 2):

--- a/BodoSQL/bodosql/tests/test_regexp.py
+++ b/BodoSQL/bodosql/tests/test_regexp.py
@@ -573,6 +573,7 @@ def test_regexp_substr(regexp_strings_df, args, memory_leak_check):
                 ),
             ),
             id="simple_pattern-1-2-no_option-no_flags-no_group",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             (
@@ -592,7 +593,7 @@ def test_regexp_substr(regexp_strings_df, args, memory_leak_check):
                 ),
             ),
             id="medium_pattern-no_pos-no_occur-no_option-no_flags-no_group",
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
         pytest.param(
             (
@@ -611,7 +612,7 @@ def test_regexp_substr(regexp_strings_df, args, memory_leak_check):
                 ),
             ),
             id="medium_pattern-1-2-1-no_flags-2",
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
         pytest.param(
             (
@@ -631,7 +632,7 @@ def test_regexp_substr(regexp_strings_df, args, memory_leak_check):
                 ),
             ),
             id="CASE-medium_pattern-31-1-01-extract-12",
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
     ],
 )

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -447,8 +447,8 @@ arrow::Datum do_arrow_compute_multi_input_datum(
 
     if (!func_res.ok()) [[unlikely]] {
         throw std::runtime_error(
-            "do_arrow_compute_multi_input: Error in Arrow compute: " +
-            func_res.status().message());
+            "do_arrow_compute_multi_input: Error in Arrow compute (" +
+            arrow_func_name + "): " + func_res.status().message());
     }
 
     return func_res.ValueOrDie();
@@ -529,8 +529,8 @@ arrow::Datum do_arrow_compute_binary(
         comparator, {left_res, right_res}, func_options);
     if (!cmp_res.ok()) [[unlikely]] {
         throw std::runtime_error(
-            "do_arrow_compute_binary: Error in Arrow compute: " +
-            cmp_res.status().message());
+            "do_arrow_compute_binary: Error in Arrow compute (" + comparator +
+            "): " + cmp_res.status().message());
     }
 
     arrow::Datum cmp_datum = cmp_res.ValueOrDie();
@@ -544,8 +544,8 @@ arrow::Datum do_arrow_compute_binary(
             arrow::compute::Cast(cmp_datum, result_type, cast_opts);
         if (!cast_res.ok()) [[unlikely]] {
             throw std::runtime_error(
-                "do_arrow_compute_binary cast_res: Error in Arrow compute: " +
-                cast_res.status().message());
+                "do_arrow_compute_binary cast_res: Error in Arrow compute (" +
+                comparator + "): " + cast_res.status().message());
         }
         cmp_res = cast_res;
     }
@@ -563,7 +563,7 @@ arrow::Datum do_arrow_compute_unary(
             arrow::compute::CallFunction("is_null", {src1}, func_options);
         if (!is_null_res.ok()) [[unlikely]] {
             throw std::runtime_error(
-                "do_arrow_compute_unary: Error in Arrow compute: " +
+                "do_arrow_compute_unary: Error in Arrow compute (is_null): " +
                 is_null_res.status().message());
         }
 
@@ -572,7 +572,7 @@ arrow::Datum do_arrow_compute_unary(
             arrow::compute::CallFunction("invert", {is_null_res.ValueOrDie()});
         if (!invert_res.ok()) [[unlikely]] {
             throw std::runtime_error(
-                "do_arrow_compute_unary: Error in Arrow compute Invert: " +
+                "do_arrow_compute_unary: Error in Arrow compute (invert): " +
                 invert_res.status().message());
         }
         return invert_res.ValueOrDie();
@@ -593,7 +593,7 @@ arrow::Datum do_arrow_compute_unary(
             "coalesce", {src1, na_fill_value}, func_options);
         if (!result.ok()) [[unlikely]] {
             throw std::runtime_error(
-                "do_arrow_compute_unary: Error in Arrow compute: " +
+                "do_arrow_compute_unary: Error in Arrow compute (coalesce): " +
                 result.status().message());
         }
 
@@ -604,7 +604,8 @@ arrow::Datum do_arrow_compute_unary(
                 arrow::compute::CallFunction("invert", {result.ValueOrDie()});
             if (!result.ok()) [[unlikely]] {
                 throw std::runtime_error(
-                    "do_arrow_compute_unary: Error in Arrow compute Invert: " +
+                    "do_arrow_compute_unary: Error in Arrow compute "
+                    "(invert): " +
                     result.status().message());
             }
         }
@@ -615,8 +616,8 @@ arrow::Datum do_arrow_compute_unary(
         arrow::compute::CallFunction(comparator, {src1}, func_options);
     if (!cmp_res.ok()) [[unlikely]] {
         throw std::runtime_error(
-            "do_arrow_compute_unary: Error in Arrow compute: " +
-            cmp_res.status().message());
+            "do_arrow_compute_unary: Error in Arrow compute (" + comparator +
+            "): " + cmp_res.status().message());
     }
 
     return cmp_res.ValueOrDie();

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1460,8 +1460,8 @@ class PhysicalArrowExpression : public PhysicalExpression {
             child->Finalize();
         }
 
-        // Reset RNG
-        gen = nullptr;
+        gen = nullptr;  // Reset RNG
+        named_regexp = nullptr;
     }
 
     arrow::Datum join_expr_internal(array_info **left_table,
@@ -1484,6 +1484,8 @@ class PhysicalArrowExpression : public PhysicalExpression {
    protected:
     // PRNG for random_int64
     std::shared_ptr<std::mt19937_64> gen;
+    // Named regex pattern for REGEXP_SUBSTR / REGEXP_INSTR
+    std::shared_ptr<std::tuple<std::string, int>> named_regexp;
 
     BodoScalarFunctionData scalar_func_data;
     const std::shared_ptr<arrow::DataType> result_type;
@@ -1494,12 +1496,11 @@ class PhysicalArrowExpression : public PhysicalExpression {
         std::conditional_t<std::is_same_v<T, std::shared_ptr<ExprResult>>,
                            std::shared_ptr<array_info>, T>;
 
-    template <typename T>
-    arrow::Datum do_arrow_compute_regexp_substr(T res, std::string pattern_str,
-                                                std::string regex_params_str,
-                                                int64_t group_to_extract) {
-        bool extract_submatches =
-            regex_params_str.find('e') != std::string::npos;
+    std::tuple<std::string, int> convert_to_named_regexp(
+        std::string pattern_str) {
+        /* Return a tuple of the input regex pattern with its capturing
+        groups converted to named groups, and the number of groups that were
+        found in the pattern. */
 
         std::string named_pattern;
         // Number of groups found in regex pattern so far
@@ -1547,6 +1548,26 @@ class PhysicalArrowExpression : public PhysicalExpression {
             }
         }
 
+        return std::tuple(named_pattern, num_groups);
+    }
+
+    template <typename T>
+    arrow::Datum do_arrow_compute_regexp_substr(T res, std::string pattern_str,
+                                                std::string regex_params_str,
+                                                int64_t group_to_extract) {
+        bool extract_submatches =
+            regex_params_str.find('e') != std::string::npos;
+
+        // Ensure all groups are named so that we can pass to extract_regex.
+        // Do this once per batch.
+        if (!named_regexp) {
+            named_regexp = std::make_shared<std::tuple<std::string, int>>(
+                convert_to_named_regexp(pattern_str));
+        }
+
+        std::string named_pattern = std::get<0>(*named_regexp);
+        int num_groups = std::get<1>(*named_regexp);
+
         if (!extract_submatches || num_groups == 0) {
             // Wrap the whole pattern in a group
             named_pattern = "(?<_whole>" + named_pattern + ")";
@@ -1569,53 +1590,155 @@ class PhysicalArrowExpression : public PhysicalExpression {
             std::static_pointer_cast<arrow::StructArray>(extract_array);
 
         // Extract the requested field
-        std::shared_ptr<arrow::Array> captured_field = nullptr;
-        if (extract_submatches && group_to_extract < num_groups) {
-            // Valid group number requested
-            captured_field = struct_result->GetFieldByName(
-                "_group" + std::to_string(group_to_extract));
-        } else if (!extract_submatches) {
-            // No group extraction requested, return whole match
-            captured_field = struct_result->GetFieldByName("_whole");
-        }
-
-        arrow::Datum captured_field_datum;
-        if (!captured_field) {
+        std::shared_ptr<arrow::Array> captured_field;
+        if (extract_submatches && group_to_extract >= num_groups) {
             // Return null array if requested group is greater than number
             // of groups in regex
             captured_field =
                 arrow::MakeArrayOfNull(arrow::utf8(), struct_result->length())
                     .ValueOrDie();
-            captured_field_datum = arrow::Datum(captured_field);
-        } else if (captured_field->type_id() == arrow::Type::STRING ||
-                   captured_field->type_id() == arrow::Type::LARGE_STRING) {
-            // Convert empty strings in the extract_regex result to NULL.
-            // Despite what the Arrow documentation says, it appears that an
-            // empty string is returned for the input strings that the
-            // regexp does not match.
-            arrow::Datum empty_string =
-                (captured_field->type_id() == arrow::Type::STRING)
-                    ? arrow::Datum(arrow::StringScalar(""))
-                    : arrow::Datum(arrow::LargeStringScalar(""));
-
-            // do_arrow_compute_multi_input only accepts a vector of
-            // ExprResults (for now)
-            std::shared_ptr<ExprResult> empty_string_expr_result =
-                std::make_shared<ScalarExprResult>(
-                    ConvertDatumToArrayInfo(empty_string));
-            std::shared_ptr<ExprResult> captured_field_expr_result =
-                std::make_shared<ArrayExprResult>(
-                    ConvertDatumToArrayInfo(arrow::Datum(captured_field)),
-                    "regexp_substr_captured_field");
-
-            captured_field_datum = do_arrow_compute_multi_input_datum(
-                {captured_field_expr_result, empty_string_expr_result},
-                "nullif");
         } else {
-            captured_field_datum = arrow::Datum(captured_field);
+            std::string field_name;
+            if (!extract_submatches) {
+                // No group extraction requested, return whole match
+                field_name = "_whole";
+            } else {
+                // extract_submatches && group_to_extract < num_groups:
+                // valid group number requested.
+                field_name = "_group" + std::to_string(group_to_extract);
+            }
+
+            // NOTE: StructArray.GetFieldByName() exists, but does not propagate
+            // the validity bitmap to the child fields. We need to retain the
+            // nulls that are emitted when there is no match for the regexp, so
+            // we use GetFlattenedField() instead.
+            auto struct_type = std::static_pointer_cast<arrow::StructType>(
+                struct_result->type());
+            int field_index = struct_type->GetFieldIndex(field_name);
+            auto captured_field_res =
+                struct_result->GetFlattenedField(field_index);
+            if (!captured_field_res.ok()) {
+                throw std::runtime_error(
+                    "do_arrow_compute_regexp_substr: Error getting flattened "
+                    "field from struct array: " +
+                    captured_field_res.status().message());
+            }
+            captured_field = captured_field_res.ValueOrDie();
         }
 
-        return captured_field_datum;
+        return arrow::Datum(captured_field);
+    }
+
+    template <typename T>
+    arrow::Datum do_arrow_compute_regexp_instr(T res, std::string pattern_str,
+                                               bool get_start_index,
+                                               std::string regex_params_str,
+                                               int64_t group_to_extract) {
+        bool extract_submatches =
+            regex_params_str.find('e') != std::string::npos;
+
+        // Ensure all groups are named so that we can pass to
+        // extract_regex_span. Do this once per batch.
+        if (!named_regexp) {
+            named_regexp = std::make_shared<std::tuple<std::string, int>>(
+                convert_to_named_regexp(pattern_str));
+        }
+
+        std::string named_pattern = std::get<0>(*named_regexp);
+        int num_groups = std::get<1>(*named_regexp);
+
+        if (!extract_submatches || num_groups == 0) {
+            // Wrap the whole pattern in a group
+            named_pattern = "(?<_whole>" + named_pattern + ")";
+            extract_submatches = false;
+        }
+
+        // Intermediate results must be Datums only because Bodo doesn't support
+        // the fixed_size_list type.
+        arrow::Datum res_datum =
+            ConvertExprResultToDatum(res, "regexp_instr string");
+
+        arrow::compute::ExtractRegexSpanOptions opts(named_pattern);
+        auto extract_regex_span_result =
+            do_arrow_compute_unary(res_datum, "extract_regex_span", &opts);
+
+        // Convert to Arrow StructArray so we can extract the
+        // field corresponding to the requested group
+        std::shared_ptr<arrow::StructArray> struct_result =
+            std::static_pointer_cast<arrow::StructArray>(
+                extract_regex_span_result.make_array());
+
+        // Extract the requested field
+        std::shared_ptr<arrow::Array> captured_field_span = nullptr;
+        if (extract_submatches && group_to_extract < num_groups) {
+            // Valid group number requested
+            captured_field_span = struct_result->GetFieldByName(
+                "_group" + std::to_string(group_to_extract));
+        } else if (!extract_submatches) {
+            // No group extraction requested, return whole match
+            captured_field_span = struct_result->GetFieldByName("_whole");
+        }
+
+        arrow::Datum captured_field_index_datum;
+        if (!captured_field_span) {
+            // Return array of -1 if requested group is greater than number
+            // of groups in regex
+            arrow::Int64Scalar negative_one_scalar(-1);
+            captured_field_index_datum =
+                arrow::Datum(arrow::MakeArrayFromScalar(negative_one_scalar,
+                                                        struct_result->length())
+                                 .ValueOrDie());
+        } else {
+            // The values of the each StructArray field are two-element
+            // fixed_size_lists. The first element of the FixedSizeList is the
+            // start index of the substring matched by the group, and the second
+            // element is the length of that substring.
+
+            // Get zero-based start indices
+            auto first_element_index = std::make_shared<arrow::Int64Scalar>(0);
+            arrow::Datum start_indices = do_arrow_compute_binary(
+                arrow::Datum(captured_field_span),
+                arrow::Datum(first_element_index), "list_element");
+
+            if (!get_start_index) {
+                // If get_start_index is False, we should return the index of
+                // the first character after the substring matched by the group.
+                // So we need to add the substring length to the start index.
+
+                // Get lengths
+                auto second_element_index =
+                    std::make_shared<arrow::Int64Scalar>(1);
+                arrow::Datum lengths = do_arrow_compute_binary(
+                    arrow::Datum(captured_field_span),
+                    arrow::Datum(second_element_index), "list_element");
+
+                // Add lengths of to start indices
+                captured_field_index_datum =
+                    do_arrow_compute_binary(start_indices, lengths, "add");
+            } else {
+                captured_field_index_datum = start_indices;
+            }
+
+            // The validity bitmap of the parent StructArray is not propagated
+            // automatically to the child fields (see
+            // https://github.com/apache/arrow/issues/41833), so we have to
+            // check it manually and return -1 if not valid.
+            auto negative_one_scalar = std::make_shared<arrow::Int64Scalar>(-1);
+            arrow::Datum valid_mask =
+                do_arrow_compute_unary(extract_regex_span_result, "is_valid");
+            auto nulled_index_res = arrow::compute::CallFunction(
+                "if_else",
+                {valid_mask, captured_field_index_datum, negative_one_scalar});
+            if (!nulled_index_res.ok()) [[unlikely]] {
+                throw std::runtime_error(
+                    "do_arrow_compute_regexp_instr: Error in Arrow compute "
+                    "(if_else): " +
+                    nulled_index_res.status().message());
+            }
+            captured_field_index_datum = nulled_index_res.ValueOrDie();
+        }
+
+        return captured_field_index_datum;
     }
 
     template <typename T>
@@ -1947,6 +2070,26 @@ class PhysicalArrowExpression : public PhysicalExpression {
                 result = captured_field_datum;
             } else {
                 result = ConvertDatumToArrayInfo(captured_field_datum);
+            }
+        } else if (scalar_func_data.arrow_func_name == "regexp_instr") {
+            auto [pattern, get_start_index, regex_params, group_to_extract] =
+                get_py_args_as_types(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str(),
+                    get_py_object_as_cstr, get_py_object_as_bool,
+                    get_py_object_as_cstr, get_py_object_as_int64);
+            std::string pattern_str(pattern);
+            std::string regex_params_str(regex_params);
+
+            arrow::Datum index_datum = do_arrow_compute_regexp_instr(
+                res, pattern_str, get_start_index, regex_params_str,
+                group_to_extract);
+
+            // Assign to result based on input type
+            if constexpr (std::is_same_v<T, arrow::Datum>) {
+                result = index_datum;
+            } else {
+                result = ConvertDatumToArrayInfo(index_datum);
             }
         } else if (scalar_func_data.arrow_func_name == "utf8_trim" ||
                    scalar_func_data.arrow_func_name == "utf8_ltrim" ||

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1559,7 +1559,7 @@ class PhysicalArrowExpression : public PhysicalExpression {
             regex_params_str.find('e') != std::string::npos;
 
         // Ensure all groups are named so that we can pass to extract_regex.
-        // Do this once per batch.
+        // Do this once per operator.
         if (!named_regexp) {
             named_regexp = std::make_shared<std::tuple<std::string, int>>(
                 convert_to_named_regexp(pattern_str));
@@ -1638,7 +1638,7 @@ class PhysicalArrowExpression : public PhysicalExpression {
             regex_params_str.find('e') != std::string::npos;
 
         // Ensure all groups are named so that we can pass to
-        // extract_regex_span. Do this once per batch.
+        // extract_regex_span. Do this once per operator.
         if (!named_regexp) {
             named_regexp = std::make_shared<std::tuple<std::string, int>>(
                 convert_to_named_regexp(pattern_str));


### PR DESCRIPTION
## Changes included in this PR

REGEXP_INSTR is now supported in the C++ backend. We don't support case-insensitive matching, so there are a couple tests I couldn't enable because of that.

## Testing strategy

CI

## User facing changes

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.