### PR TITLE
BSE-5484: Enable covering expression caching

### DIFF
--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/common/RelUtils.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/common/RelUtils.kt
@@ -16,15 +16,7 @@ object RelUtils {
      *
      * Structural assumption: each source-convention converter (Snowflake,
      * Iceberg) sits above a subtree containing exactly one source rel of that
-     * convention. The old code (`input as SnowflakeRel`) relied on the same
-     * assumption but required the source rel to be the direct child. This
-     * traversal only relaxes the "direct child" constraint by skipping through
-     * intermediate nodes (filters, projects, cache bodies) inserted after the
-     * converter was created. If a join of two same-source scans were ever
-     * placed under a single converter, the old cast would have thrown a
-     * [ClassCastException] and [findRelOfType] will throw an
-     * [IllegalStateException] — both surfaces the problem rather than
-     * silently returning the wrong source.
+     * convention.
      */
     inline fun <reified T : RelNode> findRelOfTypeOrNull(node: RelNode): T? = findRelOfTypeOrNull(node, T::class.java)
 
@@ -32,8 +24,6 @@ object RelUtils {
      * Depth-first search for the first descendant (or the node itself) of
      * type [T]. Throws [IllegalStateException] if none is found.
      *
-     * See [findRelOfTypeOrNull] for the structural assumption and caveats
-     * about multi-source plans.
      */
     inline fun <reified T : RelNode> findRelOfType(node: RelNode): T =
         findRelOfTypeOrNull<T>(node)

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/common/RelUtils.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/common/RelUtils.kt
@@ -1,0 +1,57 @@
+package com.bodosql.calcite.adapter.common
+
+import com.bodosql.calcite.rel.core.CachedSubPlanBase
+import org.apache.calcite.rel.RelNode
+
+/**
+ * Shared utilities for traversing [RelNode] trees that may contain
+ * [CachedSubPlanBase] nodes inserted by covering expression caching.
+ */
+object RelUtils {
+    /**
+     * Depth-first search for the first descendant (or the node itself) of
+     * type [T] in the given rel tree, traversing through [CachedSubPlanBase]
+     * bodies. Returns the first match found in pre-order traversal of inputs,
+     * or `null` if no node of type [T] is found.
+     *
+     * Structural assumption: each source-convention converter (Snowflake,
+     * Iceberg) sits above a subtree containing exactly one source rel of that
+     * convention. The old code (`input as SnowflakeRel`) relied on the same
+     * assumption but required the source rel to be the direct child. This
+     * traversal only relaxes the "direct child" constraint by skipping through
+     * intermediate nodes (filters, projects, cache bodies) inserted after the
+     * converter was created. If a join of two same-source scans were ever
+     * placed under a single converter, the old cast would have thrown a
+     * [ClassCastException] and [findRelOfType] will throw an
+     * [IllegalStateException] — both surfaces the problem rather than
+     * silently returning the wrong source.
+     */
+    inline fun <reified T : RelNode> findRelOfTypeOrNull(node: RelNode): T? = findRelOfTypeOrNull(node, T::class.java)
+
+    /**
+     * Depth-first search for the first descendant (or the node itself) of
+     * type [T]. Throws [IllegalStateException] if none is found.
+     *
+     * See [findRelOfTypeOrNull] for the structural assumption and caveats
+     * about multi-source plans.
+     */
+    inline fun <reified T : RelNode> findRelOfType(node: RelNode): T =
+        findRelOfTypeOrNull<T>(node)
+            ?: throw IllegalStateException("Cannot find ${T::class.java.simpleName} in rel tree")
+
+    @PublishedApi
+    internal fun <T : RelNode> findRelOfTypeOrNull(
+        node: RelNode,
+        type: Class<T>,
+    ): T? {
+        if (type.isInstance(node)) return type.cast(node)
+        if (node is CachedSubPlanBase) {
+            return findRelOfTypeOrNull(node.cachedPlan.plan, type)
+        }
+        for (input in node.inputs) {
+            val result = findRelOfTypeOrNull(input, type)
+            if (result != null) return result
+        }
+        return null
+    }
+}

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/iceberg/IcebergToBodoPhysicalConverter.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/iceberg/IcebergToBodoPhysicalConverter.kt
@@ -13,6 +13,7 @@ import com.bodosql.calcite.ir.Expr.StringLiteral
 import com.bodosql.calcite.ir.Op
 import com.bodosql.calcite.ir.StateVariable
 import com.bodosql.calcite.plan.makeCost
+import com.bodosql.calcite.rel.core.CachedSubPlanBase
 import com.bodosql.calcite.rel.core.RuntimeJoinFilterBase
 import com.bodosql.calcite.rel.metadata.BodoRelMetadataQuery
 import com.bodosql.calcite.traits.BatchingProperty
@@ -65,7 +66,27 @@ class IcebergToBodoPhysicalConverter(
     override fun loggingTitle() = "ICEBERG TIMING"
 
     // TODO: What to do with this function?
-    override fun nodeDetails(): String = getTableName(input as IcebergRel)
+    override fun nodeDetails(): String = getTableName(findIcebergRel(input))
+
+    /**
+     * Find the IcebergRel in the input chain, traversing through BodoPhysical nodes
+     * and CachedSubPlanBase bodies inserted by covering expression caching.
+     */
+    private fun findIcebergRel(node: RelNode): IcebergRel =
+        findIcebergRelOrNull(node)
+            ?: throw IllegalStateException("Cannot find IcebergRel in input chain")
+
+    private fun findIcebergRelOrNull(node: RelNode): IcebergRel? {
+        if (node is IcebergRel) return node
+        if (node is CachedSubPlanBase) {
+            return findIcebergRelOrNull(node.cachedPlan.plan)
+        }
+        for (input in node.inputs) {
+            val result = findIcebergRelOrNull(input)
+            if (result != null) return result
+        }
+        return null
+    }
 
     override fun expectedOutputBatchingProperty(inputBatchingProperty: BatchingProperty): BatchingProperty {
         // TODO: Can simplify now?
@@ -158,7 +179,7 @@ class IcebergToBodoPhysicalConverter(
      * Generate the code required to read from Iceberg.
      */
     private fun generateReadExpr(ctx: BodoPhysicalRel.BuildContext): Expr.Call {
-        val relInput = input as IcebergRel
+        val relInput = findIcebergRel(input)
         val flattenedInfo = flattenIcebergTree()
         val cols = flattenedInfo.colNames
         val filters = flattenedInfo.filters
@@ -259,7 +280,7 @@ class IcebergToBodoPhysicalConverter(
 
     private fun flattenIcebergTree(): FlattenedIcebergInfo {
         if (cachedIcebergFlattenedInfo == null) {
-            val node = input as IcebergRel
+            val node = findIcebergRel(input)
             val visitor =
                 object : RelVisitor() {
                     // Initialize all columns to be in the original location.

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/iceberg/IcebergToBodoPhysicalConverter.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/iceberg/IcebergToBodoPhysicalConverter.kt
@@ -72,7 +72,7 @@ class IcebergToBodoPhysicalConverter(
      * Find the IcebergRel in the input chain, traversing through BodoPhysical nodes
      * and CachedSubPlanBase bodies inserted by covering expression caching.
      */
-    private fun findIcebergRel(node: RelNode): IcebergRel =
+    fun findIcebergRel(node: RelNode): IcebergRel =
         findIcebergRelOrNull(node)
             ?: throw IllegalStateException("Cannot find IcebergRel in input chain")
 

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/iceberg/IcebergToBodoPhysicalConverter.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/iceberg/IcebergToBodoPhysicalConverter.kt
@@ -1,6 +1,7 @@
 package com.bodosql.calcite.adapter.iceberg
 
 import com.bodosql.calcite.adapter.bodo.BodoPhysicalRel
+import com.bodosql.calcite.adapter.common.RelUtils.findRelOfType
 import com.bodosql.calcite.application.RelationalAlgebraGenerator
 import com.bodosql.calcite.application.timers.SingleBatchRelNodeTimer
 import com.bodosql.calcite.catalog.SnowflakeCatalog
@@ -13,7 +14,6 @@ import com.bodosql.calcite.ir.Expr.StringLiteral
 import com.bodosql.calcite.ir.Op
 import com.bodosql.calcite.ir.StateVariable
 import com.bodosql.calcite.plan.makeCost
-import com.bodosql.calcite.rel.core.CachedSubPlanBase
 import com.bodosql.calcite.rel.core.RuntimeJoinFilterBase
 import com.bodosql.calcite.rel.metadata.BodoRelMetadataQuery
 import com.bodosql.calcite.traits.BatchingProperty
@@ -72,21 +72,7 @@ class IcebergToBodoPhysicalConverter(
      * Find the IcebergRel in the input chain, traversing through BodoPhysical nodes
      * and CachedSubPlanBase bodies inserted by covering expression caching.
      */
-    fun findIcebergRel(node: RelNode): IcebergRel =
-        findIcebergRelOrNull(node)
-            ?: throw IllegalStateException("Cannot find IcebergRel in input chain")
-
-    private fun findIcebergRelOrNull(node: RelNode): IcebergRel? {
-        if (node is IcebergRel) return node
-        if (node is CachedSubPlanBase) {
-            return findIcebergRelOrNull(node.cachedPlan.plan)
-        }
-        for (input in node.inputs) {
-            val result = findIcebergRelOrNull(input)
-            if (result != null) return result
-        }
-        return null
-    }
+    fun findIcebergRel(node: RelNode): IcebergRel = findRelOfType(node)
 
     override fun expectedOutputBatchingProperty(inputBatchingProperty: BatchingProperty): BatchingProperty {
         // TODO: Can simplify now?

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeToBodoPhysicalConverter.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeToBodoPhysicalConverter.kt
@@ -13,6 +13,7 @@ import com.bodosql.calcite.ir.Expr.StringLiteral
 import com.bodosql.calcite.ir.Op
 import com.bodosql.calcite.ir.StateVariable
 import com.bodosql.calcite.plan.makeCost
+import com.bodosql.calcite.rel.core.CachedSubPlanBase
 import com.bodosql.calcite.rel.core.RuntimeJoinFilterBase
 import com.bodosql.calcite.traits.BatchingProperty
 import com.bodosql.calcite.traits.ExpectedBatchingProperty
@@ -69,10 +70,30 @@ class SnowflakeToBodoPhysicalConverter(
 
     override fun loggingTitle() = "IO TIMING"
 
+    /**
+     * Find the SnowflakeRel in the input chain, traversing through BodoPhysical nodes
+     * and CachedSubPlanBase bodies inserted by covering expression caching.
+     */
+    private fun findSnowflakeRel(node: RelNode): SnowflakeRel =
+        findSnowflakeRelOrNull(node)
+            ?: throw IllegalStateException("Cannot find SnowflakeRel in input chain")
+
+    private fun findSnowflakeRelOrNull(node: RelNode): SnowflakeRel? {
+        if (node is SnowflakeRel) return node
+        if (node is CachedSubPlanBase) {
+            return findSnowflakeRelOrNull(node.cachedPlan.plan)
+        }
+        for (input in node.inputs) {
+            val result = findSnowflakeRelOrNull(input)
+            if (result != null) return result
+        }
+        return null
+    }
+
     override fun nodeDetails() =
         (
             if (isSimpleWholeTableRead()) {
-                getTableName(input as SnowflakeRel)
+                getTableName(findSnowflakeRel(input))
             } else {
                 getSnowflakeSQL()
             }
@@ -186,7 +207,7 @@ class SnowflakeToBodoPhysicalConverter(
         val tableName = getTableName(tableScan)
         val schemaName = getSchemaName(tableScan)
         val databaseName = getDatabaseName(tableScan)
-        val relInput = input as SnowflakeRel
+        val relInput = findSnowflakeRel(input)
         val args =
             listOf(
                 StringLiteral(tableName),
@@ -327,7 +348,7 @@ class SnowflakeToBodoPhysicalConverter(
         // node and run them after the read. Will deal with pushing
         // them into the IO node later.
         val sql = getSnowflakeSQL()
-        val relInput = (skipRuntimeJoinFilters()) as SnowflakeRel
+        val relInput = findSnowflakeRel(skipRuntimeJoinFilters())
 
         val passTableInfo = canUseOptimizedReadSqlPath(relInput)
 

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeToBodoPhysicalConverter.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeToBodoPhysicalConverter.kt
@@ -74,7 +74,7 @@ class SnowflakeToBodoPhysicalConverter(
      * Find the SnowflakeRel in the input chain, traversing through BodoPhysical nodes
      * and CachedSubPlanBase bodies inserted by covering expression caching.
      */
-    private fun findSnowflakeRel(node: RelNode): SnowflakeRel =
+    fun findSnowflakeRel(node: RelNode): SnowflakeRel =
         findSnowflakeRelOrNull(node)
             ?: throw IllegalStateException("Cannot find SnowflakeRel in input chain")
 

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeToBodoPhysicalConverter.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/adapter/snowflake/SnowflakeToBodoPhysicalConverter.kt
@@ -1,6 +1,7 @@
 package com.bodosql.calcite.adapter.snowflake
 
 import com.bodosql.calcite.adapter.bodo.BodoPhysicalRel
+import com.bodosql.calcite.adapter.common.RelUtils.findRelOfType
 import com.bodosql.calcite.application.PythonLoggers
 import com.bodosql.calcite.application.operatorTables.CastingOperatorTable
 import com.bodosql.calcite.application.timers.SingleBatchRelNodeTimer
@@ -13,7 +14,6 @@ import com.bodosql.calcite.ir.Expr.StringLiteral
 import com.bodosql.calcite.ir.Op
 import com.bodosql.calcite.ir.StateVariable
 import com.bodosql.calcite.plan.makeCost
-import com.bodosql.calcite.rel.core.CachedSubPlanBase
 import com.bodosql.calcite.rel.core.RuntimeJoinFilterBase
 import com.bodosql.calcite.traits.BatchingProperty
 import com.bodosql.calcite.traits.ExpectedBatchingProperty
@@ -74,21 +74,7 @@ class SnowflakeToBodoPhysicalConverter(
      * Find the SnowflakeRel in the input chain, traversing through BodoPhysical nodes
      * and CachedSubPlanBase bodies inserted by covering expression caching.
      */
-    fun findSnowflakeRel(node: RelNode): SnowflakeRel =
-        findSnowflakeRelOrNull(node)
-            ?: throw IllegalStateException("Cannot find SnowflakeRel in input chain")
-
-    private fun findSnowflakeRelOrNull(node: RelNode): SnowflakeRel? {
-        if (node is SnowflakeRel) return node
-        if (node is CachedSubPlanBase) {
-            return findSnowflakeRelOrNull(node.cachedPlan.plan)
-        }
-        for (input in node.inputs) {
-            val result = findSnowflakeRelOrNull(input)
-            if (result != null) return result
-        }
-        return null
-    }
+    fun findSnowflakeRel(node: RelNode): SnowflakeRel = findRelOfType(node)
 
     override fun nodeDetails() =
         (

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/RelationalAlgebraGenerator.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/RelationalAlgebraGenerator.java
@@ -138,7 +138,7 @@ public class RelationalAlgebraGenerator {
   public static String sqlStyle = "SNOWFLAKE";
 
   /** Should we use the covering expression approach to cache or only exact matches. */
-  public static boolean coveringExpressionCaching = false;
+  public static boolean coveringExpressionCaching = true;
 
   /** Should we prefetch metadata location for Snowflake-managed Iceberg tables. */
   public static boolean prefetchSFIceberg = false;

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/FilterRulesCommon.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/FilterRulesCommon.java
@@ -1,7 +1,7 @@
 package com.bodosql.calcite.application.logicalRules;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import org.apache.calcite.rex.*;
 import org.apache.calcite.sql.SqlKind;
@@ -53,7 +53,7 @@ public class FilterRulesCommon {
    * @return The RexNode after pruning common expressions.
    */
   private static RexNode pruneConditionExtractCommon(
-      RelBuilder builder, RexNode cond, HashSet<RexNode> commonOps) {
+      RelBuilder builder, RexNode cond, LinkedHashSet<RexNode> commonOps) {
     if (cond.getKind() == SqlKind.AND) {
       List<RexNode> operands = new ArrayList<>();
       RexCall callCond = (RexCall) cond;
@@ -99,7 +99,7 @@ public class FilterRulesCommon {
    * @return A pair of values containing the new condition RexNode and if it was changed.
    */
   public static Pair<RexNode, Boolean> updateConditionsExtractCommon(
-      RelBuilder builder, RexNode cond, HashSet<RexNode> commonOps) {
+      RelBuilder builder, RexNode cond, LinkedHashSet<RexNode> commonOps) {
     List<RexNode> nodes = new ArrayList<>();
     if (cond.getKind() == SqlKind.AND) {
       // If we have an AND we UNION together any of
@@ -126,12 +126,12 @@ public class FilterRulesCommon {
       // removed from the OR and we can rewrite the whole RexNode
       // as AND(saved, PRUNE_OR).
       RexCall orCond = (RexCall) cond;
-      HashSet<RexNode> sharedOps = new HashSet<>();
+      LinkedHashSet<RexNode> sharedOps = new LinkedHashSet<>();
       Pair<RexNode, Boolean> nodePair =
           updateConditionsExtractCommon(builder, orCond.operands.get(0), sharedOps);
       nodes.add(nodePair.getKey());
       for (int i = 1; i < orCond.operands.size(); i++) {
-        HashSet<RexNode> otherOps = new HashSet<>();
+        LinkedHashSet<RexNode> otherOps = new LinkedHashSet<>();
         nodePair = updateConditionsExtractCommon(builder, orCond.operands.get(i), otherOps);
         nodes.add(nodePair.getKey());
         sharedOps.retainAll(otherOps);

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/JoinReorderConditionRule.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/JoinReorderConditionRule.java
@@ -4,7 +4,7 @@ import static com.bodosql.calcite.application.logicalRules.FilterRulesCommon.fil
 import static com.bodosql.calcite.application.logicalRules.FilterRulesCommon.updateConditionsExtractCommon;
 
 import com.bodosql.calcite.application.utils.BodoSQLStyleImmutable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.core.Join;
@@ -52,7 +52,7 @@ public class JoinReorderConditionRule extends RelRule<JoinReorderConditionRule.C
     // a common condition. For this we check the string representation.
     Join join = call.rel(0);
     RelBuilder builder = call.builder();
-    HashSet<RexNode> commonExprs = new HashSet<RexNode>();
+    LinkedHashSet<RexNode> commonExprs = new LinkedHashSet<RexNode>();
     Pair<RexNode, Boolean> updatedOR =
         updateConditionsExtractCommon(builder, join.getCondition(), commonExprs);
     boolean changed = updatedOR.getValue();

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/LogicalFilterReorderConditionRule.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/LogicalFilterReorderConditionRule.java
@@ -4,7 +4,7 @@ import static com.bodosql.calcite.application.logicalRules.FilterRulesCommon.fil
 import static com.bodosql.calcite.application.logicalRules.FilterRulesCommon.updateConditionsExtractCommon;
 
 import com.bodosql.calcite.application.utils.BodoSQLStyleImmutable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
 import org.apache.calcite.rel.core.Filter;
@@ -52,7 +52,7 @@ public class LogicalFilterReorderConditionRule
     // a common condition.
     Filter filter = call.rel(0);
     RelBuilder builder = call.builder();
-    HashSet<RexNode> commonExprs = new HashSet<RexNode>();
+    LinkedHashSet<RexNode> commonExprs = new LinkedHashSet<RexNode>();
     Pair<RexNode, Boolean> updatedOR =
         updateConditionsExtractCommon(builder, filter.getCondition(), commonExprs);
     boolean changed = updatedOR.getValue();

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
@@ -7,6 +7,7 @@ import com.bodosql.calcite.adapter.common.TreeReverserDuplicateTracker
 import com.bodosql.calcite.adapter.iceberg.IcebergToBodoPhysicalConverter
 import com.bodosql.calcite.adapter.pandas.PandasToBodoPhysicalConverter
 import com.bodosql.calcite.adapter.snowflake.SnowflakeToBodoPhysicalConverter
+import com.bodosql.calcite.application.PythonLoggers
 import com.bodosql.calcite.application.RelationalAlgebraGenerator
 import com.bodosql.calcite.application.logicalRules.FilterRulesCommon
 import com.bodosql.calcite.rel.core.BodoPhysicalRelFactories
@@ -38,6 +39,7 @@ import org.apache.calcite.rex.RexNode
 import org.apache.calcite.rex.RexPermuteInputsShuttle
 import org.apache.calcite.rex.RexSimplify
 import org.apache.calcite.rex.RexUtil
+import org.apache.calcite.sql.SqlAggFunction
 import org.apache.calcite.sql.`fun`.SqlStdOperatorTable
 import org.apache.calcite.sql.type.SqlTypeName
 import org.apache.calcite.tools.Program
@@ -397,6 +399,9 @@ class CacheSubPlanProgram : Program {
                             Pair(updatedFilter, true)
                         }
                     }
+                // We pushed cacheRoot onto the relBuilder stack to compute filterInfo via
+                // relBuilder.field(idx). Pop it now so the stack is clean for subsequent use.
+                relBuilder.build()
                 val materializedCaching =
                     filterInfo.withIndex().filter { !it.value.second }.map { Pair(it.value.first, it.index) }
                 if (materializedCaching.isNotEmpty()) {
@@ -546,6 +551,9 @@ class CacheSubPlanProgram : Program {
                                 Triple(combinedAggregate, updatedIndices, filterInfo.map { it.first }),
                             )
                         } catch (e: Exception) {
+                            PythonLoggers.VERBOSE_LEVEL_TWO_LOGGER.info(
+                                "Partial aggregation caching failed, falling back to exact match: ${e.message}",
+                            )
                             Pair(false, Triple(cacheRoot, listOf(), listOf()))
                         }
                     } else {
@@ -670,8 +678,7 @@ class CacheSubPlanProgram : Program {
             parents: List<Pair<CoveringExpressionState, RelNode>>,
         ): Triple<RelNode, List<List<Int>>, List<Pair<RexNode?, Boolean>>> {
             relBuilder.push(input)
-            // Note: You can't hash RelBuilder.AggCall consistently, so we assume the string representations are unique.
-            val aggCallsMap = HashMap<String, Pair<AggCall, Int>>()
+            val aggCallsMap = HashMap<AggCallKey, Pair<AggCall, Int>>()
             parents.forEach {
                 val agg = it.second as Aggregate
                 val indices = it.first.keptColumns
@@ -683,11 +690,19 @@ class CacheSubPlanProgram : Program {
                                 fieldCollation.withFieldIndex(indices[fieldCollation.fieldIndex])
                             },
                         )
-                    val aggCall = buildEquivalentAggCall(aggCall, newArgs, newCollation)
-                    val aggCallString = aggCall.toString()
-                    if (!aggCallsMap.contains(aggCallString)) {
+                    val newAggCall = buildEquivalentAggCall(aggCall, newArgs, newCollation)
+                    val key =
+                        AggCallKey(
+                            aggCall.aggregation,
+                            aggCall.isDistinct,
+                            aggCall.isApproximate,
+                            aggCall.ignoreNulls(),
+                            aggCall.argList.map { idx -> indices[idx] },
+                            newCollation,
+                        )
+                    if (!aggCallsMap.contains(key)) {
                         val newIdx = aggCallsMap.size
-                        aggCallsMap[aggCallString] = Pair(aggCall, newIdx)
+                        aggCallsMap[key] = Pair(newAggCall, newIdx)
                     }
                 }
             }
@@ -732,10 +747,20 @@ class CacheSubPlanProgram : Program {
                                     },
                                 )
                             val newAggCall = buildEquivalentAggCall(aggCall, newArgs, newCollation)
-                            val newAggIdx = aggCallsMap[newAggCall.toString()]!!.second
+                            val key =
+                                AggCallKey(
+                                    aggCall.aggregation,
+                                    aggCall.isDistinct,
+                                    aggCall.isApproximate,
+                                    aggCall.ignoreNulls(),
+                                    aggCall.argList.map { idx -> indices[idx] },
+                                    newCollation,
+                                )
+                            val newAggIdx = aggCallsMap[key]!!.second
                             newIndices[colIdx + agg.groupSet.cardinality()] =
                                 groupKeys.cardinality() + newAggIdx
                         }
+                        relBuilder.build()
                     } else {
                         // Here we are taking the "partial aggregation" path. That means we still need to
                         // execute the aggregate. As a result, columns need to be place relative to their
@@ -780,7 +805,16 @@ class CacheSubPlanProgram : Program {
                                     },
                                 )
                             val newAggCall = buildEquivalentAggCall(aggCall, newArgs, newCollation)
-                            val newAggIdx = aggCallsMap[newAggCall.toString()]!!.second
+                            val key =
+                                AggCallKey(
+                                    aggCall.aggregation,
+                                    aggCall.isDistinct,
+                                    aggCall.isApproximate,
+                                    aggCall.ignoreNulls(),
+                                    aggCall.argList.map { idx -> indices[idx] },
+                                    newCollation,
+                                )
+                            val newAggIdx = aggCallsMap[key]!!.second
                             // Must be exactly 1 argument to allow partial aggregation
                             val arg = aggCall.argList[0]
                             val oldIndex = indices[arg]
@@ -795,6 +829,7 @@ class CacheSubPlanProgram : Program {
                             requiredIndices.add(oldIndex)
                             newIndices[oldIndex] = newAggIdx + groupKeys.cardinality()
                         }
+                        relBuilder.build()
                     }
                     newIndices
                 }
@@ -1219,6 +1254,23 @@ class CacheSubPlanProgram : Program {
         val baseNode: RelNode,
         val keptColumns: List<Int>,
         val filter: RexNode?,
+    )
+
+    /**
+     * Structured key for deduplicating aggregate calls during covering
+     * expression caching. Uses the same semantic fields as
+     * [AggregateCall.equals] but with remapped argument indices and
+     * collation, avoiding reliance on [RelBuilder.AggCall.toString] which
+     * omits fields like ignoreNulls and approximate and may produce
+     * non-canonical RexNode string representations.
+     */
+    private data class AggCallKey(
+        val aggregation: SqlAggFunction,
+        val distinct: Boolean,
+        val approximate: Boolean,
+        val ignoreNulls: Boolean,
+        val argList: List<Int>,
+        val collation: RelCollation,
     )
 
     /**

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
@@ -1,5 +1,6 @@
 package com.bodosql.calcite.prepare
 
+import com.bodosql.calcite.adapter.bodo.BodoPhysicalAggregate
 import com.bodosql.calcite.adapter.bodo.BodoPhysicalCachedSubPlan
 import com.bodosql.calcite.adapter.bodo.BodoPhysicalJoin
 import com.bodosql.calcite.adapter.bodo.BodoPhysicalRel
@@ -27,6 +28,7 @@ import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.RelShuttleImpl
 import org.apache.calcite.rel.RelVisitor
+import org.apache.calcite.rel.SingleRel
 import org.apache.calcite.rel.core.Aggregate
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rel.core.Filter
@@ -44,7 +46,6 @@ import org.apache.calcite.sql.`fun`.SqlStdOperatorTable
 import org.apache.calcite.sql.type.SqlTypeName
 import org.apache.calcite.tools.Program
 import org.apache.calcite.tools.RelBuilder
-import org.apache.calcite.tools.RelBuilder.AggCall
 import org.apache.calcite.util.ImmutableBitSet
 import org.apache.calcite.util.Util
 import org.apache.calcite.util.mapping.MappingType
@@ -459,11 +460,19 @@ class CacheSubPlanProgram : Program {
                 // Check for converters which should always match
                 // Note: We don't need to check these separately by construction because they couldn't match to this point
                 // if they had different conventions.
-                val newRoot = parents[0].second.copy(parents[0].second.traitSet, listOf(cacheRoot))
-                processCaching(
-                    newRoot,
-                    parents.map { CoveringExpressionState(it.second, it.first.keptColumns, it.first.filter) },
-                )
+                // However, if the cache root is not in the converter's source convention (e.g. a BodoPhysicalFilter
+                // was inserted by earlier filter processing), we cannot create a converter on top of it and must
+                // materialize the cache here instead.
+                val converterSourceConvention = (parents[0].second as SingleRel).input.convention
+                if (cacheRoot.convention == converterSourceConvention) {
+                    val newRoot = parents[0].second.copy(parents[0].second.traitSet, listOf(cacheRoot))
+                    processCaching(
+                        newRoot,
+                        parents.map { CoveringExpressionState(it.second, it.first.keptColumns, it.first.filter) },
+                    )
+                } else {
+                    generateCacheNodes(cacheRoot, parents, parents.size)
+                }
             } else {
                 generateCacheNodes(cacheRoot, parents, parents.size)
             }
@@ -677,20 +686,17 @@ class CacheSubPlanProgram : Program {
             input: RelNode,
             parents: List<Pair<CoveringExpressionState, RelNode>>,
         ): Triple<RelNode, List<List<Int>>, List<Pair<RexNode?, Boolean>>> {
-            relBuilder.push(input)
-            val aggCallsMap = HashMap<AggCallKey, Pair<AggCall, Int>>()
+            val aggCallsMap = HashMap<AggCallKey, Pair<AggregateCall, Int>>()
             parents.forEach {
                 val agg = it.second as Aggregate
                 val indices = it.first.keptColumns
                 agg.aggCallList.forEach { aggCall ->
-                    val newArgs = aggCall.argList.map { idx -> relBuilder.field(indices[idx]) }
                     val newCollation =
                         RelCollations.of(
                             aggCall.collation.fieldCollations.map { fieldCollation ->
                                 fieldCollation.withFieldIndex(indices[fieldCollation.fieldIndex])
                             },
                         )
-                    val newAggCall = buildEquivalentAggCall(aggCall, newArgs, newCollation)
                     val key =
                         AggCallKey(
                             aggCall.aggregation,
@@ -702,13 +708,20 @@ class CacheSubPlanProgram : Program {
                         )
                     if (!aggCallsMap.contains(key)) {
                         val newIdx = aggCallsMap.size
+                        val newAggCall = buildEquivalentAggCall(aggCall, indices, newCollation, input, groupKeys.cardinality())
                         aggCallsMap[key] = Pair(newAggCall, newIdx)
                     }
                 }
             }
             val newAggCalls = aggCallsMap.values.sortedBy { it.second }.map { it.first }
-            relBuilder.aggregate(relBuilder.groupKey(groupKeys), newAggCalls)
-            val newAggregate = relBuilder.build()
+            val newAggregate =
+                BodoPhysicalAggregate.create(
+                    relBuilder.getCluster(),
+                    input,
+                    groupKeys,
+                    listOf(groupKeys),
+                    newAggCalls,
+                )
             val newKeysIndices =
                 groupKeys.withIndex().associate {
                     Pair(it.value, it.index)
@@ -746,7 +759,6 @@ class CacheSubPlanProgram : Program {
                                         fieldCollation.withFieldIndex(indices[fieldCollation.fieldIndex])
                                     },
                                 )
-                            val newAggCall = buildEquivalentAggCall(aggCall, newArgs, newCollation)
                             val key =
                                 AggCallKey(
                                     aggCall.aggregation,
@@ -804,7 +816,6 @@ class CacheSubPlanProgram : Program {
                                         fieldCollation.withFieldIndex(indices[fieldCollation.fieldIndex])
                                     },
                                 )
-                            val newAggCall = buildEquivalentAggCall(aggCall, newArgs, newCollation)
                             val key =
                                 AggCallKey(
                                     aggCall.aggregation,
@@ -861,20 +872,39 @@ class CacheSubPlanProgram : Program {
         }
 
         /**
-         * Builds an aggCall that matches the one passed in but with new arguments.
-         * @param aggCall The aggCall to match.
+         * Builds an AggregateCall that matches the one passed in but with remapped
+         * argument indices and collation. Preserves the original return type to
+         * avoid type re-inference issues (e.g. SUM0 on BIGINT may re-infer as DOUBLE).
+         * @param aggCall The original aggregate call.
+         * @param indices The column mapping from the consumer's input to the cache root.
+         * @param newCollation The remapped collation.
+         * @param input The input rel that the new aggregate will sit on top of.
+         * @param groupCount The number of grouping keys in the new aggregate.
          */
         private fun buildEquivalentAggCall(
             aggCall: AggregateCall,
-            newArgs: List<RexNode>,
+            indices: List<Int>,
             newCollation: RelCollation,
-        ): AggCall =
-            relBuilder
-                .aggregateCall(aggCall.aggregation, newArgs)
-                .distinct(aggCall.isDistinct)
-                .approximate(aggCall.isApproximate)
-                .ignoreNulls(aggCall.ignoreNulls())
-                .sort(newCollation)
+            input: RelNode,
+            groupCount: Int,
+        ): AggregateCall {
+            val newArgIndices = aggCall.argList.map { idx -> indices[idx] }
+            return AggregateCall.create(
+                aggCall.aggregation,
+                aggCall.isDistinct,
+                aggCall.isApproximate,
+                aggCall.ignoreNulls(),
+                aggCall.rexList,
+                newArgIndices,
+                -1,
+                aggCall.distinctKeys,
+                newCollation,
+                groupCount,
+                input,
+                aggCall.type,
+                aggCall.name,
+            )
+        }
 
         /**
          * Process a join that is known to be a candidate for caching. This also includes

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
@@ -86,10 +86,6 @@ class CacheSubPlanProgram : Program {
      * if we see "all aggregates" or "all joins". In addition, several places don't continue
      * caching on "groups" of inputs.
      *
-     * Note: This is not fully deployed across our test suite yet, so any change to this code
-     * should ensure we run all tests with RelationalAlgebraGenerator.coveringExpressionCaching
-     * = True before merging.
-     *
      * @param rel The original plan.
      * @return The new plan with covering expressions generated if
      * possible.

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
@@ -463,8 +463,8 @@ class CacheSubPlanProgram : Program {
                 // However, if the cache root is not in the converter's source convention (e.g. a BodoPhysicalFilter
                 // was inserted by earlier filter processing), we cannot create a converter on top of it and must
                 // materialize the cache here instead.
-                val converterSourceConvention = (parents[0].second as SingleRel).input.convention
-                if (cacheRoot.convention == converterSourceConvention) {
+                val converterSourceConvention = (parents[0].second as? SingleRel)?.input?.convention
+                if (converterSourceConvention != null && cacheRoot.convention == converterSourceConvention) {
                     val newRoot = parents[0].second.copy(parents[0].second.traitSet, listOf(cacheRoot))
                     processCaching(
                         newRoot,
@@ -748,11 +748,8 @@ class CacheSubPlanProgram : Program {
                             val newKeyIdx = indices[keyIdx]
                             newIndices[colIdx] = newKeysIndices[newKeyIdx]!!
                         }
-                        // Push the input again for field generation
-                        relBuilder.push(input)
                         agg.aggCallList.withIndex().forEach { callInfo ->
                             val (colIdx, aggCall) = callInfo
-                            val newArgs = aggCall.argList.map { idx -> relBuilder.field(indices[idx]) }
                             val newCollation =
                                 RelCollations.of(
                                     aggCall.collation.fieldCollations.map { fieldCollation ->
@@ -772,7 +769,6 @@ class CacheSubPlanProgram : Program {
                             newIndices[colIdx + agg.groupSet.cardinality()] =
                                 groupKeys.cardinality() + newAggIdx
                         }
-                        relBuilder.build()
                     } else {
                         // Here we are taking the "partial aggregation" path. That means we still need to
                         // execute the aggregate. As a result, columns need to be place relative to their
@@ -787,8 +783,6 @@ class CacheSubPlanProgram : Program {
                             val oldIndex = indices[keyIdx]
                             newIndices[keyIdx] = newKeysIndices[oldIndex]!!
                         }
-                        // Push the input again for field generation
-                        relBuilder.push(input)
                         // For the aggregate call(s) we currently require that every function can compute
                         // the partial aggregation directly from its result without any necessary remapping.
                         // For example, max, min, sum. As a result, we need to remap every function location
@@ -809,7 +803,6 @@ class CacheSubPlanProgram : Program {
                             if (!supportedAggCalls.contains(aggCall.aggregation)) {
                                 throw IllegalStateException("Internal Error: Unsupported aggregate function for partial aggregation")
                             }
-                            val newArgs = aggCall.argList.map { idx -> relBuilder.field(indices[idx]) }
                             val newCollation =
                                 RelCollations.of(
                                     aggCall.collation.fieldCollations.map { fieldCollation ->
@@ -840,7 +833,6 @@ class CacheSubPlanProgram : Program {
                             requiredIndices.add(oldIndex)
                             newIndices[arg] = newAggIdx + groupKeys.cardinality()
                         }
-                        relBuilder.build()
                     }
                     newIndices
                 }
@@ -1293,6 +1285,18 @@ class CacheSubPlanProgram : Program {
      * collation, avoiding reliance on [RelBuilder.AggCall.toString] which
      * omits fields like ignoreNulls and approximate and may produce
      * non-canonical RexNode string representations.
+     *
+     * Note: This key intentionally excludes the aggregate call's return type
+     * ([AggregateCall.type]). Two calls with the same aggregation function,
+     * arguments, and flags but different inferred return types would collide
+     * in the dedup map. In practice this is safe because a given aggregation
+     * applied to the same input column always infers the same return type
+     * (the return type is a deterministic function of the aggregation and
+     * its argument types, which are themselves part of the key via the
+     * remapped argList). If a future aggregate function violates this
+     * invariant, [buildEquivalentAggCall] still preserves the original
+     * return type per-call, so only the dedup grouping — not correctness of
+     * the built call — could be affected.
      */
     private data class AggCallKey(
         val aggregation: SqlAggFunction,

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
@@ -1209,7 +1209,7 @@ class CacheSubPlanProgram : Program {
                 FilterRulesCommon.updateConditionsExtractCommon(
                     relBuilder,
                     baseFilter,
-                    HashSet(),
+                    LinkedHashSet(),
                 )
             val combinedFilter = simplify.simplifyUnknownAsFalse(reorderedFilter)
             // Generate the new root.
@@ -1259,7 +1259,7 @@ class CacheSubPlanProgram : Program {
                                 FilterRulesCommon.updateConditionsExtractCommon(
                                     relBuilder,
                                     mergedFilter,
-                                    HashSet(),
+                                    LinkedHashSet(),
                                 )
                             filterSimplifier.simplifyUnknownAsFalse(reorderedFilter)
                         }

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/CacheSubPlanProgram.kt
@@ -838,7 +838,7 @@ class CacheSubPlanProgram : Program {
                                 )
                             }
                             requiredIndices.add(oldIndex)
-                            newIndices[oldIndex] = newAggIdx + groupKeys.cardinality()
+                            newIndices[arg] = newAggIdx + groupKeys.cardinality()
                         }
                         relBuilder.build()
                     }
@@ -1436,5 +1436,62 @@ class CacheSubPlanProgram : Program {
     companion object {
         @JvmStatic
         fun canCacheNode(rel: RelNode): Boolean = rel is BodoPhysicalRel && rel !is BodoPhysicalCachedSubPlan
+
+        /**
+         * Reconcile the numConsumers of every cache node in the plan to match the
+         * actual number of times codegen will call emit() on it. This must be called
+         * after all programs that insert/move cache node copies (CacheSubPlanProgram
+         * and RuntimeJoinFilterProgram) have finished.
+         *
+         * The count mirrors how BodoCodeGenVisitor traverses the tree: each
+         * BodoPhysicalCachedSubPlan at the top level is counted once, and the body
+         * of each cache node (cachedPlan.plan) is visited exactly once — regardless
+         * of how many top-level copies share that body — because codegen only
+         * generates the body on the first (write) visit.
+         */
+        @JvmStatic
+        fun reconcileNumConsumers(root: RelNode) {
+            val counts = HashMap<Int, Int>()
+            val visitedBodies = HashSet<Int>()
+            val visitor =
+                object : RelVisitor() {
+                    override fun visit(
+                        node: RelNode,
+                        ordinal: Int,
+                        parent: RelNode?,
+                    ) {
+                        if (node is CachedSubPlanBase) {
+                            counts.merge(node.cacheID, 1) { a, b -> a + b }
+                            if (visitedBodies.add(node.cacheID)) {
+                                this.visit(node.cachedPlan.plan, 0, null)
+                            }
+                        }
+                        node.childrenAccept(this)
+                    }
+                }
+            visitor.go(root)
+            val seen = HashSet<Int>()
+            val setterVisitedBodies = HashSet<Int>()
+            val setter =
+                object : RelVisitor() {
+                    override fun visit(
+                        node: RelNode,
+                        ordinal: Int,
+                        parent: RelNode?,
+                    ) {
+                        if (node is CachedSubPlanBase) {
+                            if (seen.add(node.cacheID)) {
+                                val count = counts[node.cacheID] ?: 0
+                                node.cachedPlan.setNumConsumers(count)
+                            }
+                            if (setterVisitedBodies.add(node.cacheID)) {
+                                this.visit(node.cachedPlan.plan, 0, null)
+                            }
+                        }
+                        node.childrenAccept(this)
+                    }
+                }
+            setter.go(root)
+        }
     }
 }

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/RuntimeJoinFilterProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/RuntimeJoinFilterProgram.kt
@@ -26,6 +26,8 @@ import com.bodosql.calcite.rel.core.CachedPlanInfo
 import com.bodosql.calcite.rel.core.CachedSubPlanBase
 import com.bodosql.calcite.rel.core.cachePlanContainers.CacheNodeTopologicalSortVisitor
 import com.bodosql.calcite.rel.core.cachePlanContainers.CachedResultVisitor
+import com.bodosql.calcite.table.CatalogTable
+import com.bodosql.calcite.table.SnowflakeCatalogTable
 import com.google.common.annotations.VisibleForTesting
 import org.apache.calcite.plan.BodoRelOptCluster
 import org.apache.calcite.plan.RelOptLattice
@@ -367,6 +369,7 @@ object RuntimeJoinFilterProgram : Program {
                 converter
             } else {
                 val filterInfo = liveJoins.flattenToLists()
+                val catalogTable = findCatalogTable(converter.input)
                 val snowflakeRtjf =
                     SnowflakeRuntimeJoinFilter.create(
                         converter.input,
@@ -374,7 +377,7 @@ object RuntimeJoinFilterProgram : Program {
                         filterInfo.equalityFilterColumns,
                         filterInfo.equalityFilterIsFirstLocations,
                         filterInfo.nonEqualityFilterColumns,
-                        (converter.input as SnowflakeRel).getCatalogTable(),
+                        catalogTable,
                     )
                 liveJoins = JoinFilterProgramState()
                 converter.copy(converter.traitSet, listOf(snowflakeRtjf))
@@ -385,6 +388,7 @@ object RuntimeJoinFilterProgram : Program {
                 converter
             } else {
                 val filterInfo = liveJoins.flattenToLists()
+                val icebergCatalogTable = findIcebergCatalogTable(converter.input)
                 val icebergRtjf =
                     IcebergRuntimeJoinFilter.create(
                         converter.input,
@@ -392,7 +396,7 @@ object RuntimeJoinFilterProgram : Program {
                         filterInfo.equalityFilterColumns,
                         filterInfo.equalityFilterIsFirstLocations,
                         filterInfo.nonEqualityFilterColumns,
-                        (converter.input as IcebergRel).getCatalogTable(),
+                        icebergCatalogTable,
                     )
                 liveJoins = JoinFilterProgramState()
                 converter.copy(converter.traitSet, listOf(icebergRtjf))
@@ -963,6 +967,50 @@ object RuntimeJoinFilterProgram : Program {
                     JoinFilterProgramState()
                 }
             }
+
+        /**
+         * Find the catalog table for a node that may be wrapped by BodoPhysical nodes
+         * inserted by covering expression caching. Traverses the input chain until a
+         * SnowflakeRel is found. If a CachedSubPlanBase is encountered, searches its
+         * cached plan body as well.
+         */
+        private fun findCatalogTable(node: RelNode): SnowflakeCatalogTable =
+            findSnowflakeRel(node)?.getCatalogTable()
+                ?: throw IllegalStateException("Cannot find SnowflakeRel in input chain for catalog table")
+
+        private fun findSnowflakeRel(node: RelNode): SnowflakeRel? {
+            if (node is SnowflakeRel) return node
+            if (node is CachedSubPlanBase) {
+                return findSnowflakeRel(node.cachedPlan.plan)
+            }
+            for (input in node.inputs) {
+                val result = findSnowflakeRel(input)
+                if (result != null) return result
+            }
+            return null
+        }
+
+        /**
+         * Find the catalog table for a node that may be wrapped by BodoPhysical nodes
+         * inserted by covering expression caching. Traverses the input chain until an
+         * IcebergRel is found. If a CachedSubPlanBase is encountered, searches its
+         * cached plan body as well.
+         */
+        private fun findIcebergCatalogTable(node: RelNode): CatalogTable =
+            findIcebergRel(node)?.getCatalogTable()
+                ?: throw IllegalStateException("Cannot find IcebergRel in input chain for catalog table")
+
+        private fun findIcebergRel(node: RelNode): IcebergRel? {
+            if (node is IcebergRel) return node
+            if (node is CachedSubPlanBase) {
+                return findIcebergRel(node.cachedPlan.plan)
+            }
+            for (input in node.inputs) {
+                val result = findIcebergRel(input)
+                if (result != null) return result
+            }
+            return null
+        }
     }
 
     /**

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/RuntimeJoinFilterProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/RuntimeJoinFilterProgram.kt
@@ -14,10 +14,8 @@ import com.bodosql.calcite.adapter.bodo.BodoPhysicalSort
 import com.bodosql.calcite.adapter.bodo.BodoPhysicalUnion
 import com.bodosql.calcite.adapter.bodo.BodoPhysicalWindow
 import com.bodosql.calcite.adapter.common.LimitUtils
-import com.bodosql.calcite.adapter.iceberg.IcebergRel
 import com.bodosql.calcite.adapter.iceberg.IcebergRuntimeJoinFilter
 import com.bodosql.calcite.adapter.iceberg.IcebergToBodoPhysicalConverter
-import com.bodosql.calcite.adapter.snowflake.SnowflakeRel
 import com.bodosql.calcite.adapter.snowflake.SnowflakeRuntimeJoinFilter
 import com.bodosql.calcite.adapter.snowflake.SnowflakeToBodoPhysicalConverter
 import com.bodosql.calcite.application.logicalRules.WindowFilterTranspose
@@ -26,8 +24,6 @@ import com.bodosql.calcite.rel.core.CachedPlanInfo
 import com.bodosql.calcite.rel.core.CachedSubPlanBase
 import com.bodosql.calcite.rel.core.cachePlanContainers.CacheNodeTopologicalSortVisitor
 import com.bodosql.calcite.rel.core.cachePlanContainers.CachedResultVisitor
-import com.bodosql.calcite.table.CatalogTable
-import com.bodosql.calcite.table.SnowflakeCatalogTable
 import com.google.common.annotations.VisibleForTesting
 import org.apache.calcite.plan.BodoRelOptCluster
 import org.apache.calcite.plan.RelOptLattice
@@ -369,7 +365,7 @@ object RuntimeJoinFilterProgram : Program {
                 converter
             } else {
                 val filterInfo = liveJoins.flattenToLists()
-                val catalogTable = findCatalogTable(converter.input)
+                val catalogTable = converter.findSnowflakeRel(converter.input).getCatalogTable()
                 val snowflakeRtjf =
                     SnowflakeRuntimeJoinFilter.create(
                         converter.input,
@@ -388,7 +384,7 @@ object RuntimeJoinFilterProgram : Program {
                 converter
             } else {
                 val filterInfo = liveJoins.flattenToLists()
-                val icebergCatalogTable = findIcebergCatalogTable(converter.input)
+                val icebergCatalogTable = converter.findIcebergRel(converter.input).getCatalogTable()
                 val icebergRtjf =
                     IcebergRuntimeJoinFilter.create(
                         converter.input,
@@ -967,50 +963,6 @@ object RuntimeJoinFilterProgram : Program {
                     JoinFilterProgramState()
                 }
             }
-
-        /**
-         * Find the catalog table for a node that may be wrapped by BodoPhysical nodes
-         * inserted by covering expression caching. Traverses the input chain until a
-         * SnowflakeRel is found. If a CachedSubPlanBase is encountered, searches its
-         * cached plan body as well.
-         */
-        private fun findCatalogTable(node: RelNode): SnowflakeCatalogTable =
-            findSnowflakeRel(node)?.getCatalogTable()
-                ?: throw IllegalStateException("Cannot find SnowflakeRel in input chain for catalog table")
-
-        private fun findSnowflakeRel(node: RelNode): SnowflakeRel? {
-            if (node is SnowflakeRel) return node
-            if (node is CachedSubPlanBase) {
-                return findSnowflakeRel(node.cachedPlan.plan)
-            }
-            for (input in node.inputs) {
-                val result = findSnowflakeRel(input)
-                if (result != null) return result
-            }
-            return null
-        }
-
-        /**
-         * Find the catalog table for a node that may be wrapped by BodoPhysical nodes
-         * inserted by covering expression caching. Traverses the input chain until an
-         * IcebergRel is found. If a CachedSubPlanBase is encountered, searches its
-         * cached plan body as well.
-         */
-        private fun findIcebergCatalogTable(node: RelNode): CatalogTable =
-            findIcebergRel(node)?.getCatalogTable()
-                ?: throw IllegalStateException("Cannot find IcebergRel in input chain for catalog table")
-
-        private fun findIcebergRel(node: RelNode): IcebergRel? {
-            if (node is IcebergRel) return node
-            if (node is CachedSubPlanBase) {
-                return findIcebergRel(node.cachedPlan.plan)
-            }
-            for (input in node.inputs) {
-                val result = findIcebergRel(input)
-                if (result != null) return result
-            }
-            return null
-        }
     }
 
     /**

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/RuntimeJoinFilterProgram.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/prepare/RuntimeJoinFilterProgram.kt
@@ -63,7 +63,14 @@ object RuntimeJoinFilterProgram : Program {
                 filterShuttle.keptCacheConsumerUpdates,
                 filterShuttle.inlinedCacheConsumerUpdates,
             )
-        return result.accept(cacheReplaceShuttle)
+        val finalResult = result.accept(cacheReplaceShuttle)
+        // Reconcile numConsumers to match the actual number of cache node copies in
+        // the final tree. This fixes mismatches introduced by covering-expression
+        // caching (where result.copy() in CoveringExpressionCacheReplacement can
+        // create extra copies not accounted for by numConsumers) and by the
+        // inlining/keep logic above.
+        CacheSubPlanProgram.reconcileNumConsumers(finalResult)
+        return finalResult
     }
 
     /**

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/core/CachedPlanInfo.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/core/CachedPlanInfo.kt
@@ -24,6 +24,10 @@ class CachedPlanInfo private constructor(
 
     fun getNumConsumers(): Int = numConsumers
 
+    fun setNumConsumers(value: Int) {
+        numConsumers = value
+    }
+
     companion object {
         fun create(
             plan: RelNode,

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rel/rel2sql/BodoRelToSqlConverter.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rel/rel2sql/BodoRelToSqlConverter.java
@@ -3,6 +3,7 @@ package org.apache.calcite.rel.rel2sql;
 import com.bodosql.calcite.adapter.snowflake.SnowflakeTableScan;
 import com.bodosql.calcite.adapter.snowflake.SnowflakeToBodoPhysicalConverter;
 import com.bodosql.calcite.application.operatorTables.CastingOperatorTable;
+import com.bodosql.calcite.rel.core.CachedSubPlanBase;
 import com.google.common.collect.ImmutableList;
 import org.apache.calcite.adapter.jdbc.JdbcTable;
 import org.apache.calcite.plan.RelOptTable;
@@ -45,6 +46,10 @@ public class BodoRelToSqlConverter extends RelToSqlConverter {
 
     public Result visit(RelSubset e) {
         return dispatch(e.getBestOrOriginal());
+    }
+
+    public Result visit(CachedSubPlanBase e) {
+        return dispatch(e.getCachedPlan().getPlan());
     }
 
     private SqlNode castTimestampTZColumnsToVariant(RelDataType rowType, SqlNode sqlTable) {

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/interactive/BodoGenTest.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/interactive/BodoGenTest.kt
@@ -93,7 +93,7 @@ object BodoGenTest {
                 true, // Enable Streaming Sort for Testing
                 false, // Disable Streaming Sort Limit Offset for Testing
                 "SNOWFLAKE", // Maintain case sensitivity in the Snowflake style by default
-                false, // Only cache identical nodes
+                true, // Enable covering expression caching for testing
                 true, // Generate a prefetch call at the beginning of SQL queries
                 null,
             )

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/interactive/GenTestFixture.kt
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/test/java/com/bodosql/interactive/GenTestFixture.kt
@@ -45,7 +45,7 @@ abstract class GenTestFixture {
                 // Disable Streaming Sort Limit Offset
                 // Maintain case sensitivity in the Snowflake style by default
                 "SNOWFLAKE",
-                false,
+                true, // Enable covering expression caching for testing
                 true,
                 null,
             )

--- a/BodoSQL/setup.py
+++ b/BodoSQL/setup.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from setuptools import setup
 from setuptools.command.build_py import build_py
@@ -25,7 +26,7 @@ def build_libs(obj):
         ]
         if "BODO_FORCE_COLORED_BUILD" in os.environ:
             cmd_list.append("-Dstyle.color=always")
-        obj.spawn(cmd_list)
+        subprocess.run(cmd_list, check=True)
 
         executable_jar_path = os.path.join(
             "calcite_sql",
@@ -42,8 +43,8 @@ def build_libs(obj):
         except OSError:
             pass
         os.rename(executable_jar_path, dst_jar_path)
-    except ExecError as e:
-        obj.error("maven build failed with error:", e)
+    except subprocess.CalledProcessError as e:
+        raise ExecError(f"maven build failed with error: {e}") from e
 
 
 class CustomBuildPyCommand(build_py):

--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -144,7 +144,7 @@ bodo_use_decimal = os.environ.get("BODO_USE_DECIMAL", "0") != "0"
 # Which SQL defaults should BODOSQL use (Snowflake vs Spark)
 bodo_sql_style = os.environ.get("BODO_SQL_STYLE", "SNOWFLAKE").upper()
 # Should we enable full covering set caching.
-bodosql_full_caching = os.environ.get("BODO_USE_PARTIAL_CACHING", "0") != "0"
+bodosql_full_caching = os.environ.get("BODO_USE_PARTIAL_CACHING", "1") != "0"
 # If enabled, always uses the hash-based implementation instead of the
 # sorting-based implementation for streaming window function execution.
 bodo_disable_streaming_window_sort = (


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Enables covering expressions and fixes a few bugs with them.

In the future if we find plans we don't like caused by covering expressions we can make it cost based.

## Testing strategy
PR CI and https://github.com/bodo-ai/customer-sample-code/actions/runs/30305340181/job/90108104711
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
Better subplan caching
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.