### PR TITLE
Support SUBSTRING_INDEX and SPLIT_PART in BodoSQL C++ backend

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -3879,6 +3879,201 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             return ArrowScalarFuncExpression(
                 uint64_empty_data, [is_bit_set, one_expr, zero_expr], "if_else", ()
             )
+        elif func_name == "FORMAT" and len(op_exprs) == 2:
+            """
+            Returns a formatted string representation of a number.
+            The number is rounded to the specified precision and printed
+            with enough zeros to demonstrate that precision.
+            Commas are also inserted as thousands separators.
+            """
+
+            src = op_exprs[0]
+            ensure_type_of_expr(src, "src", (int, float))
+
+            precision_digits = op_exprs[1]
+            ensure_type_of_expr(precision_digits, "precision_digits", int)
+
+            # MySQL treats any precision digits < 0 as 0
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            zero_expr = ConstantExpression(int_empty_data, input_plan, 0)
+            precision_digits = ArrowScalarFuncExpression(
+                int_empty_data,
+                [precision_digits, zero_expr],
+                "max_element_wise",
+                (False,),
+            )
+
+            # Round the number to the specified precision
+            rounded = ArithOpExpression(src.empty_data, src, precision_digits, "round")
+
+            # Get the string representation of the number
+            str_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.string()))
+            rounded_str = CastExpression(str_empty_data, rounded)
+
+            # Get the character index of the decimal point in the string. Returns -1 if not found.
+            decimal_point_pos = ArrowScalarFuncExpression(
+                int_empty_data, [rounded_str], "find_substring", (".",)
+            )
+            # Get full character length of string
+            rounded_str_length = ArrowScalarFuncExpression(
+                int_empty_data, [rounded_str], "utf8_length", ()
+            )
+
+            # Get whether the number has a nonzero fractional component
+            negative_one_expr = ConstantExpression(int_empty_data, input_plan, -1)
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            has_no_dot = ComparisonOpExpression(
+                bool_empty_data, decimal_point_pos, negative_one_expr, operator.eq
+            )
+
+            # First, we will deal with inserting commas to separate thousands in the integer part.
+
+            # Slice to obtain the integer part of the number.
+            is_negative = ArrowScalarFuncExpression(
+                bool_empty_data, [rounded_str], "match_substring", ("-",)
+            )
+            one_expr = ConstantExpression(int_empty_data, input_plan, 1)
+            start_index = CaseExpression(
+                int_empty_data, is_negative, one_expr, zero_expr
+            )
+            end_index = CaseExpression(
+                int_empty_data, has_no_dot, rounded_str_length, decimal_point_pos
+            )
+            integer_part = ArrowScalarFuncExpression(
+                str_empty_data,
+                [rounded_str, start_index, end_index],
+                "utf8_slice_codeunits",
+                (),
+            )
+
+            # Figure out how many characters (spaces) we should add to the left side to make the length
+            # of the integer part a multiple of 3 (so we can insert commas in the right places).
+            # Note that if the length is already a multiple of 3, we end up adding 3 spaces anyway,
+            # but it doesn't matter since we'll trim them off.
+            integer_part_len = ArrowScalarFuncExpression(
+                int_empty_data, [integer_part], "utf8_length", ()
+            )
+            three_expr = ConstantExpression(int_empty_data, input_plan, 3)
+            len_mod_3 = ArithOpExpression(
+                int_empty_data, integer_part_len, three_expr, "__mod__"
+            )
+            num_to_offset = ArithOpExpression(
+                int_empty_data, three_expr, len_mod_3, "__sub__"
+            )
+
+            # Get space characters of the desired length to offset
+            space_str = ConstantExpression(str_empty_data, input_plan, " ")
+            space_offset_str = ArrowScalarFuncExpression(
+                str_empty_data, [space_str, num_to_offset], "binary_repeat", ()
+            )
+            separator = ConstantExpression(str_empty_data, input_plan, "")
+            offset_integer_part = ArrowScalarFuncExpression(
+                str_empty_data,
+                [space_offset_str, integer_part, separator],
+                "binary_join_element_wise",
+                (),
+            )
+
+            # Use regex to add commas every three digits (or spaces)
+            integer_part_with_commas = ArrowScalarFuncExpression(
+                str_empty_data,
+                [offset_integer_part],
+                "replace_substring_regex",
+                (r"([0-9 ]{3})", r"\1,"),
+            )
+            # Clean up result by trimming off spaces and commas
+            integer_part_with_commas = ArrowScalarFuncExpression(
+                str_empty_data, [integer_part_with_commas], "utf8_trim", (" ,",)
+            )
+
+            # Add back the negative sign if needed
+            negative_sign_expr = ConstantExpression(str_empty_data, input_plan, "-")
+            negative_comma_integer_part = ArrowScalarFuncExpression(
+                str_empty_data,
+                [negative_sign_expr, integer_part_with_commas, separator],
+                "binary_join_element_wise",
+                (),
+            )
+            integer_part_with_commas = CaseExpression(
+                str_empty_data,
+                is_negative,
+                negative_comma_integer_part,
+                integer_part_with_commas,
+            )
+
+            # Combine the integer and fractional part to get the number with proper comma-formatting
+            fractional_part = ArrowScalarFuncExpression(
+                str_empty_data,
+                [rounded_str, decimal_point_pos],
+                "bodo_substr_three",
+                (),
+            )
+            num_with_commas = ArrowScalarFuncExpression(
+                str_empty_data,
+                [integer_part_with_commas, fractional_part, separator],
+                "binary_join_element_wise",
+                (),
+            )
+            num_with_commas = CaseExpression(
+                str_empty_data, has_no_dot, integer_part_with_commas, num_with_commas
+            )
+
+            # Now we need to make sure that the formatted number has enough decimal digits.
+
+            # Calculate length of the fractional part of the number
+            frac_length = ArithOpExpression(
+                int_empty_data, rounded_str_length, decimal_point_pos, "__sub__"
+            )
+            # Subtract 1 to exclude the decimal point itself from the fractional length
+            frac_length = ArithOpExpression(
+                int_empty_data, frac_length, one_expr, "__sub__"
+            )
+            # The fractional length is simply 0 if the string form of the number has no decimal point
+            frac_length = CaseExpression(
+                int_empty_data, has_no_dot, zero_expr, frac_length
+            )
+
+            # Calculate the number of zeros we need to add so there are precision_digits decimal places.
+            # Note that due to the round, it's impossible for the string form of the number to have more than precision_digits decimal places.
+            # It could have fewer than precision_digits decimal places if it had fewer than that many to start with.
+            num_missing_zeros = ArithOpExpression(
+                int_empty_data, precision_digits, frac_length, "__sub__"
+            )
+            zero_str = ConstantExpression(str_empty_data, input_plan, "0")
+            extra_zeros_str = ArrowScalarFuncExpression(
+                str_empty_data, [zero_str, num_missing_zeros], "binary_repeat", ()
+            )
+
+            # Ensure we add a dot before the extra zeros if the number doesn't have a decimal point
+            dot_expr = ConstantExpression(str_empty_data, input_plan, ".")
+            dot_and_extra_zeros = ArrowScalarFuncExpression(
+                str_empty_data,
+                [dot_expr, extra_zeros_str, separator],
+                "binary_join_element_wise",
+                (),
+            )
+            padding = CaseExpression(
+                str_empty_data, has_no_dot, dot_and_extra_zeros, extra_zeros_str
+            )
+
+            # Append extra zeros
+            num_padded = ArrowScalarFuncExpression(
+                str_empty_data,
+                [num_with_commas, padding, separator],
+                "binary_join_element_wise",
+                (),
+            )
+
+            # If precision_digits is 0, the initial round and cast to string removes the decimal point even for float input.
+            # Therefore, we can just use the string form directly in that case, no need to worry about removing decimal
+            # points from the string.
+            zero_precision_digits = ComparisonOpExpression(
+                bool_empty_data, precision_digits, zero_expr, operator.eq
+            )
+            return CaseExpression(
+                str_empty_data, zero_precision_digits, rounded_str, num_padded
+            )
+
         elif func_name == "LEFT" and len(op_exprs) == 2:
             # Implement LEFT as substr(0,...)
             src = op_exprs[0]
@@ -4020,6 +4215,33 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 [src],
                 "utf8_length",
                 (),
+            )
+        elif func_name == "STRCMP" and len(op_exprs) == 2:
+            str1_expr = op_exprs[0]
+            str2_expr = op_exprs[1]
+            ensure_type_of_expr(str1_expr, "str1_expr", (str, pa.binary()))
+            ensure_type_of_expr(str2_expr, "str2_expr", (str, pa.binary()))
+
+            bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
+            str1_greater = ComparisonOpExpression(
+                bool_empty_data, str1_expr, str2_expr, operator.gt
+            )
+            strings_equal = ComparisonOpExpression(
+                bool_empty_data, str1_expr, str2_expr, operator.eq
+            )
+
+            # Using lexicographical comparison, return 1 if str1 > str2, -1 if str1 < str2, 0 if str1 == str2.
+            int_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.int64()))
+            one_expr = ConstantExpression(int_empty_data, input_plan, 1)
+            zero_expr = ConstantExpression(int_empty_data, input_plan, 0)
+            negative_one_expr = ConstantExpression(int_empty_data, input_plan, -1)
+            return CaseExpression(
+                int_empty_data,
+                strings_equal,
+                zero_expr,
+                CaseExpression(
+                    int_empty_data, str1_greater, one_expr, negative_one_expr
+                ),
             )
         elif func_name in ("INSTR", "CHARINDEX") and len(op_exprs) in (2, 3):
             if func_name == "INSTR":

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -4512,7 +4512,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             )
             ensure_arg_is_const_expr_of_type(count_expr, "count_expr", int)
 
-            # Implementation involves splitting, so easiest to do it on the C++ side
+            # Implementation involves fixed_size_list results, so easier
+            # to do it on the C++ side.
             return ArrowScalarFuncExpression(
                 src.empty_data,
                 [src],
@@ -4535,7 +4536,8 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             # part_num is 1-based.
             part_num = part_num_expr.value if part_num_expr.value != 0 else 1
 
-            # Implementation involves splitting, so easiest to do it on the C++ side
+            # Implementation involves fixed_size_list results, so easier
+            # to do it on the C++ side.
             return ArrowScalarFuncExpression(
                 src.empty_data,
                 [src],

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -4501,6 +4501,25 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 new_index,
             )
 
+        elif func_name == "SUBSTRING_INDEX" and len(op_exprs) == 3:
+            src = op_exprs[0]
+            delim_expr = op_exprs[1]
+            count_expr = op_exprs[2]
+
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(
+                delim_expr, "delim_expr", (str, pa.binary())
+            )
+            ensure_arg_is_const_expr_of_type(count_expr, "count_expr", int)
+
+            # Implementation involves splitting, so easiest to do it on the C++ side
+            return ArrowScalarFuncExpression(
+                src.empty_data,
+                [src],
+                "substring_index",
+                (delim_expr.value, count_expr.value),
+            )
+
         elif func_name == "REGEXP_REPLACE" and len(op_exprs) in (2, 3, 4, 5, 6):
             src = op_exprs[0]
             regexp = op_exprs[1]

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -4520,6 +4520,29 @@ def java_call_to_python_call(ctx, java_call, input_plan):
                 (delim_expr.value, count_expr.value),
             )
 
+        elif func_name == "SPLIT_PART" and len(op_exprs) == 3:
+            src = op_exprs[0]
+            delim_expr = op_exprs[1]
+            part_num_expr = op_exprs[2]
+
+            ensure_type_of_expr(src, "src", (str, pa.binary()))
+            ensure_arg_is_const_expr_of_type(
+                delim_expr, "delim_expr", (str, pa.binary())
+            )
+            ensure_arg_is_const_expr_of_type(part_num_expr, "part_num_expr", int)
+
+            # Snowflake treats a part number of 0 the same as 1.
+            # part_num is 1-based.
+            part_num = part_num_expr.value if part_num_expr.value != 0 else 1
+
+            # Implementation involves splitting, so easiest to do it on the C++ side
+            return ArrowScalarFuncExpression(
+                src.empty_data,
+                [src],
+                "split_part",
+                (delim_expr.value, part_num),
+            )
+
         elif func_name == "REGEXP_REPLACE" and len(op_exprs) in (2, 3, 4, 5, 6):
             src = op_exprs[0]
             regexp = op_exprs[1]

--- a/BodoSQL/bodosql/tests/test_string_ops_first_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_first_half.py
@@ -739,16 +739,17 @@ def test_editdistance(query, memory_leak_check):
         pytest.param(
             "SELECT SPLIT_PART(A, ' ', 1) FROM table1",
             id="vector_space_1",
+            marks=pytest.mark.bodosql_cpp,
         ),
         pytest.param(
             "SELECT SPLIT_PART(A, 'a', 2) FROM table1",
             id="vector_a_2",
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
         pytest.param(
             "SELECT SPLIT_PART(A, '  ', -1) FROM table1",
             id="vector_doublespace_-1",
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
         pytest.param(
             "SELECT SPLIT_PART(A, RIGHT(A, 1), 1 + (LENGTH(A) % 6)) FROM table1",
@@ -758,6 +759,7 @@ def test_editdistance(query, memory_leak_check):
         pytest.param(
             "SELECT CASE WHEN INSTR(A, '  ') > 0 THEN SPLIT_PART(A, '  ', 3) ELSE SPLIT_PART(A, 'e', -2) END FROM table1",
             id="case",
+            marks=pytest.mark.bodosql_cpp,
         ),
     ],
 )

--- a/BodoSQL/bodosql/tests/test_string_ops_second_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_second_half.py
@@ -536,6 +536,7 @@ def test_string_fns_scalar_vector_case(
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "args",
     [
@@ -643,6 +644,7 @@ def test_rtrimmed_length(query, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "args",
     [
@@ -687,6 +689,7 @@ def test_strcmp_nonascii(args, memory_leak_check):
     )
 
 
+@pytest.mark.bodosql_cpp
 @pytest.mark.parametrize(
     "args",
     [

--- a/BodoSQL/bodosql/tests/test_string_ops_second_half.py
+++ b/BodoSQL/bodosql/tests/test_string_ops_second_half.py
@@ -776,12 +776,12 @@ def test_format(args, bodosql_string_fn_testing_df, memory_leak_check):
         pytest.param(
             "SELECT SUBSTRING_INDEX(source, 'a', occur) from table1",
             id="SUBSTRING_INDEX_scalar_str",
-            marks=(pytest.mark.slow,),
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             "SELECT SUBSTRING_INDEX(source, ' ', 2) from table1",
             id="SUBSTRING_INDEX_scalar_str_scalar_int",
-            marks=(pytest.mark.slow,),
+            marks=[pytest.mark.slow, pytest.mark.bodosql_cpp],
         ),
         pytest.param(
             "SELECT SUBSTRING_INDEX(source, delim, 3) from table1",
@@ -790,6 +790,7 @@ def test_format(args, bodosql_string_fn_testing_df, memory_leak_check):
         pytest.param(
             "SELECT SUBSTRING_INDEX('alpha,beta,gamma,delta,epsilon', ',', 3) from table1",
             id="SUBSTRING_INDEX_all_scalar",
+            marks=pytest.mark.bodosql_cpp,
         ),
     ],
 )

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -1200,11 +1200,18 @@ std::shared_ptr<ExprResult> PhysicalArrowExpression::ProcessBatch(
         // Special handling for multi-input Arrow functions with options
         if (scalar_func_data.arrow_func_name == "max_element_wise" ||
             scalar_func_data.arrow_func_name == "min_element_wise") {
-            auto [skip_nulls] = get_py_args_as_types(
-                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
-                get_py_object_as_bool);
+            arrow::compute::ElementWiseAggregateOptions opts;
 
-            arrow::compute::ElementWiseAggregateOptions opts(skip_nulls);
+            assert_py_args_is_tuple(scalar_func_data.args,
+                                    scalar_func_data.arrow_func_name.c_str());
+            if (PyTuple_Size(scalar_func_data.args) > 1) {
+                auto [skip_nulls] = get_py_args_as_types(
+                    scalar_func_data.args,
+                    scalar_func_data.arrow_func_name.c_str(),
+                    get_py_object_as_bool);
+                opts.skip_nulls = skip_nulls;
+            }
+
             result = do_arrow_compute_multi_input(
                 in_expr_results, scalar_func_data.arrow_func_name, &opts);
         } else {

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -129,7 +129,8 @@ std::shared_ptr<arrow::Array> NullArrowArray(bool value, size_t num_elements) {
 
 arrow::Datum do_arrow_compute_multi_input_datum(
     const std::vector<std::shared_ptr<ExprResult>>& in_expr_results,
-    const std::string& arrow_func_name) {
+    const std::string& arrow_func_name,
+    const arrow::compute::FunctionOptions* func_options) {
     std::vector<arrow::Datum> arg_datums;
     for (auto& expr_res : in_expr_results) {
         arrow::Datum arg_datum = ConvertExprResultToDatum(
@@ -554,9 +555,10 @@ arrow::Datum do_arrow_compute_multi_input_datum(
 
 std::shared_ptr<array_info> do_arrow_compute_multi_input(
     const std::vector<std::shared_ptr<ExprResult>>& in_expr_results,
-    const std::string& arrow_func_name) {
-    arrow::Datum result_datum =
-        do_arrow_compute_multi_input_datum(in_expr_results, arrow_func_name);
+    const std::string& arrow_func_name,
+    const arrow::compute::FunctionOptions* func_options) {
+    arrow::Datum result_datum = do_arrow_compute_multi_input_datum(
+        in_expr_results, arrow_func_name, func_options);
     return ConvertDatumToArrayInfo(result_datum);
 }
 
@@ -1192,9 +1194,24 @@ std::shared_ptr<ExprResult> PhysicalArrowExpression::ProcessBatch(
         for (const auto& child : children) {
             in_expr_results.emplace_back(child->ProcessBatch(input_batch));
         }
+
         time_pt start_init_time = start_timer();
-        result = do_arrow_compute_multi_input(in_expr_results,
-                                              scalar_func_data.arrow_func_name);
+
+        // Special handling for multi-input Arrow functions with options
+        if (scalar_func_data.arrow_func_name == "max_element_wise" ||
+            scalar_func_data.arrow_func_name == "min_element_wise") {
+            auto [skip_nulls] = get_py_args_as_types(
+                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
+                get_py_object_as_bool);
+
+            arrow::compute::ElementWiseAggregateOptions opts(skip_nulls);
+            result = do_arrow_compute_multi_input(
+                in_expr_results, scalar_func_data.arrow_func_name, &opts);
+        } else {
+            result = do_arrow_compute_multi_input(
+                in_expr_results, scalar_func_data.arrow_func_name);
+        }
+
         this->metrics.arrow_compute_time += end_timer(start_init_time);
     } else {
         std::shared_ptr<ExprResult> res =

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -2455,7 +2455,7 @@ arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
  * @brief Occurrences of `delim_str` divide the input string `res_datum`
  * into parts. SPLIT_PART returns the substring corresponding to a part
  * number, where 1 is the first part. If the part number is negative,
- * the counting happens frome left to right. If `delim_str` is empty,
+ * the counting happens from the right. If `delim_str` is empty,
  * `res_datum` is returned as is. If there are fewer than abs(part_num)
  * parts in the string, an empty string is emitted.
  */

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -2284,6 +2284,141 @@ arrow::Datum do_arrow_compute_replace_substring_regex_single(
     return final_replaced_string;
 }
 
+/**
+ * @brief If `count` == 0, returns empty string. If `count` > 0, returns the
+ * substring that is left of the `count`-th occurrence of `delim_str` in
+ * `res_datum`. If `count` < 0, returns the substring that is right of the
+ * abs(count)-th ocurrence of `delim_str` in `res_datum`. If abs(count) is
+ * higher than the number of occurrences of `delim_str`, returns the original
+ * string (`res_datum`).
+ */
+arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
+                                              std::string delim_str,
+                                              int count) {
+    // Return empty string if count is 0
+    if (count == 0) {
+        auto empty_string_scalar =
+            (res_datum.type()->id() == arrow::Type::LARGE_STRING)
+                ? std::static_pointer_cast<arrow::Scalar>(
+                      std::make_shared<arrow::LargeStringScalar>(""))
+                : std::static_pointer_cast<arrow::Scalar>(
+                      std::make_shared<arrow::StringScalar>(""));
+        auto empty_string_arr = ScalarToArrowArray(
+            empty_string_scalar, res_datum.make_array()->length());
+        return arrow::Datum(empty_string_arr);
+    }
+
+    int count_abs = std::abs(count);
+
+    // Split the string on the delimiter count_abs times. The sign of `count`
+    // controls the direction we search for `count_abs` delimiter occurrences.
+    arrow::compute::SplitPatternOptions split_opts{delim_str, count_abs,
+                                                   count < 0};
+    // split_string is a ListArray. If `count` is positive, the last element of
+    // each list is the part of the string we DON'T want to return. If `count`
+    // is negative, it is the first element of each list we don't want to
+    // return. Of course, if the string has more than `count_abs` occurrences of
+    // the delimiter, we should return the full string.
+    arrow::Datum split_string =
+        do_arrow_compute_unary(res_datum, "split_pattern", &split_opts);
+
+    // In theory, here we could try to slice the lists to keep only the elements
+    // we want (all but the first or all but the last) and then rejoin them with
+    // the original delimiter. However, there are some annoyances:
+    //   - Slice indices must be constants and cannot be negative.
+    //   - Slicing throws an error if one of the lists does not have the right
+    //   number of elements,
+    //      unless you pass return_fixed_size_list = true which fills with
+    //      nulls.
+    //   - There is no binary_join kernel for fixed_size_list. It also emits
+    //   null if any
+    //     element in the list is null, with no null_handling option like
+    //     binary_join_element_wise has.
+
+    // Therefore, we instead extract the part of the string we DON'T want to
+    // keep and determine its length and start position so we can use
+    // bodo_substr_three to slice it off, leaving us with the substring to the
+    // left of the (count_abs)-th delimiter occurrence from the left or the
+    // substring to the right of the (count_abs)-th delimiter occurrence from
+    // the right.
+
+    // Get the first or the (count_abs + 1)-th list element from the
+    // split_string. We can't use list_element directly, because the lists in
+    // the ListArray could have different lengths depending on the number of
+    // delimiter occurrences in the string, and list_element raises an error
+    // instead of returning NULL in that case. Therefore, we first get a slice
+    // containing only the first or the (count_abs + 1)-th element with the
+    // return_fixed_size_list option set to true, which substitutes NULL when
+    // the original list has no element corresponding to a particular index.
+    arrow::compute::ListSliceOptions list_slice_opts;
+    if (count > 0) {
+        // Get the part of the string we would want to throw away if the string
+        // has at least count_abs delimiters. (In this case, the last element,
+        // since we want the substring to the left)
+        list_slice_opts.start = count_abs;
+        list_slice_opts.stop = count_abs + 1;
+    } else {
+        // Get the part of the string we would want to throw away if the string
+        // has at least count_abs delimiters. (In this case, the first element,
+        // since we want the substring to the right)
+        list_slice_opts.start = 0;
+        list_slice_opts.stop = 1;
+    }
+    list_slice_opts.return_fixed_size_list = true;
+    arrow::Datum element_to_remove_list =
+        do_arrow_compute_unary(split_string, "list_slice", &list_slice_opts);
+
+    // Get the singular list element from our list slice.
+    // If there are fewer than `count_abs` occurrences of the delimiter,
+    // this will be NULL if count > 0 but not if count < 0.
+    auto zero_scalar = std::make_shared<arrow::Int64Scalar>(0);
+    arrow::Datum element_to_remove = do_arrow_compute_binary(
+        element_to_remove_list, zero_scalar, "list_element");
+
+    arrow::Datum to_remove_length =
+        do_arrow_compute_unary(element_to_remove, "utf8_length");
+    auto delim_len_scalar =
+        std::make_shared<arrow::Int64Scalar>(delim_str.length());
+
+    // Get the substring result (assuming there were enough delimiter
+    // occurrences)
+    arrow::Datum substring;
+    if (count > 0) {
+        // Substring left of the (count_abs)-th occurrence of delimeter from the
+        // left res_datum[0: len(res_datum) - len(to_remove_part) - len(delim)]
+        arrow::Datum full_length =
+            do_arrow_compute_unary(res_datum, "utf8_length");
+        arrow::Datum to_keep_length =
+            do_arrow_compute_binary(full_length, to_remove_length, "subtract");
+        to_keep_length = do_arrow_compute_binary(to_keep_length,
+                                                 delim_len_scalar, "subtract");
+        substring = do_arrow_compute_multi_input_datum(
+            {res_datum, zero_scalar, to_keep_length}, "bodo_substr_three");
+    } else {
+        // Substring right of the (count_abs)-th occurrence of delimeter from
+        // the right res_datum[len(to_remove_part) + len(delim): ]
+        arrow::Datum start_index =
+            do_arrow_compute_binary(to_remove_length, delim_len_scalar, "add");
+        substring = do_arrow_compute_multi_input_datum({res_datum, start_index},
+                                                       "bodo_substr_three");
+    }
+
+    // To be able to tell whether we should return the full string or not,
+    // we need to get the actual length of the split_string list.
+    // The length of each list is the minimum of `count_abs` + 1 and
+    // number of delimiter occurrences + 1.
+    arrow::Datum list_length =
+        do_arrow_compute_unary(split_string, "list_value_length");
+
+    // Make sure the full string is returned if there are fewer than `count_abs`
+    // occurrences of the delimiter.
+    auto count_abs_scalar = std::make_shared<arrow::Int32Scalar>(count_abs + 1);
+    arrow::Datum return_full_string =
+        do_arrow_compute_binary(list_length, count_abs_scalar, "less");
+    return do_arrow_compute_multi_input_datum(
+        {return_full_string, res_datum, substring}, "if_else");
+}
+
 arrow::Datum do_arrow_compute_dow_num(arrow::Datum res_datum) {
     // We strip off the leading spaces and only look at the first two
     // characters of the input string in accordance with Snowflake (e.g.

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -2295,8 +2295,8 @@ arrow::Datum do_arrow_compute_replace_substring_regex_single(
 arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
                                               std::string delim_str,
                                               int count) {
-    // Return empty string if count is 0
-    if (count == 0) {
+    // Return empty string if count is 0 or delimiter is empty
+    if (count == 0 || delim_str == "") {
         auto empty_string_scalar =
             (res_datum.type()->id() == arrow::Type::LARGE_STRING)
                 ? std::static_pointer_cast<arrow::Scalar>(
@@ -2322,20 +2322,7 @@ arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
     arrow::Datum split_string =
         do_arrow_compute_unary(res_datum, "split_pattern", &split_opts);
 
-    // In theory, here we could try to slice the lists to keep only the elements
-    // we want (all but the first or all but the last) and then rejoin them with
-    // the original delimiter. However, there are some annoyances:
-    //   - Slice indices must be constants and cannot be negative.
-    //   - Slicing throws an error if one of the lists does not have the right
-    //   number of elements,
-    //      unless you pass return_fixed_size_list = true which fills with
-    //      nulls.
-    //   - There is no binary_join kernel for fixed_size_list. It also emits
-    //   null if any
-    //     element in the list is null, with no null_handling option like
-    //     binary_join_element_wise has.
-
-    // Therefore, we instead extract the part of the string we DON'T want to
+    // Our approach here is to extract the part of the string we DON'T want to
     // keep and determine its length and start position so we can use
     // bodo_substr_three to slice it off, leaving us with the substring to the
     // left of the (count_abs)-th delimiter occurrence from the left or the
@@ -2384,7 +2371,7 @@ arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
     // occurrences)
     arrow::Datum substring;
     if (count > 0) {
-        // Substring left of the (count_abs)-th occurrence of delimeter from the
+        // Substring left of the (count_abs)-th occurrence of delimiter from the
         // left res_datum[0: len(res_datum) - len(to_remove_part) - len(delim)]
         arrow::Datum full_length =
             do_arrow_compute_unary(res_datum, "utf8_length");
@@ -2395,7 +2382,7 @@ arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
         substring = do_arrow_compute_multi_input_datum(
             {res_datum, zero_scalar, to_keep_length}, "bodo_substr_three");
     } else {
-        // Substring right of the (count_abs)-th occurrence of delimeter from
+        // Substring right of the (count_abs)-th occurrence of delimiter from
         // the right res_datum[len(to_remove_part) + len(delim): ]
         arrow::Datum start_index =
             do_arrow_compute_binary(to_remove_length, delim_len_scalar, "add");
@@ -2417,6 +2404,100 @@ arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
         do_arrow_compute_binary(list_length, count_abs_scalar, "less");
     return do_arrow_compute_multi_input_datum(
         {return_full_string, res_datum, substring}, "if_else");
+}
+
+/**
+ * @brief Occurrences of `delim_str` divide the input string `res_datum`
+ * into parts. SPLIT_PART returns the substring corresponding to a part
+ * number, where 1 is the first part. If the part number is negative,
+ * the counting happens frome left to right. If `delim_str` is empty,
+ * `res_datum` is returned as is. If there are fewer than abs(part_num)
+ * parts in the string, an empty string is emitted.
+ */
+arrow::Datum do_arrow_compute_split_part(arrow::Datum res_datum,
+                                         std::string delim_str, int part_num) {
+    // Snowflake returns the original string when the delimiter is empty
+    if (delim_str == "") {
+        return res_datum;
+    }
+
+    int part_num_abs = std::abs(part_num);
+
+    // Split the string on the delimiter (part_num_abs) times. The sign of
+    // `part_num` controls the direction we search for (part_num_abs) delimiter
+    // occurrences. It's important than we don't split on all the occurrences of
+    // the delimiter in the string. If we did, a slew of Arrow limitations would
+    // make it much harder to pick the right list element when part_num is
+    // negative. This way, we know the second element is the one we are looking
+    // for.
+    arrow::compute::SplitPatternOptions split_opts{delim_str, part_num_abs,
+                                                   part_num < 0};
+    // split_string is a ListArray
+    arrow::Datum split_string =
+        do_arrow_compute_unary(res_datum, "split_pattern", &split_opts);
+
+    // Get a single-element list of the part we want, with
+    // return_fixed_size_list = true. We need to do this since calling
+    // list_element directly will throw an error if there are fewer than
+    // `part_num` parts in the split string (for positive `part_num`).
+    arrow::compute::ListSliceOptions list_slice_opts;
+    if (part_num > 0) {
+        // part_num is one-based, so part_num - 1 is the index corresponding to
+        // the part
+        list_slice_opts.start = part_num - 1;
+        list_slice_opts.stop = part_num;
+    } else {
+        // When the part number is negative, we count right to left.
+        // We split the string into (at most) part_num_abs + 1 parts, so the
+        // leftmost part is the remaining non-split segment, and the second
+        // part is the requested part.
+        list_slice_opts.start = 1;
+        list_slice_opts.stop = 2;
+    }
+    list_slice_opts.return_fixed_size_list = true;
+    arrow::Datum part_list =
+        do_arrow_compute_unary(split_string, "list_slice", &list_slice_opts);
+
+    // Get the actual string part. May or may not be NULL.
+    // The reliable test for whether the requested part exists
+    // is the length of split_string.
+    auto zero_scalar = std::make_shared<arrow::Int64Scalar>(0);
+    arrow::Datum part =
+        do_arrow_compute_binary(part_list, zero_scalar, "list_element");
+
+    // To be able to tell whether we should return an empty string or not,
+    // we need to get the actual length of the split_string list.
+    // The length of each list is the minimum of `part_num_abs` + 1 and
+    // number of delimiter occurrences + 1.
+    arrow::Datum list_length =
+        do_arrow_compute_unary(split_string, "list_value_length");
+
+    // If there's only one element / part, just use that.
+    // The above code for part_num < 0 assumes two or more parts
+    // (at least one delimiter occurrence).
+    arrow::Datum first_part =
+        do_arrow_compute_binary(split_string, zero_scalar, "list_element");
+    auto one_scalar = std::make_shared<arrow::Int32Scalar>(1);
+    arrow::Datum more_than_one_part =
+        do_arrow_compute_binary(list_length, one_scalar, "greater");
+    part = do_arrow_compute_multi_input_datum(
+        {more_than_one_part, part, first_part}, "if_else");
+
+    // Make sure an empty string is returned if there are fewer than
+    // `part_num_abs` parts.
+    auto part_num_abs_scalar =
+        std::make_shared<arrow::Int32Scalar>(part_num_abs);
+    arrow::Datum return_empty_string =
+        do_arrow_compute_binary(list_length, part_num_abs_scalar, "less");
+
+    auto empty_string_scalar =
+        (res_datum.type()->id() == arrow::Type::LARGE_STRING)
+            ? std::static_pointer_cast<arrow::Scalar>(
+                  std::make_shared<arrow::LargeStringScalar>(""))
+            : std::static_pointer_cast<arrow::Scalar>(
+                  std::make_shared<arrow::StringScalar>(""));
+    return do_arrow_compute_multi_input_datum(
+        {return_empty_string, empty_string_scalar, part}, "if_else");
 }
 
 arrow::Datum do_arrow_compute_dow_num(arrow::Datum res_datum) {

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -200,7 +200,8 @@ extern std::function<bool(int)> less_equal_test;
  */
 arrow::Datum do_arrow_compute_multi_input_datum(
     const std::vector<std::shared_ptr<ExprResult>> &in_expr_results,
-    const std::string &arrow_func_name);
+    const std::string &arrow_func_name,
+    const arrow::compute::FunctionOptions *func_options = nullptr);
 
 /**
  * @brief Perform an Arrow compute operation with multiple input expressions.
@@ -212,7 +213,8 @@ arrow::Datum do_arrow_compute_multi_input_datum(
  */
 std::shared_ptr<array_info> do_arrow_compute_multi_input(
     const std::vector<std::shared_ptr<ExprResult>> &in_expr_results,
-    const std::string &arrow_func_name);
+    const std::string &arrow_func_name,
+    const arrow::compute::FunctionOptions *func_options = nullptr);
 
 /**
  * @brief Convert ExprResult to arrow and run compute operation on it.

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1451,6 +1451,9 @@ arrow::Datum do_arrow_compute_dow_num(arrow::Datum res_datum);
 arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
                                               std::string delim_str, int count);
 
+arrow::Datum do_arrow_compute_split_part(arrow::Datum res_datum,
+                                         std::string delim_str, int part_num);
+
 struct PhysicalArrowExpressionMetrics {
     using timer_t = MetricBase::TimerValue;
     timer_t arrow_compute_time = 0;
@@ -1801,6 +1804,23 @@ class PhysicalArrowExpression : public PhysicalExpression {
                 result = substring_datum;
             } else {
                 result = ConvertDatumToArrayInfo(substring_datum);
+            }
+        } else if (scalar_func_data.arrow_func_name == "split_part") {
+            auto [delimiter, count] = get_py_args_as_types(
+                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
+                get_py_object_as_cstr, get_py_object_as_int64);
+            std::string delim_str(delimiter);
+
+            arrow::Datum res_datum =
+                ConvertExprResultToDatum(res, "split_part string");
+            arrow::Datum part_datum =
+                do_arrow_compute_split_part(res_datum, delim_str, count);
+
+            // Assign to result based on input type
+            if constexpr (std::is_same_v<T, arrow::Datum>) {
+                result = part_datum;
+            } else {
+                result = ConvertDatumToArrayInfo(part_datum);
             }
         } else if (scalar_func_data.arrow_func_name == "utf8_trim" ||
                    scalar_func_data.arrow_func_name == "utf8_ltrim" ||

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1806,7 +1806,7 @@ class PhysicalArrowExpression : public PhysicalExpression {
                 result = ConvertDatumToArrayInfo(substring_datum);
             }
         } else if (scalar_func_data.arrow_func_name == "split_part") {
-            auto [delimiter, count] = get_py_args_as_types(
+            auto [delimiter, part_num] = get_py_args_as_types(
                 scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
                 get_py_object_as_cstr, get_py_object_as_int64);
             std::string delim_str(delimiter);
@@ -1814,7 +1814,7 @@ class PhysicalArrowExpression : public PhysicalExpression {
             arrow::Datum res_datum =
                 ConvertExprResultToDatum(res, "split_part string");
             arrow::Datum part_datum =
-                do_arrow_compute_split_part(res_datum, delim_str, count);
+                do_arrow_compute_split_part(res_datum, delim_str, part_num);
 
             // Assign to result based on input type
             if constexpr (std::is_same_v<T, arrow::Datum>) {

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -1448,6 +1448,9 @@ arrow::Datum do_arrow_compute_replace_substring_regex_single(
 
 arrow::Datum do_arrow_compute_dow_num(arrow::Datum res_datum);
 
+arrow::Datum do_arrow_compute_substring_index(arrow::Datum res_datum,
+                                              std::string delim_str, int count);
+
 struct PhysicalArrowExpressionMetrics {
     using timer_t = MetricBase::TimerValue;
     timer_t arrow_compute_time = 0;
@@ -1781,6 +1784,23 @@ class PhysicalArrowExpression : public PhysicalExpression {
                 result = replaced_string_datum;
             } else {
                 result = ConvertDatumToArrayInfo(replaced_string_datum);
+            }
+        } else if (scalar_func_data.arrow_func_name == "substring_index") {
+            auto [delimiter, count] = get_py_args_as_types(
+                scalar_func_data.args, scalar_func_data.arrow_func_name.c_str(),
+                get_py_object_as_cstr, get_py_object_as_int64);
+            std::string delim_str(delimiter);
+
+            arrow::Datum res_datum =
+                ConvertExprResultToDatum(res, "substring_index string");
+            arrow::Datum substring_datum =
+                do_arrow_compute_substring_index(res_datum, delim_str, count);
+
+            // Assign to result based on input type
+            if constexpr (std::is_same_v<T, arrow::Datum>) {
+                result = substring_datum;
+            } else {
+                result = ConvertDatumToArrayInfo(substring_datum);
             }
         } else if (scalar_func_data.arrow_func_name == "utf8_trim" ||
                    scalar_func_data.arrow_func_name == "utf8_ltrim" ||


### PR DESCRIPTION
## Changes included in this PR

SUBSTRING_INDEX and SPLIT_PART are now supported in the C++ backend.

## Testing strategy

CI

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.