### PR TITLE
[GPU] Handle empty build table case in broadcast join

### DIFF
--- a/bodo/libs/streaming/cuda_join.cpp
+++ b/bodo/libs/streaming/cuda_join.cpp
@@ -535,43 +535,44 @@ std::pair<std::unique_ptr<cudf::table>, bool> CudaHashJoin::ProbeProcessBatch(
             probe_views.push_back(chunk->view());
         }
         probe_to_select = cudf::concatenate(probe_views, stream);
+    }
 
-        bool null_handle = std::visit(
-            [](auto& handle) { return handle == nullptr; }, this->_join_handle);
-        // ANTI joins with an empty build table (null join handle) should output
-        // all probe rows, and for other join types we can just return early
-        // since we know the probe rows can't match.
-        if (probe_to_select->num_rows() == 0) {
+    bool null_handle = std::visit(
+        [](auto& handle) { return handle == nullptr; }, this->_join_handle);
+
+    // ANTI joins with an empty build table (null join handle) should output
+    // all probe rows, and for other join types we can just return early
+    // since we know the probe rows can't match.
+    if (probe_to_select->num_rows() == 0) {
+        return get_empty_output_table(global_is_last, stream);
+    }
+
+    if (null_handle) {
+        // build table is empty
+        if (this->join_type == duckdb::JoinType::ANTI) {
+            // intentionally do nothing
+        } else if (this->join_type == duckdb::JoinType::LEFT ||
+                   this->join_type == duckdb::JoinType::OUTER) {
+            cudf::table_view probe_kept_view = probe_to_select->select(
+                this->probe_kept_cols.begin(), this->probe_kept_cols.end());
+            cudf::table_view build_kept_view = _build_table->select(
+                this->build_kept_cols.begin(), this->build_kept_cols.end());
+            // Create probe_idx_view to create every probe row in the
+            // output.
+            auto seq_col = cudf::sequence(probe_to_select->num_rows(),
+                                          cudf::numeric_scalar<int32_t>(0),
+                                          cudf::numeric_scalar<int32_t>(1));
+            cudf::column_view probe_idx_view = seq_col->view();
+            // Create build_idx_view to create NA build rows in the output.
+            auto neg_one_col = cudf::sequence(probe_to_select->num_rows(),
+                                              cudf::numeric_scalar<int32_t>(-1),
+                                              cudf::numeric_scalar<int32_t>(0));
+            cudf::column_view build_idx_view = neg_one_col->view();
+            return materialize_and_output(probe_kept_view, probe_idx_view,
+                                          build_kept_view, build_idx_view,
+                                          global_is_last, stream);
+        } else {
             return get_empty_output_table(global_is_last, stream);
-        }
-        if (null_handle) {
-            // build table is empty
-            if (this->join_type == duckdb::JoinType::ANTI) {
-                // intentionally do nothing
-            } else if (this->join_type == duckdb::JoinType::LEFT ||
-                       this->join_type == duckdb::JoinType::OUTER) {
-                cudf::table_view probe_kept_view = probe_to_select->select(
-                    this->probe_kept_cols.begin(), this->probe_kept_cols.end());
-                cudf::table_view build_kept_view = _build_table->select(
-                    this->build_kept_cols.begin(), this->build_kept_cols.end());
-                // Create probe_idx_view to create every probe row in the
-                // output.
-                auto seq_col = cudf::sequence(probe_to_select->num_rows(),
-                                              cudf::numeric_scalar<int32_t>(0),
-                                              cudf::numeric_scalar<int32_t>(1));
-                cudf::column_view probe_idx_view = seq_col->view();
-                // Create build_idx_view to create NA build rows in the output.
-                auto neg_one_col =
-                    cudf::sequence(probe_to_select->num_rows(),
-                                   cudf::numeric_scalar<int32_t>(-1),
-                                   cudf::numeric_scalar<int32_t>(0));
-                cudf::column_view build_idx_view = neg_one_col->view();
-                return materialize_and_output(probe_kept_view, probe_idx_view,
-                                              build_kept_view, build_idx_view,
-                                              global_is_last, stream);
-            } else {
-                return get_empty_output_table(global_is_last, stream);
-            }
         }
     }
 

--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -95,7 +95,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
 
         size_t total_bytes = get_smallest_gpu_mem_size();
         this->metrics.init_time += end_timer(start_init);
-        // Do broadcast join if probe table is order of magnitude smaller than
+        // Do broadcast join if build table is order of magnitude smaller than
         // probe and it fits on GPU with room for the hash table.
         return (build_total < (probe_total * 0.1)) &&
                ((build_total * 4) < total_bytes);

--- a/bodo/tests/conftest.py
+++ b/bodo/tests/conftest.py
@@ -29,7 +29,12 @@ from numba.core.runtime import rtsys  # noqa TID253
 import bodo
 import bodo.user_logging
 from bodo.tests.iceberg_database_helpers.utils import DATABASE_NAME
-from bodo.tests.utils import get_gpu_0_process_count, get_num_gpus, temp_env_override
+from bodo.tests.utils import (
+    get_gpu_0_process_count,
+    get_num_gpus,
+    set_broadcast_join,
+    temp_env_override,
+)
 
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
@@ -980,6 +985,18 @@ def gpu_disable_cpu_fallback(request, monkeypatch):
         allow_fallback = kws.get("allow_fallback", False)
         if not allow_fallback:
             monkeypatch.setenv("BODO_GPU_DISABLE_CPU_FALLBACK", "1")
+
+
+@pytest.fixture(params=["no_broadcast", "broadcast"])
+def join_strategy(request):
+    """
+    Fixture for join strategy, allowing tests to run with both broadcast and non-broadcast joins.
+    """
+    strategy = request.param
+    do_broadcast = strategy == "broadcast"
+
+    with set_broadcast_join(do_broadcast):
+        yield strategy
 
 
 def pytest_runtest_teardown(item, nextitem):

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -26,7 +26,6 @@ from bodo.pandas.utils import (
 from bodo.tests.utils import (
     _test_equal,
     is_multi_worker_per_gpu_test,
-    set_broadcast_join,
     temp_config_override,
 )
 
@@ -1448,12 +1447,11 @@ def test_project_after_filter(datapath):
 
 @pytest.mark.gpu
 @pytest.mark.parametrize("how", ["inner", "left", "right", "outer"])
-@pytest.mark.parametrize("broadcast", [True, False])
-def test_merge(how, broadcast):
+def test_merge(how, join_strategy):
     """Simple test for DataFrame merge."""
 
     # Make sure bdf3 is unevaluated in the process.
-    with assert_executed_plan_count(0), set_broadcast_join(broadcast):
+    with assert_executed_plan_count(0):
         df1 = pd.DataFrame(
             {
                 "B": ["a1", "b11", "c111"],
@@ -1550,11 +1548,10 @@ def test_merge_switch_side():
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("broadcast", [True, False])
-def test_merge_non_equi_cond(broadcast):
+def test_merge_non_equi_cond(join_strategy):
     """Simple test for non-equi join conditions."""
     # Make sure bdf3 is unevaluated in the process.
-    with assert_executed_plan_count(0), set_broadcast_join(broadcast):
+    with assert_executed_plan_count(0):
         df1 = pd.DataFrame(
             {
                 "B": pd.array([4, 5, 6], "Int64"),
@@ -1594,7 +1591,7 @@ def test_merge_non_equi_cond(broadcast):
     )
 
     # Make sure bdf3 is unevaluated at this point.
-    with assert_executed_plan_count(0), set_broadcast_join(broadcast):
+    with assert_executed_plan_count(0):
         df1.loc[0, "B"] = np.nan
         bdf1 = bd.from_pandas(df1)
 
@@ -1621,11 +1618,10 @@ def test_merge_non_equi_cond(broadcast):
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("broadcast", [True, False])
-def test_merge_mixed_join_conds(broadcast):
+def test_merge_mixed_join_conds(join_strategy):
     """Test merge with both equi and non-equi join conditions."""
     # Make sure bdf3 is unevaluated at this point.
-    with assert_executed_plan_count(0), set_broadcast_join(broadcast):
+    with assert_executed_plan_count(0):
         df1 = pd.DataFrame(
             {
                 "B": pd.array([4, 5, 6], "Int64"),
@@ -2697,10 +2693,9 @@ def test_filter_source_matching():
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("broadcast", [True, False])
-def test_filter_series_isin(broadcast):
+def test_filter_series_isin(join_strategy):
     """Test dataframe filter with isin case"""
-    with assert_executed_plan_count(0), set_broadcast_join(broadcast):
+    with assert_executed_plan_count(0):
         df1 = pd.DataFrame(
             {
                 "A": [1.4, 2.1, 3.3],
@@ -2727,10 +2722,9 @@ def test_filter_series_isin(broadcast):
 
 
 @pytest.mark.gpu
-@pytest.mark.parametrize("broadcast", [True, False])
-def test_filter_series_not_isin(index_val, broadcast):
+def test_filter_series_not_isin(index_val, join_strategy):
     """Test dataframe filter with not isin case"""
-    with assert_executed_plan_count(0), set_broadcast_join(broadcast):
+    with assert_executed_plan_count(0):
         df1 = pd.DataFrame(
             {
                 "A": [1.4, 2.1, 3.3],
@@ -4829,6 +4823,28 @@ def test_join_filter_pushdown_aggregate_split_keys():
     _test_equal(
         bdf4,
         df4,
+        check_pandas_types=False,
+        sort_output=True,
+        reset_index=True,
+    )
+
+
+@pytest.mark.gpu
+def test_merge_empty_build(join_strategy):
+    """Test join behavior when the build table is empty."""
+    df1 = pd.DataFrame({"A": range(100)})
+    df2 = pd.DataFrame({"A": pd.array([], "Int32")})
+
+    with assert_executed_plan_count(0):
+        bdf2 = bd.from_pandas(df2)
+        bdf1 = bd.from_pandas(df1)
+        bdf3 = bdf1.merge(bdf2, left_on="A", right_on="A", how="left")
+
+    df3 = df1.merge(df2, left_on="A", right_on="A", how="left")
+
+    _test_equal(
+        bdf3,
+        df3,
         check_pandas_types=False,
         sort_output=True,
         reset_index=True,


### PR DESCRIPTION
## Changes included in this PR

As titled, previously an empty build table would result in a null join handle. We can handle empty build table case for broadcast join in the same way we handle it for other joins. 

As fixes minor testing issue with broadcast join in DF library tests

## Testing strategy

New test added, PR CI

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.