### PR TITLE
[GPU][BSE-5520] Fix aggregations containing nulls

### DIFF
--- a/BodoSQL/bodosql/tests/test_agg_nogroupby.py
+++ b/BodoSQL/bodosql/tests/test_agg_nogroupby.py
@@ -571,7 +571,9 @@ def test_agg_replicated(datapath, memory_leak_check):
 @pytest.mark.parametrize(
     "query",
     [
-        pytest.param("SELECT ANY_VALUE(A) FROM table1", id="int32"),
+        pytest.param(
+            "SELECT ANY_VALUE(A) FROM table1", id="int32", marks=pytest.mark.gpu
+        ),
         pytest.param(
             "SELECT ANY_VALUE(B) FROM table1", id="string", marks=pytest.mark.slow
         ),

--- a/BodoSQL/bodosql/tests/test_tpch_second_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_second_half.py
@@ -434,6 +434,7 @@ def test_tpch_q18(tpch_data, memory_leak_check):
 @pytest.mark.timeout(600)
 @pytest.mark.slow
 @pytest.mark.bodosql_cpp
+@pytest.mark.gpu
 def test_tpch_q19(tpch_data, memory_leak_check):
     QUANTITY1 = 1
     QUANTITY2 = 10

--- a/BodoSQL/bodosql/tests/test_tpch_second_half.py
+++ b/BodoSQL/bodosql/tests/test_tpch_second_half.py
@@ -338,6 +338,7 @@ def test_tpch_q16(tpch_data, spark_info, memory_leak_check):
 @pytest.mark.timeout(600)
 @pytest.mark.slow
 @pytest.mark.bodosql_cpp
+@pytest.mark.gpu
 def test_tpch_q17(tpch_data, memory_leak_check):
     BRAND = "Brand#23"
     CONTAINER = "MED BOX"

--- a/bodo/pandas/physical/gpu_reduce.cpp
+++ b/bodo/pandas/physical/gpu_reduce.cpp
@@ -30,6 +30,76 @@ std::vector<std::unique_ptr<cudf::scalar>> make_vector_of_two_cudf_scalars(
     return out;
 }
 
+template <typename ArrowType>
+std::shared_ptr<arrow::Scalar> make_numeric_reduction_identity(
+    std::string op_name) {
+    using CType = ArrowType::c_type;
+
+    CType value;
+
+    if (op_name == "add") {
+        value = CType{0};
+    } else if (op_name == "multiply") {
+        value = CType{1};
+    } else if (op_name == "less") {
+        value = std::numeric_limits<CType>::max();
+    } else if (op_name == "greater") {
+        value = std::numeric_limits<CType>::min();
+    } else if (op_name == "first") {
+        return arrow::MakeNullScalar(
+            arrow::TypeTraits<ArrowType>::type_singleton());
+    } else {
+        throw std::runtime_error("Unsupported reduction function: " + op_name);
+    }
+
+    return arrow::MakeScalar(value);
+}
+
+/**
+ * @brief Create the identity scalar for a reduction operation based on the
+ * operation name and Arrow data type.
+ *
+ * @param op_name Reduction operation i.e. "add", "multiply", "less", "greater",
+ * "first"
+ * @param type Arrow data type of the scalar
+ * @return std::shared_ptr<arrow::Scalar>
+ */
+std::shared_ptr<arrow::Scalar> make_reduction_identity(
+    std::string op_name, const std::shared_ptr<arrow::DataType>& type) {
+    switch (type->id()) {
+        case arrow::Type::INT8:
+            return make_numeric_reduction_identity<arrow::Int8Type>(op_name);
+        case arrow::Type::INT16:
+            return make_numeric_reduction_identity<arrow::Int16Type>(op_name);
+        case arrow::Type::INT32:
+            return make_numeric_reduction_identity<arrow::Int32Type>(op_name);
+        case arrow::Type::INT64:
+            return make_numeric_reduction_identity<arrow::Int64Type>(op_name);
+
+        case arrow::Type::UINT8:
+            return make_numeric_reduction_identity<arrow::UInt8Type>(op_name);
+        case arrow::Type::UINT16:
+            return make_numeric_reduction_identity<arrow::UInt16Type>(op_name);
+        case arrow::Type::UINT32:
+            return make_numeric_reduction_identity<arrow::UInt32Type>(op_name);
+        case arrow::Type::UINT64:
+            return make_numeric_reduction_identity<arrow::UInt64Type>(op_name);
+
+        case arrow::Type::FLOAT:
+            return make_numeric_reduction_identity<arrow::FloatType>(op_name);
+        case arrow::Type::DOUBLE:
+            return make_numeric_reduction_identity<arrow::DoubleType>(op_name);
+
+        case arrow::Type::BOOL:
+            return make_numeric_reduction_identity<arrow::BooleanType>(op_name);
+
+        default:
+            throw std::runtime_error(
+                "GPUReductionFunction: No reduction identity for Arrow type " +
+                type->ToString());
+    }
+}
+
 /**
  * @brief Get cudf reduce_aggregation object corresponding to the given
  * reduction function name.
@@ -152,42 +222,57 @@ void GPUReductionFunction::Finalize(MPI_Comm comm) {
     for (size_t i = 0; i < this->function_names.size(); i++) {
         std::unique_ptr<cudf::scalar>& result = this->results[i];
 
-        MPI_Comm has_data_comm;
+        std::shared_ptr<arrow::Table> arrow_table;
+        cudf::data_type result_dtype = result->type();
+        bool has_data = (result != nullptr && result->is_valid());
+
+        bool global_has_data = false;
+
         CHECK_MPI(
-            MPI_Comm_split(comm, result != nullptr ? 1 : MPI_UNDEFINED, 0,
-                           &has_data_comm),
-            "GPUReductionFunction::Finalize: MPI error on MPI_Comm_split:");
-        if (result != nullptr) {
-            cudf::data_type result_dtype = result->type();
-            std::shared_ptr<arrow::Table> arrow_table =
-                cudf_scalar_to_arrow_table(result);
-
-            // Extract the pointer to the scalar value from the Arrow table
-            // All Arrow primitive types store data in the second buffer
-            void* result_ptr = reinterpret_cast<void*>(arrow_table->column(0)
-                                                           ->chunk(0)
-                                                           ->data()
-                                                           ->buffers[1]
-                                                           ->address());
-
-            MPI_Datatype mpi_dtype = cudf_dtype_to_mpi(result_dtype);
-            // NOTE: OpenMPI collectives are not CUDA-aware
-            if (function_names[i] == "first") {
-                CHECK_MPI(
-                    MPI_Bcast(result_ptr, 1, mpi_dtype, 0, has_data_comm),
-                    "GPUReductionFunction::Finalize: MPI error on MPI_Bcast:");
-            } else {
-                CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, result_ptr, 1, mpi_dtype,
-                                        this->mpi_reduce_op, has_data_comm),
-                          "GPUReductionFunction::Finalize: MPI error on "
-                          "MPI_Allreduce:");
-            }
-
-            // Copy the reduced CPU result back to cudf scalar
-            std::shared_ptr<arrow::Scalar> arrow_scalar =
-                arrow_table->column(0)->GetScalar(0).ValueOrDie();
-            this->results[i] = arrow_scalar_to_cudf(arrow_scalar);
+            MPI_Allreduce(&has_data, &global_has_data, 1, MPI_C_BOOL, MPI_LOR,
+                          comm),
+            "GPUReductionFunction::Finalize: MPI error on MPI_Allreduce:");
+        if (!global_has_data) {
+            continue;
         }
+
+        if (has_data) {
+            arrow_table = cudf_scalar_to_arrow_table(result);
+        } else {
+            auto arrow_dtype = cudf_to_arrow_type(result_dtype);
+            std::shared_ptr<arrow::Scalar> scalar =
+                make_reduction_identity(reduction_names[i], arrow_dtype);
+            auto array = arrow::MakeArrayFromScalar(*scalar, 1).ValueOrDie();
+            arrow_table =
+                arrow::Table::FromRecordBatches(
+                    {arrow::RecordBatch::Make(
+                        arrow::schema({arrow::field("value", scalar->type)}), 1,
+                        {array})})
+                    .ValueOrDie();
+        }
+
+        // Extract the pointer to the scalar value from the Arrow table
+        // All Arrow primitive types store data in the second buffer
+        void* result_ptr = reinterpret_cast<void*>(
+            arrow_table->column(0)->chunk(0)->data()->buffers[1]->address());
+
+        MPI_Datatype mpi_dtype = cudf_dtype_to_mpi(result_dtype);
+        // NOTE: OpenMPI collectives are not CUDA-aware
+        if (function_names[i] == "first") {
+            CHECK_MPI(
+                MPI_Bcast(result_ptr, 1, mpi_dtype, 0, comm),
+                "GPUReductionFunction::Finalize: MPI error on MPI_Bcast:");
+        } else {
+            CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, result_ptr, 1, mpi_dtype,
+                                    this->mpi_reduce_op, comm),
+                      "GPUReductionFunction::Finalize: MPI error on "
+                      "MPI_Allreduce:");
+        }
+
+        // Copy the reduced CPU result back to cudf scalar
+        std::shared_ptr<arrow::Scalar> arrow_scalar =
+            arrow_table->column(0)->GetScalar(0).ValueOrDie();
+        this->results[i] = arrow_scalar_to_cudf(arrow_scalar);
     }
 }
 

--- a/bodo/pandas/physical/gpu_reduce.cpp
+++ b/bodo/pandas/physical/gpu_reduce.cpp
@@ -81,9 +81,7 @@ void GPUReductionFunction::CombineResults(
     assert(other.size() == this->results.size());
 
     for (size_t i = 0; i < this->function_names.size(); i++) {
-        const std::string& function_name = this->function_names[i];
         const std::string& combine_reduce_name = this->reduction_names[i];
-        const GPUReductionType& reduction_type = this->reduction_types[i];
         // Current reduction result
         std::unique_ptr<cudf::scalar>& result = this->results[i];
         std::unique_ptr<cudf::scalar>& other_result = other[i];
@@ -115,13 +113,7 @@ void GPUReductionFunction::CombineResults(
         std::unique_ptr<cudf::scalar> cmp_scalar =
             cudf::reduce(combined->view(), *agg, out_dtype, output_stream);
 
-        if (reduction_type == GPUReductionType::COMPARISON ||
-            reduction_type == GPUReductionType::AGGREGATION) {
-            result = std::move(cmp_scalar);
-        } else {
-            throw std::runtime_error("Unsupported reduction function: " +
-                                     function_name);
-        }
+        result = std::move(cmp_scalar);
     }
 }
 

--- a/bodo/pandas/physical/gpu_reduce.cpp
+++ b/bodo/pandas/physical/gpu_reduce.cpp
@@ -46,8 +46,9 @@ std::shared_ptr<arrow::Scalar> make_numeric_reduction_identity(
     } else if (op_name == "greater") {
         value = std::numeric_limits<CType>::min();
     } else if (op_name == "first") {
-        return arrow::MakeNullScalar(
-            arrow::TypeTraits<ArrowType>::type_singleton());
+        // For first/any_value, the identity value is not used in practice,
+        // but we still need to provide a valid value.
+        value = CType{0};
     } else {
         throw std::runtime_error("Unsupported reduction function: " + op_name);
     }
@@ -66,6 +67,8 @@ std::shared_ptr<arrow::Scalar> make_numeric_reduction_identity(
  */
 std::shared_ptr<arrow::Scalar> make_reduction_identity(
     std::string op_name, const std::shared_ptr<arrow::DataType>& type) {
+    // Complete list of types currently supported by GPU reductions (see
+    // cudf_dtype_to_mpi)
     switch (type->id()) {
         case arrow::Type::INT8:
             return make_numeric_reduction_identity<arrow::Int8Type>(op_name);
@@ -313,7 +316,6 @@ OperatorResult PhysicalGPUReduce::ConsumeBatchGPU(
                         input_col_idx,
                         this->out_schema->column_types[i]->ToArrowDataType(),
                         se->stream));
-
             } else if (func_name == "min") {
                 reduction_functions.push_back(
                     std::make_unique<GPUReductionFunctionMin>(
@@ -345,6 +347,12 @@ OperatorResult PhysicalGPUReduce::ConsumeBatchGPU(
                         this->out_schema->column_types[i]->ToArrowDataType(),
                         se->stream));
 
+            } else if (func_name == "first") {
+                reduction_functions.push_back(
+                    std::make_unique<GPUReductionFunctionFirst>(
+                        input_col_idx,
+                        this->out_schema->column_types[i]->ToArrowDataType(),
+                        se->stream));
             } else {
                 throw std::runtime_error("Unsupported reduction function: " +
                                          func_name);

--- a/bodo/pandas/physical/gpu_reduce.cpp
+++ b/bodo/pandas/physical/gpu_reduce.cpp
@@ -223,25 +223,28 @@ void GPUReductionFunction::Finalize(MPI_Comm comm) {
         std::unique_ptr<cudf::scalar>& result = this->results[i];
 
         std::shared_ptr<arrow::Table> arrow_table;
-        cudf::data_type result_dtype = result->type();
+
         bool has_data = (result != nullptr && result->is_valid());
-
-        bool global_has_data = false;
-
+        // Check that at least one rank has non-empty, non-null data. We need to
+        // get a rank with non-empty data for first/any_value.
+        int rank, first_non_null_rank;
+        MPI_Comm_rank(comm, &rank);
+        int null_rank = std::numeric_limits<int>::max();
+        int candidate = has_data ? rank : null_rank;
         CHECK_MPI(
-            MPI_Allreduce(&has_data, &global_has_data, 1, MPI_C_BOOL, MPI_LOR,
+            MPI_Allreduce(&candidate, &first_non_null_rank, 1, MPI_INT, MPI_MIN,
                           comm),
             "GPUReductionFunction::Finalize: MPI error on MPI_Allreduce:");
-        if (!global_has_data) {
+        if (first_non_null_rank == null_rank) {
+            // All ranks either have null data or are empty, emit null.
             continue;
         }
 
         if (has_data) {
             arrow_table = cudf_scalar_to_arrow_table(result);
         } else {
-            auto arrow_dtype = cudf_to_arrow_type(result_dtype);
-            std::shared_ptr<arrow::Scalar> scalar =
-                make_reduction_identity(reduction_names[i], arrow_dtype);
+            std::shared_ptr<arrow::Scalar> scalar = make_reduction_identity(
+                reduction_names[i], cudf_to_arrow_type(out_dtype));
             auto array = arrow::MakeArrayFromScalar(*scalar, 1).ValueOrDie();
             arrow_table =
                 arrow::Table::FromRecordBatches(
@@ -256,11 +259,11 @@ void GPUReductionFunction::Finalize(MPI_Comm comm) {
         void* result_ptr = reinterpret_cast<void*>(
             arrow_table->column(0)->chunk(0)->data()->buffers[1]->address());
 
-        MPI_Datatype mpi_dtype = cudf_dtype_to_mpi(result_dtype);
+        MPI_Datatype mpi_dtype = cudf_dtype_to_mpi(out_dtype);
         // NOTE: OpenMPI collectives are not CUDA-aware
         if (function_names[i] == "first") {
             CHECK_MPI(
-                MPI_Bcast(result_ptr, 1, mpi_dtype, 0, comm),
+                MPI_Bcast(result_ptr, 1, mpi_dtype, first_non_null_rank, comm),
                 "GPUReductionFunction::Finalize: MPI error on MPI_Bcast:");
         } else {
             CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, result_ptr, 1, mpi_dtype,

--- a/bodo/pandas/physical/gpu_reduce.cpp
+++ b/bodo/pandas/physical/gpu_reduce.cpp
@@ -228,8 +228,9 @@ void GPUReductionFunction::Finalize(MPI_Comm comm) {
         std::shared_ptr<arrow::Table> arrow_table;
 
         bool has_data = (result != nullptr && result->is_valid());
-        // Check that at least one rank has non-empty, non-null data. We need to
-        // get a rank with non-empty data for first/any_value.
+        // Check that at least one rank has non-empty, non-null data. We acquire
+        // a rank with non-empty data for first/any_value to avoid returning
+        // null when rank 0 is empty and other ranks have non-null data.
         int rank, first_non_null_rank;
         MPI_Comm_rank(comm, &rank);
         int null_rank = std::numeric_limits<int>::max();

--- a/bodo/pandas/physical/gpu_reduce.h
+++ b/bodo/pandas/physical/gpu_reduce.h
@@ -36,11 +36,6 @@ inline bool gpu_capable_reduce(duckdb::LogicalAggregate& logical_aggregate) {
     return true;
 }
 
-enum class GPUReductionType {
-    COMPARISON,
-    AGGREGATION,
-};
-
 struct PhysicalGPUReduceMetrics {
     using stat_t = MetricBase::StatValue;
     using time_t = MetricBase::TimerValue;
@@ -54,25 +49,21 @@ struct GPUReductionFunction {
     int input_col_idx;
     std::vector<std::string> function_names;
     std::vector<std::string> reduction_names;
-    std::vector<GPUReductionType> reduction_types;
     std::vector<std::unique_ptr<cudf::scalar>> results;
     cudf::data_type out_dtype;
     MPI_Op mpi_reduce_op;
     GPUReductionFunction(
         int input_col_idx, std::vector<std::string> function_names,
         std::vector<std::string> reduction_names,
-        std::vector<GPUReductionType> reduction_types,
         std::vector<std::unique_ptr<cudf::scalar>> initial_results,
         std::shared_ptr<arrow::DataType> dt, MPI_Op mpi_reduce_op)
         : input_col_idx(input_col_idx),
           function_names(std::move(function_names)),
           reduction_names(std::move(reduction_names)),
-          reduction_types(std::move(reduction_types)),
           results(std::move(initial_results)),
           out_dtype(arrow_to_cudf_type(dt)),
           mpi_reduce_op(mpi_reduce_op) {
         assert(this->function_names.size() == this->reduction_names.size());
-        assert(this->function_names.size() == this->reduction_types.size());
         assert(this->function_names.size() == this->results.size());
         assert(!this->function_names.empty());
     }
@@ -114,7 +105,6 @@ struct GPUReductionFunctionMax : public GPUReductionFunction {
                             std::shared_ptr<arrow::DataType> dt,
                             rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(input_col_idx, {"max"}, {"greater"},
-                               {GPUReductionType::COMPARISON},
                                make_vector_of_one_nullptr(), dt, MPI_MAX) {}
 };
 
@@ -134,7 +124,6 @@ struct GPUReductionFunctionMin : public GPUReductionFunction {
                             std::shared_ptr<arrow::DataType> dt,
                             rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(input_col_idx, {"min"}, {"less"},
-                               {GPUReductionType::COMPARISON},
                                make_vector_of_one_nullptr(), dt, MPI_MIN) {}
 };
 
@@ -143,7 +132,7 @@ struct GPUReductionFunctionSum : public GPUReductionFunction {
                             std::shared_ptr<arrow::DataType> dt,
                             rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(
-              input_col_idx, {"sum"}, {"add"}, {GPUReductionType::AGGREGATION},
+              input_col_idx, {"sum"}, {"add"},
               make_vector_of_cudf_scalar(arrow_scalar_to_cudf(
                   use_sql_rules ? arrow::MakeNullScalar(dt)
                                 : arrow::MakeScalar(dt, 0).ValueOrDie(),
@@ -157,7 +146,6 @@ struct GPUReductionFunctionProduct : public GPUReductionFunction {
                                 rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(
               input_col_idx, {"product"}, {"multiply"},
-              {GPUReductionType::AGGREGATION},
               make_vector_of_cudf_scalar(arrow_scalar_to_cudf(
                   use_sql_rules ? arrow::MakeNullScalar(dt)
                                 : arrow::MakeScalar(dt, 1).ValueOrDie(),
@@ -171,7 +159,6 @@ struct GPUReductionFunctionCount : public GPUReductionFunction {
                               rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(
               input_col_idx, {"count"}, {"add"},
-              {GPUReductionType::AGGREGATION},
               make_vector_of_cudf_scalar(arrow_scalar_to_cudf(
                   arrow::MakeScalar(dt, 0).ValueOrDie(), output_stream)),
               dt, MPI_SUM) {}
@@ -183,7 +170,6 @@ struct GPUReductionFunctionMean : public GPUReductionFunction {
                              rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(
               input_col_idx, {"sum", "count"}, {"add", "add"},
-              {GPUReductionType::AGGREGATION, GPUReductionType::AGGREGATION},
               make_vector_of_two_cudf_scalars(
                   arrow_scalar_to_cudf(arrow::MakeScalar(dt, 0).ValueOrDie(),
                                        output_stream),

--- a/bodo/pandas/physical/gpu_reduce.h
+++ b/bodo/pandas/physical/gpu_reduce.h
@@ -29,7 +29,8 @@ inline bool gpu_capable_reduce(duckdb::LogicalAggregate& logical_aggregate) {
             agg_expr.function.name != "product" &&
             agg_expr.function.name != "count" &&
             agg_expr.function.name != "mean" &&
-            agg_expr.function.name != "count_star") {
+            agg_expr.function.name != "count_star" &&
+            agg_expr.function.name != "first") {
             return false;
         }
     }

--- a/bodo/pandas/physical/gpu_reduce.h
+++ b/bodo/pandas/physical/gpu_reduce.h
@@ -113,7 +113,6 @@ struct GPUReductionFunctionFirst : public GPUReductionFunction {
                               std::shared_ptr<arrow::DataType> dt,
                               rmm::cuda_stream_view& output_stream)
         : GPUReductionFunction(input_col_idx, {"first"}, {"first"},
-                               {GPUReductionType::COMPARISON},
                                make_vector_of_one_nullptr(), dt,
                                MPI_OP_NULL /* handled specially in Finalize*/) {
     }

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -4851,6 +4851,20 @@ def test_merge_empty_build(join_strategy):
     )
 
 
+@pytest.mark.gpu
+def test_some_null_reduce():
+    """Test that rank 0 having all null values returns the correct answer"""
+
+    pass
+
+
+@pytest.mark.gpu
+def test_all_null_reduce():
+    """Test that all ranks having all null values returns the correct answer"""
+
+    pass
+
+
 def test_df_copy(datapath):
     """Test that dataframe copy on an unexecuted plan behaves as expected."""
 

--- a/bodo/tests/test_df_lib/test_end_to_end.py
+++ b/bodo/tests/test_df_lib/test_end_to_end.py
@@ -4852,17 +4852,28 @@ def test_merge_empty_build(join_strategy):
 
 
 @pytest.mark.gpu
-def test_some_null_reduce():
-    """Test that rank 0 having all null values returns the correct answer"""
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param([None, None, None, None, 1], id="some_null"),
+        pytest.param(pd.array([pd.NA] * 5, dtype="Int32"), id="all_null"),
+    ],
+)
+def test_null_reduce(data):
+    """Test reduction with all null values on some or all ranks"""
 
-    pass
+    df1 = pd.DataFrame({"A": data})
+    df2 = df1.A.min()
 
+    with assert_executed_plan_count(0):
+        bodo_df1 = bd.from_pandas(df1)
+        bodo_df2 = bodo_df1.A.min()
 
-@pytest.mark.gpu
-def test_all_null_reduce():
-    """Test that all ranks having all null values returns the correct answer"""
-
-    pass
+    _test_equal(
+        bodo_df2,
+        df2,
+        check_pandas_types=False,
+    )
 
 
 def test_df_copy(datapath):


### PR DESCRIPTION
## Changes included in this PR

Enable SQL ANY_VALUE on GPU and address 2 issues with null/empty data in GPU reduce:
1. When using SQL rules, Null values were being treated as regular values in the MPI reduce
2. If Rank 0 had empty data, it was excluded from the MPI reduce

The first issue is addressed by using an identity value for ranks containing Null (in addition to an extra all reduce to determine if any rank has valid data)

The second issue is addressed by having all ranks participate in the computation. For FIRST/ANY_VALUE, the first rank with non-empty data sends it's result to rank 0. 

## Testing strategy

New tests added, TPCH Q17,Q19 enabled for SQL on GPU. 

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

`SELECT ANY_VALUE(x) FROM T` Now runs on GPU

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.