### PR TITLE
Add cast options infrastructure for CastExpression in C++ backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -816,6 +816,15 @@ if (NOT WIN32)
     COMPILE_FLAGS "-Wno-unused-function"
   )
 
+  # plan_optimizer.pyx cimports from pyarrow.lib and the compiler complains
+  # that many of the PyArrow wrap/unwrap functions automatically included
+  # are unused
+  SET_SOURCE_FILES_PROPERTIES(
+    "bodo/pandas/plan_optimizer.cpp"
+    PROPERTIES
+    COMPILE_FLAGS "-Wno-unused-variable"
+  )
+
   target_compile_options(
     ext
     PRIVATE

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1,4 +1,5 @@
 #include "_plan.h"
+#include <arrow/compute/kernel.h>
 #include <arrow/python/pyarrow.h>
 #include <arrow/type.h>
 #include <fmt/format.h>
@@ -47,6 +48,7 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_sample.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
+#include "physical/expression.h"
 
 #include "../libs/gpu_utils.h"
 
@@ -510,7 +512,8 @@ static duckdb::BoundCastInfo BindCastFunction(
 }
 
 std::unique_ptr<duckdb::Expression> make_cast_expr(
-    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py) {
+    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
+    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts) {
     // Convert std::unique_ptr to duckdb::unique_ptr.
     auto source_duck = to_duckdb(source);
     std::shared_ptr<arrow::Schema> out_schema = unwrap_schema(out_schema_py);
@@ -523,9 +526,11 @@ std::unique_ptr<duckdb::Expression> make_cast_expr(
     auto res = duckdb::make_uniq<duckdb::BoundCastExpression>(
         std::move(source_duck), out_type,
         BindCastFunction(source_duck->return_type, out_type));
-    // Store the Arrow type in the cast info to have full type information (e.g.
+
+    // Store the Arrow cast options in the cast info. This also helps
+    // track the original Arrow type to have full type information (e.g.
     // interval precision).
-    res->bound_cast.arrow_type = field->type();
+    res->bound_cast.arrow_cast_opts = cast_opts;
     return res;
 }
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -513,7 +513,7 @@ static duckdb::BoundCastInfo BindCastFunction(
 
 std::unique_ptr<duckdb::Expression> make_cast_expr(
     std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
-    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts) {
+    std::unique_ptr<arrow::compute::FunctionOptions> cast_opts) {
     // Convert std::unique_ptr to duckdb::unique_ptr.
     auto source_duck = to_duckdb(source);
     std::shared_ptr<arrow::Schema> out_schema = unwrap_schema(out_schema_py);
@@ -527,10 +527,22 @@ std::unique_ptr<duckdb::Expression> make_cast_expr(
         std::move(source_duck), out_type,
         BindCastFunction(source_duck->return_type, out_type));
 
+    // Fill in the cast options target type with the schema field type.
+    // We expect the existing to_type to be null.
+    arrow::compute::CastOptions *as_cast_options =
+        dynamic_cast<arrow::compute::CastOptions *>(cast_opts.get());
+    if (as_cast_options) {
+        as_cast_options->to_type = field->type();
+    }
+    BodoStringCastOptions *as_bodo_string_cast_options =
+        dynamic_cast<BodoStringCastOptions *>(cast_opts.get());
+    if (as_bodo_string_cast_options) {
+        as_bodo_string_cast_options->to_type = field->type();
+    }
     // Store the Arrow cast options in the cast info. This also helps
     // track the original Arrow type to have full type information (e.g.
     // interval precision).
-    res->bound_cast.arrow_cast_opts = cast_opts;
+    res->bound_cast.arrow_cast_opts = std::move(cast_opts);
     return res;
 }
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -1,4 +1,5 @@
 #include "_plan.h"
+#include <arrow/compute/kernel.h>
 #include <arrow/python/pyarrow.h>
 #include <arrow/type.h>
 #include <fmt/format.h>
@@ -47,6 +48,7 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_sample.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
+#include "physical/expression.h"
 
 #include "../libs/gpu_utils.h"
 
@@ -498,7 +500,8 @@ static duckdb::BoundCastInfo BindCastFunction(
 }
 
 std::unique_ptr<duckdb::Expression> make_cast_expr(
-    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py) {
+    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
+    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts) {
     // Convert std::unique_ptr to duckdb::unique_ptr.
     auto source_duck = to_duckdb(source);
     std::shared_ptr<arrow::Schema> out_schema = unwrap_schema(out_schema_py);
@@ -511,9 +514,11 @@ std::unique_ptr<duckdb::Expression> make_cast_expr(
     auto res = duckdb::make_uniq<duckdb::BoundCastExpression>(
         std::move(source_duck), out_type,
         BindCastFunction(source_duck->return_type, out_type));
-    // Store the Arrow type in the cast info to have full type information (e.g.
+
+    // Store the Arrow cast options in the cast info. This also helps
+    // track the original Arrow type to have full type information (e.g.
     // interval precision).
-    res->bound_cast.arrow_type = field->type();
+    res->bound_cast.arrow_cast_opts = cast_opts;
     return res;
 }
 

--- a/bodo/pandas/_plan.cpp
+++ b/bodo/pandas/_plan.cpp
@@ -501,7 +501,7 @@ static duckdb::BoundCastInfo BindCastFunction(
 
 std::unique_ptr<duckdb::Expression> make_cast_expr(
     std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
-    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts) {
+    std::unique_ptr<arrow::compute::FunctionOptions> cast_opts) {
     // Convert std::unique_ptr to duckdb::unique_ptr.
     auto source_duck = to_duckdb(source);
     std::shared_ptr<arrow::Schema> out_schema = unwrap_schema(out_schema_py);
@@ -515,10 +515,22 @@ std::unique_ptr<duckdb::Expression> make_cast_expr(
         std::move(source_duck), out_type,
         BindCastFunction(source_duck->return_type, out_type));
 
+    // Fill in the cast options target type with the schema field type.
+    // We expect the existing to_type to be null.
+    arrow::compute::CastOptions *as_cast_options =
+        dynamic_cast<arrow::compute::CastOptions *>(cast_opts.get());
+    if (as_cast_options) {
+        as_cast_options->to_type = field->type();
+    }
+    BodoStringCastOptions *as_bodo_string_cast_options =
+        dynamic_cast<BodoStringCastOptions *>(cast_opts.get());
+    if (as_bodo_string_cast_options) {
+        as_bodo_string_cast_options->to_type = field->type();
+    }
     // Store the Arrow cast options in the cast info. This also helps
     // track the original Arrow type to have full type information (e.g.
     // interval precision).
-    res->bound_cast.arrow_cast_opts = cast_opts;
+    res->bound_cast.arrow_cast_opts = std::move(cast_opts);
     return res;
 }
 

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -472,7 +472,7 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
  */
 std::unique_ptr<duckdb::Expression> make_cast_expr(
     std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
-    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts);
+    std::unique_ptr<arrow::compute::FunctionOptions> cast_opts);
 
 /**
  * @brief Create a conjunction (and/or) expression from two sources.

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -482,7 +482,7 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
  */
 std::unique_ptr<duckdb::Expression> make_cast_expr(
     std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
-    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts);
+    std::unique_ptr<arrow::compute::FunctionOptions> cast_opts);
 
 /**
  * @brief Create a conjunction (and/or) expression from two sources.

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -467,10 +467,12 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
  *
  * @param source - the source of the expression
  * @param out_schema_py output data type
+ * @param cast_opts FunctionOptions pointer denoting which cast function to call
  * @return duckdb::unique_ptr<duckdb::Expression> - the output expr
  */
 std::unique_ptr<duckdb::Expression> make_cast_expr(
-    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py);
+    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
+    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts);
 
 /**
  * @brief Create a conjunction (and/or) expression from two sources.

--- a/bodo/pandas/_plan.h
+++ b/bodo/pandas/_plan.h
@@ -477,10 +477,12 @@ std::unique_ptr<duckdb::Expression> make_unaryop_expr(
  *
  * @param source - the source of the expression
  * @param out_schema_py output data type
+ * @param cast_opts FunctionOptions pointer denoting which cast function to call
  * @return duckdb::unique_ptr<duckdb::Expression> - the output expr
  */
 std::unique_ptr<duckdb::Expression> make_cast_expr(
-    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py);
+    std::unique_ptr<duckdb::Expression> &source, PyObject *out_schema_py,
+    std::shared_ptr<const arrow::compute::FunctionOptions> cast_opts);
 
 /**
  * @brief Create a conjunction (and/or) expression from two sources.

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1245,23 +1245,76 @@ PyObject *_duckdbFilterToPyicebergFilter(
 
 std::shared_ptr<arrow::DataType> getCastReturnType(
     const duckdb::BoundCastExpression &bce) {
-    std::shared_ptr<arrow::DataType> arrow_type = bce.bound_cast.arrow_type;
     std::shared_ptr<arrow::DataType> duck_arrow_type =
         duckdbTypeToArrow(bce.return_type);
 
-    auto [_, arrow_duck_type] = arrow_field_to_duckdb(
-        std::make_shared<arrow::Field>("", duck_arrow_type));
-
-    // DuckDB generated cast nodes don't have Arrow type or DuckDB may change
-    // the type so reconcile here by prioritizing the DuckDB type. BodoSQL
-    // generated nodes have Arrow type and we run minimal DuckDB optimization so
-    // Arrow type is likely used for BodoSQL which has more complex date/time
-    // types with precision issues.
-    if (!arrow_type || !arrow_duck_type.EqualTypeInfo(bce.return_type)) {
-        arrow_type = duck_arrow_type;
+    // Get Arrow return type from FunctionOptions
+    std::shared_ptr<const arrow::compute::FunctionOptions> arrow_cast_opts =
+        bce.bound_cast.arrow_cast_opts;
+    if (!arrow_cast_opts) {
+        // If arrow_cast_opts is null, meaning this is likely a DuckDB-generated
+        // cast node return the DuckDB type
+        return duck_arrow_type;
+    }
+    std::shared_ptr<arrow::DataType> arrow_type;
+    std::shared_ptr<const arrow::compute::CastOptions> as_cast_options =
+        std::dynamic_pointer_cast<const arrow::compute::CastOptions>(
+            arrow_cast_opts);
+    std::shared_ptr<const BodoStringCastOptions> as_bodo_string_cast_options =
+        std::dynamic_pointer_cast<const BodoStringCastOptions>(arrow_cast_opts);
+    if (as_cast_options) {
+        arrow_type = as_cast_options->to_type.GetSharedPtr();
+    } else if (as_bodo_string_cast_options) {
+        arrow_type = as_bodo_string_cast_options->to_type.GetSharedPtr();
+    } else {
+        // Unexpected options class, return DuckDB type
+        return duck_arrow_type;
     }
 
+    // DuckDB may change the type of cast nodes, so reconcile here by
+    // prioritizing the DuckDB type. BodoSQL generated nodes have Arrow type and
+    // we run minimal DuckDB optimization so Arrow type is likely used for
+    // BodoSQL which has more complex date/time types with precision issues.
+    auto [_, arrow_duck_type] = arrow_field_to_duckdb(
+        std::make_shared<arrow::Field>("", duck_arrow_type));
+    if (!arrow_duck_type.EqualTypeInfo(bce.return_type)) {
+        return duck_arrow_type;
+    }
     return arrow_type;
+}
+
+std::unique_ptr<arrow::compute::FunctionOptions> getCastOptions(
+    const duckdb::BoundCastExpression &bce) {
+    // Determine target type which may be different from the existing one
+    std::shared_ptr<arrow::DataType> new_arrow_type = getCastReturnType(bce);
+
+    // If the cast node doesn't have cast options, use Arrow default
+    // CastOptions
+    if (!bce.bound_cast.arrow_cast_opts) {
+        std::unique_ptr<arrow::compute::CastOptions> default_cast_opts =
+            std::make_unique<arrow::compute::CastOptions>();
+        default_cast_opts->to_type = new_arrow_type;
+        return default_cast_opts;
+    }
+
+    // Copy the function options so we can modify the target type
+    std::unique_ptr<arrow::compute::FunctionOptions> new_arrow_cast_opts =
+        bce.bound_cast.arrow_cast_opts->Copy();
+    arrow::compute::CastOptions *as_cast_options =
+        dynamic_cast<arrow::compute::CastOptions *>(new_arrow_cast_opts.get());
+    if (as_cast_options) {
+        as_cast_options->to_type = new_arrow_type;
+        return new_arrow_cast_opts;
+    }
+    BodoStringCastOptions *as_bodo_string_cast_options =
+        dynamic_cast<BodoStringCastOptions *>(new_arrow_cast_opts.get());
+    if (as_bodo_string_cast_options) {
+        as_bodo_string_cast_options->to_type = new_arrow_type;
+        return new_arrow_cast_opts;
+    }
+    throw std::runtime_error(
+        "Cast options not arrow::compute::CastOptions or "
+        "BodoStringCastOptions");
 }
 
 PyObject *duckdbFilterSetToPyicebergFilter(

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1258,7 +1258,11 @@ std::unique_ptr<arrow::compute::FunctionOptions> getCastOptions(
         return default_cast_opts;
     }
 
-    // Copy the function options so we can modify the target type
+    // Copy the function options so we can modify the target type.
+    // We could declare BoundCastInfo::arrow_cast_opts as mutable
+    // and modify it directly, but it would be unintuitive for a
+    // getter function to have that side effect and could potentially
+    // lead to mysterious bugs.
     std::unique_ptr<arrow::compute::FunctionOptions> new_arrow_cast_opts =
         bce.bound_cast.arrow_cast_opts->Copy();
     arrow::compute::CastOptions *as_cast_options =

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1297,7 +1297,11 @@ std::unique_ptr<arrow::compute::FunctionOptions> getCastOptions(
         return default_cast_opts;
     }
 
-    // Copy the function options so we can modify the target type
+    // Copy the function options so we can modify the target type.
+    // We could declare BoundCastInfo::arrow_cast_opts as mutable
+    // and modify it directly, but it would be unintuitive for a
+    // getter function to have that side effect and could potentially
+    // lead to mysterious bugs.
     std::unique_ptr<arrow::compute::FunctionOptions> new_arrow_cast_opts =
         bce.bound_cast.arrow_cast_opts->Copy();
     arrow::compute::CastOptions *as_cast_options =

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1206,23 +1206,76 @@ PyObject *_duckdbFilterToPyicebergFilter(
 
 std::shared_ptr<arrow::DataType> getCastReturnType(
     const duckdb::BoundCastExpression &bce) {
-    std::shared_ptr<arrow::DataType> arrow_type = bce.bound_cast.arrow_type;
     std::shared_ptr<arrow::DataType> duck_arrow_type =
         duckdbTypeToArrow(bce.return_type);
 
-    auto [_, arrow_duck_type] = arrow_field_to_duckdb(
-        std::make_shared<arrow::Field>("", duck_arrow_type));
-
-    // DuckDB generated cast nodes don't have Arrow type or DuckDB may change
-    // the type so reconcile here by prioritizing the DuckDB type. BodoSQL
-    // generated nodes have Arrow type and we run minimal DuckDB optimization so
-    // Arrow type is likely used for BodoSQL which has more complex date/time
-    // types with precision issues.
-    if (!arrow_type || !arrow_duck_type.EqualTypeInfo(bce.return_type)) {
-        arrow_type = duck_arrow_type;
+    // Get Arrow return type from FunctionOptions
+    std::shared_ptr<const arrow::compute::FunctionOptions> arrow_cast_opts =
+        bce.bound_cast.arrow_cast_opts;
+    if (!arrow_cast_opts) {
+        // If arrow_cast_opts is null, meaning this is likely a DuckDB-generated
+        // cast node return the DuckDB type
+        return duck_arrow_type;
+    }
+    std::shared_ptr<arrow::DataType> arrow_type;
+    std::shared_ptr<const arrow::compute::CastOptions> as_cast_options =
+        std::dynamic_pointer_cast<const arrow::compute::CastOptions>(
+            arrow_cast_opts);
+    std::shared_ptr<const BodoStringCastOptions> as_bodo_string_cast_options =
+        std::dynamic_pointer_cast<const BodoStringCastOptions>(arrow_cast_opts);
+    if (as_cast_options) {
+        arrow_type = as_cast_options->to_type.GetSharedPtr();
+    } else if (as_bodo_string_cast_options) {
+        arrow_type = as_bodo_string_cast_options->to_type.GetSharedPtr();
+    } else {
+        // Unexpected options class, return DuckDB type
+        return duck_arrow_type;
     }
 
+    // DuckDB may change the type of cast nodes, so reconcile here by
+    // prioritizing the DuckDB type. BodoSQL generated nodes have Arrow type and
+    // we run minimal DuckDB optimization so Arrow type is likely used for
+    // BodoSQL which has more complex date/time types with precision issues.
+    auto [_, arrow_duck_type] = arrow_field_to_duckdb(
+        std::make_shared<arrow::Field>("", duck_arrow_type));
+    if (!arrow_duck_type.EqualTypeInfo(bce.return_type)) {
+        return duck_arrow_type;
+    }
     return arrow_type;
+}
+
+std::unique_ptr<arrow::compute::FunctionOptions> getCastOptions(
+    const duckdb::BoundCastExpression &bce) {
+    // Determine target type which may be different from the existing one
+    std::shared_ptr<arrow::DataType> new_arrow_type = getCastReturnType(bce);
+
+    // If the cast node doesn't have cast options, use Arrow default
+    // CastOptions
+    if (!bce.bound_cast.arrow_cast_opts) {
+        std::unique_ptr<arrow::compute::CastOptions> default_cast_opts =
+            std::make_unique<arrow::compute::CastOptions>();
+        default_cast_opts->to_type = new_arrow_type;
+        return default_cast_opts;
+    }
+
+    // Copy the function options so we can modify the target type
+    std::unique_ptr<arrow::compute::FunctionOptions> new_arrow_cast_opts =
+        bce.bound_cast.arrow_cast_opts->Copy();
+    arrow::compute::CastOptions *as_cast_options =
+        dynamic_cast<arrow::compute::CastOptions *>(new_arrow_cast_opts.get());
+    if (as_cast_options) {
+        as_cast_options->to_type = new_arrow_type;
+        return new_arrow_cast_opts;
+    }
+    BodoStringCastOptions *as_bodo_string_cast_options =
+        dynamic_cast<BodoStringCastOptions *>(new_arrow_cast_opts.get());
+    if (as_bodo_string_cast_options) {
+        as_bodo_string_cast_options->to_type = new_arrow_type;
+        return new_arrow_cast_opts;
+    }
+    throw std::runtime_error(
+        "Cast options not arrow::compute::CastOptions or "
+        "BodoStringCastOptions");
 }
 
 PyObject *duckdbFilterSetToPyicebergFilter(

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -321,6 +321,22 @@ std::shared_ptr<arrow::DataType> getCastReturnType(
     const duckdb::BoundCastExpression &bce);
 
 /**
+ * @brief Get the Arrow cast function options from the Bodo-generated cast node
+ * (stored by make_cast_expr in _plan.cpp). This contains the Arrow target type
+ * for the cast operation. We use this Arrow type instead of the
+ * duckdb::BoundCastExpression return type since DuckDB types may lose
+ * information (e.g. Interval precision). DuckDB generated types don't have
+ * Arrow type or DuckDB may change the type so this function has to reconcile
+ * (see: getCastReturnType()).
+ *
+ * @param bce Cast node
+ * @return std::unique_ptr<arrow::compute::FunctionOptions> Arrow function
+ *  options of the cast node
+ */
+std::unique_ptr<arrow::compute::FunctionOptions> getCastOptions(
+    const duckdb::BoundCastExpression &bce);
+
+/**
  * @brief Convert duckdb table filters to pyiceberg expressions.
  * @param filters - the duckdb table filters to convert
  * @param arrow_schema - the arrow schema to bind the filters to

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -1,5 +1,6 @@
 #include "expression.h"
 #include <arrow/type_fwd.h>
+#include <arrow/util/checked_cast.h>
 #include <arrow/util/value_parsing.h>
 #include <cmath>
 #include "_util.h"
@@ -623,6 +624,16 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
     return ConvertDatumToArrayInfo(casted);
 }
 
+std::shared_ptr<array_info> do_arrow_compute_cast(
+    std::shared_ptr<ExprResult> left_res,
+    const arrow::compute::FunctionOptions* cast_options) {
+    arrow::Datum src1 =
+        ConvertExprResultToDatum(left_res, "do_arrow_compute left");
+
+    arrow::Datum casted = do_arrow_compute_cast(src1, cast_options);
+    return ConvertDatumToArrayInfo(casted);
+}
+
 void do_result_type_cast(arrow::Result<arrow::Datum>& out_res,
                          const std::shared_ptr<arrow::DataType> result_type) {
     arrow::Datum out_datum = out_res.ValueOrDie();
@@ -737,6 +748,36 @@ arrow::Datum do_arrow_compute_unary(
 arrow::Datum do_arrow_compute_cast(
     arrow::Datum left_res,
     const std::shared_ptr<arrow::DataType>& return_type) {
+    // If only return_type is given, configure CastOptions to Bodo defaults.
+    // This overload is only used if called directly from C++. Regular
+    // CastExpressions are guaranteed to have cast options, created in plan.py.
+    arrow::compute::CastOptions cast_opts;
+    cast_opts.to_type = return_type;
+    cast_opts.allow_int_overflow = true;
+    cast_opts.allow_float_truncate = true;
+
+    return do_arrow_compute_cast(left_res, &cast_opts);
+}
+
+arrow::Datum do_arrow_compute_cast(
+    arrow::Datum left_res,
+    const arrow::compute::FunctionOptions* cast_options) {
+    std::shared_ptr<arrow::DataType> return_type;
+
+    const arrow::compute::CastOptions* as_cast_options =
+        dynamic_cast<const arrow::compute::CastOptions*>(cast_options);
+    const BodoStringCastOptions* as_bodo_string_cast_options =
+        dynamic_cast<const BodoStringCastOptions*>(cast_options);
+    if (as_cast_options) {
+        return_type = as_cast_options->to_type.GetSharedPtr();
+    } else if (as_bodo_string_cast_options) {
+        return_type = as_bodo_string_cast_options->to_type.GetSharedPtr();
+    } else {
+        throw std::runtime_error(
+            "do_arrow_compute_cast: Cast options not "
+            "arrow::compute::CastOptions or BodoStringCastOptions");
+    }
+
     // No need to cast if type is already the target type.
     // Note that arrow::DataType.Equals() also compares type parameters such
     // as time units and timezones.
@@ -744,13 +785,17 @@ arrow::Datum do_arrow_compute_cast(
         return left_res;
     }
 
-    // Globally set the allow_int_overflow cast option to true; in the future,
-    // CastExpressions should support these options.
-    arrow::compute::CastOptions cast_opts;
-    cast_opts.allow_int_overflow = true;
-    cast_opts.allow_float_truncate = true;
-    arrow::Result<arrow::Datum> cmp_res =
-        arrow::compute::Cast(left_res, return_type, cast_opts);
+    // Call Arrow Cast or bodo_string_cast depending on the class of cast
+    // options passed
+    arrow::Result<arrow::Datum> cmp_res;
+    if (as_cast_options) {
+        cmp_res = arrow::compute::Cast(left_res, *as_cast_options);
+    } else {
+        EnsureBodoStringCastRegistered();
+        cmp_res = arrow::compute::CallFunction("bodo_string_cast", {left_res},
+                                               as_bodo_string_cast_options);
+    }
+
     if (!cmp_res.ok()) [[unlikely]] {
         throw std::runtime_error(
             "do_arrow_compute_cast: Error in Arrow compute: " +
@@ -1058,7 +1103,7 @@ std::shared_ptr<PhysicalExpression> buildPhysicalExprTree(
             return std::static_pointer_cast<PhysicalExpression>(
                 std::make_shared<PhysicalCastExpression>(
                     buildPhysicalExprTree(bce.child, col_ref_map, no_scalars),
-                    getCastReturnType(bce)));
+                    getCastOptions(bce)));
         } break;  // suppress wrong fallthrough error
         case duckdb::ExpressionClass::BOUND_BETWEEN: {
             // Convert the base duckdb::Expression node to its actual derived
@@ -1774,37 +1819,79 @@ void EnsureSubstrRegistered() {
     });
 }
 
+class BodoStringCastOptionsType : public arrow::compute::FunctionOptionsType {
+   public:
+    const char* type_name() const override {
+        return BodoStringCastOptions::kTypeName;
+    }
+
+    std::string Stringify(
+        const arrow::compute::FunctionOptions& options) const override {
+        const auto& opts =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(
+                options);
+        return "{to_type=" + opts.to_type.ToString() +
+               ", emit_null_on_failure=" +
+               (opts.emit_null_on_failure ? "true" : "false") + "}";
+    }
+
+    bool Compare(const arrow::compute::FunctionOptions& options,
+                 const arrow::compute::FunctionOptions& other) const override {
+        const auto& lhs =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(
+                options);
+        const auto& rhs =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(other);
+        return lhs.to_type == rhs.to_type &&
+               lhs.emit_null_on_failure == rhs.emit_null_on_failure;
+    }
+
+    std::unique_ptr<arrow::compute::FunctionOptions> Copy(
+        const arrow::compute::FunctionOptions& options) const override {
+        const auto& opts =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(
+                options);
+        return std::make_unique<BodoStringCastOptions>(
+            opts.to_type, opts.emit_null_on_failure);
+    }
+};
+
+static const BodoStringCastOptionsType kBodoStringCastOptionsType =
+    BodoStringCastOptionsType();
+
+BodoStringCastOptions::BodoStringCastOptions()
+    : arrow::compute::FunctionOptions(&kBodoStringCastOptionsType) {}
+BodoStringCastOptions::BodoStringCastOptions(arrow::TypeHolder to_type,
+                                             bool emit_null_on_failure)
+    : arrow::compute::FunctionOptions(&kBodoStringCastOptionsType),
+      to_type(to_type),
+      emit_null_on_failure(emit_null_on_failure) {}
+
 struct BodoStringCastState : public arrow::compute::KernelState {
     std::shared_ptr<arrow::DataType> target_type;
-    // Later, Arrow's CastOptions will be replaced with a specialized options
-    // class for this kernel
-    arrow::compute::CastOptions options;
-    // Placeholder until we have a dedicated options class
-    bool emit_null_on_failure = true;
+    BodoStringCastOptions options;
 
     BodoStringCastState(std::shared_ptr<arrow::DataType> type,
-                        arrow::compute::CastOptions opts)
+                        BodoStringCastOptions opts)
         : target_type(std::move(type)), options(std::move(opts)) {}
 };
 
 arrow::Result<std::unique_ptr<arrow::compute::KernelState>> InitTryCast(
     arrow::compute::KernelContext* ctx,
     const arrow::compute::KernelInitArgs& args) {
-    // Safely cast the generic FunctionOptions to CastOptions
+    // Safely cast the generic FunctionOptions to BodoStringCastOptions
     const auto* cast_options =
-        dynamic_cast<const arrow::compute::CastOptions*>(args.options);
+        dynamic_cast<const BodoStringCastOptions*>(args.options);
     if (!cast_options) {
-        return arrow::Status::Invalid("CastOptions are required.");
+        return arrow::Status::Invalid("BodoStringCastOptions are required.");
     }
 
-    // TODO: Throw an error if other cast options are provided
-
-    // Extract the target type from CastOptions
+    // Extract the target type from BodoStringCastOptions
     std::shared_ptr<arrow::DataType> target_type =
         cast_options->to_type.GetSharedPtr();
     if (!target_type) {
         return arrow::Status::Invalid(
-            "target type (CastOptions.to_type) must be specified.");
+            "target type (BodoStringCastOptions.to_type) must be specified.");
     }
 
     // Return our custom state wrapping the options
@@ -1819,7 +1906,7 @@ struct BodoStringCastVisitor {
     template <typename ParseFunc, typename OutputSetter>
     arrow::Status ParseValues(ParseFunc parse_func, OutputSetter set_output) {
         auto* state = static_cast<BodoStringCastState*>(ctx->state());
-        bool emit_null_on_failure = state->emit_null_on_failure;
+        bool emit_null_on_failure = state->options.emit_null_on_failure;
 
         // GetValues accounts for the ArraySpan offset, so we don't need to
         // account for it when indexing into input_offsets or input_data
@@ -2011,7 +2098,7 @@ arrow::Result<arrow::TypeHolder> ResolveCastTargetType(
     }
 
     // Return the target type in the BodoStringCastState which comes from
-    // CastOptions
+    // BodoStringCastOptions
     return arrow::TypeHolder(state->target_type);
 }
 
@@ -2025,7 +2112,7 @@ void RegisterBodoStringCast(arrow::compute::FunctionRegistry* registry) {
             "are coerced to NULL if the `emit_null_on_failure` option is set "
             "to true.",
             {"str_array"},
-            "CastOptions"});
+            "BodoStringCastOptions"});
 
     // Use arrow::compute::OutputType(ResolveCastTargetType) for dynamic mapping
     arrow::compute::ScalarKernel kernel(
@@ -2058,6 +2145,13 @@ void EnsureBodoStringCastRegistered() {
     std::call_once(once_flag_, [&]() {
         auto* registry = arrow::compute::GetFunctionRegistry();
         RegisterBodoStringCast(registry);
+        arrow::Status add_options_type_status =
+            registry->AddFunctionOptionsType(&kBodoStringCastOptionsType);
+        if (!add_options_type_status.ok()) {
+            throw std::runtime_error(
+                "Failed to add BodoStringCastOptionsType to Arrow function "
+                "registry.");
+        }
     });
 }
 

--- a/bodo/pandas/physical/expression.cpp
+++ b/bodo/pandas/physical/expression.cpp
@@ -1,5 +1,6 @@
 #include "expression.h"
 #include <arrow/type_fwd.h>
+#include <arrow/util/checked_cast.h>
 #include <arrow/util/value_parsing.h>
 #include <cmath>
 #include "../libs/_decimal_ext.h"
@@ -624,6 +625,16 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
     return ConvertDatumToArrayInfo(casted);
 }
 
+std::shared_ptr<array_info> do_arrow_compute_cast(
+    std::shared_ptr<ExprResult> left_res,
+    const arrow::compute::FunctionOptions* cast_options) {
+    arrow::Datum src1 =
+        ConvertExprResultToDatum(left_res, "do_arrow_compute left");
+
+    arrow::Datum casted = do_arrow_compute_cast(src1, cast_options);
+    return ConvertDatumToArrayInfo(casted);
+}
+
 void do_result_type_cast(arrow::Result<arrow::Datum>& out_res,
                          const std::shared_ptr<arrow::DataType> result_type) {
     arrow::Datum out_datum = out_res.ValueOrDie();
@@ -814,6 +825,36 @@ arrow::Datum do_arrow_compute_unary(
 arrow::Datum do_arrow_compute_cast(
     arrow::Datum left_res,
     const std::shared_ptr<arrow::DataType>& return_type) {
+    // If only return_type is given, configure CastOptions to Bodo defaults.
+    // This overload is only used if called directly from C++. Regular
+    // CastExpressions are guaranteed to have cast options, created in plan.py.
+    arrow::compute::CastOptions cast_opts;
+    cast_opts.to_type = return_type;
+    cast_opts.allow_int_overflow = true;
+    cast_opts.allow_float_truncate = true;
+
+    return do_arrow_compute_cast(left_res, &cast_opts);
+}
+
+arrow::Datum do_arrow_compute_cast(
+    arrow::Datum left_res,
+    const arrow::compute::FunctionOptions* cast_options) {
+    std::shared_ptr<arrow::DataType> return_type;
+
+    const arrow::compute::CastOptions* as_cast_options =
+        dynamic_cast<const arrow::compute::CastOptions*>(cast_options);
+    const BodoStringCastOptions* as_bodo_string_cast_options =
+        dynamic_cast<const BodoStringCastOptions*>(cast_options);
+    if (as_cast_options) {
+        return_type = as_cast_options->to_type.GetSharedPtr();
+    } else if (as_bodo_string_cast_options) {
+        return_type = as_bodo_string_cast_options->to_type.GetSharedPtr();
+    } else {
+        throw std::runtime_error(
+            "do_arrow_compute_cast: Cast options not "
+            "arrow::compute::CastOptions or BodoStringCastOptions");
+    }
+
     // No need to cast if type is already the target type.
     // Note that arrow::DataType.Equals() also compares type parameters such
     // as time units and timezones.
@@ -821,13 +862,17 @@ arrow::Datum do_arrow_compute_cast(
         return left_res;
     }
 
-    // Globally set the allow_int_overflow cast option to true; in the future,
-    // CastExpressions should support these options.
-    arrow::compute::CastOptions cast_opts;
-    cast_opts.allow_int_overflow = true;
-    cast_opts.allow_float_truncate = true;
-    arrow::Result<arrow::Datum> cmp_res =
-        arrow::compute::Cast(left_res, return_type, cast_opts);
+    // Call Arrow Cast or bodo_string_cast depending on the class of cast
+    // options passed
+    arrow::Result<arrow::Datum> cmp_res;
+    if (as_cast_options) {
+        cmp_res = arrow::compute::Cast(left_res, *as_cast_options);
+    } else {
+        EnsureBodoStringCastRegistered();
+        cmp_res = arrow::compute::CallFunction("bodo_string_cast", {left_res},
+                                               as_bodo_string_cast_options);
+    }
+
     if (!cmp_res.ok()) [[unlikely]] {
         throw std::runtime_error(
             "do_arrow_compute_cast: Error in Arrow compute: " +
@@ -1135,7 +1180,7 @@ std::shared_ptr<PhysicalExpression> buildPhysicalExprTree(
             return std::static_pointer_cast<PhysicalExpression>(
                 std::make_shared<PhysicalCastExpression>(
                     buildPhysicalExprTree(bce.child, col_ref_map, no_scalars),
-                    getCastReturnType(bce)));
+                    getCastOptions(bce)));
         } break;  // suppress wrong fallthrough error
         case duckdb::ExpressionClass::BOUND_BETWEEN: {
             // Convert the base duckdb::Expression node to its actual derived
@@ -1851,37 +1896,79 @@ void EnsureSubstrRegistered() {
     });
 }
 
+class BodoStringCastOptionsType : public arrow::compute::FunctionOptionsType {
+   public:
+    const char* type_name() const override {
+        return BodoStringCastOptions::kTypeName;
+    }
+
+    std::string Stringify(
+        const arrow::compute::FunctionOptions& options) const override {
+        const auto& opts =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(
+                options);
+        return "{to_type=" + opts.to_type.ToString() +
+               ", emit_null_on_failure=" +
+               (opts.emit_null_on_failure ? "true" : "false") + "}";
+    }
+
+    bool Compare(const arrow::compute::FunctionOptions& options,
+                 const arrow::compute::FunctionOptions& other) const override {
+        const auto& lhs =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(
+                options);
+        const auto& rhs =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(other);
+        return lhs.to_type == rhs.to_type &&
+               lhs.emit_null_on_failure == rhs.emit_null_on_failure;
+    }
+
+    std::unique_ptr<arrow::compute::FunctionOptions> Copy(
+        const arrow::compute::FunctionOptions& options) const override {
+        const auto& opts =
+            arrow::internal::checked_cast<const BodoStringCastOptions&>(
+                options);
+        return std::make_unique<BodoStringCastOptions>(
+            opts.to_type, opts.emit_null_on_failure);
+    }
+};
+
+static const BodoStringCastOptionsType kBodoStringCastOptionsType =
+    BodoStringCastOptionsType();
+
+BodoStringCastOptions::BodoStringCastOptions()
+    : arrow::compute::FunctionOptions(&kBodoStringCastOptionsType) {}
+BodoStringCastOptions::BodoStringCastOptions(arrow::TypeHolder to_type,
+                                             bool emit_null_on_failure)
+    : arrow::compute::FunctionOptions(&kBodoStringCastOptionsType),
+      to_type(to_type),
+      emit_null_on_failure(emit_null_on_failure) {}
+
 struct BodoStringCastState : public arrow::compute::KernelState {
     std::shared_ptr<arrow::DataType> target_type;
-    // Later, Arrow's CastOptions will be replaced with a specialized options
-    // class for this kernel
-    arrow::compute::CastOptions options;
-    // Placeholder until we have a dedicated options class
-    bool emit_null_on_failure = true;
+    BodoStringCastOptions options;
 
     BodoStringCastState(std::shared_ptr<arrow::DataType> type,
-                        arrow::compute::CastOptions opts)
+                        BodoStringCastOptions opts)
         : target_type(std::move(type)), options(std::move(opts)) {}
 };
 
 arrow::Result<std::unique_ptr<arrow::compute::KernelState>> InitTryCast(
     arrow::compute::KernelContext* ctx,
     const arrow::compute::KernelInitArgs& args) {
-    // Safely cast the generic FunctionOptions to CastOptions
+    // Safely cast the generic FunctionOptions to BodoStringCastOptions
     const auto* cast_options =
-        dynamic_cast<const arrow::compute::CastOptions*>(args.options);
+        dynamic_cast<const BodoStringCastOptions*>(args.options);
     if (!cast_options) {
-        return arrow::Status::Invalid("CastOptions are required.");
+        return arrow::Status::Invalid("BodoStringCastOptions are required.");
     }
 
-    // TODO: Throw an error if other cast options are provided
-
-    // Extract the target type from CastOptions
+    // Extract the target type from BodoStringCastOptions
     std::shared_ptr<arrow::DataType> target_type =
         cast_options->to_type.GetSharedPtr();
     if (!target_type) {
         return arrow::Status::Invalid(
-            "target type (CastOptions.to_type) must be specified.");
+            "target type (BodoStringCastOptions.to_type) must be specified.");
     }
 
     // Return our custom state wrapping the options
@@ -1896,7 +1983,7 @@ struct BodoStringCastVisitor {
     template <typename ParseFunc, typename OutputSetter>
     arrow::Status ParseValues(ParseFunc parse_func, OutputSetter set_output) {
         auto* state = static_cast<BodoStringCastState*>(ctx->state());
-        bool emit_null_on_failure = state->emit_null_on_failure;
+        bool emit_null_on_failure = state->options.emit_null_on_failure;
 
         // GetValues accounts for the ArraySpan offset, so we don't need to
         // account for it when indexing into input_offsets or input_data
@@ -2088,7 +2175,7 @@ arrow::Result<arrow::TypeHolder> ResolveCastTargetType(
     }
 
     // Return the target type in the BodoStringCastState which comes from
-    // CastOptions
+    // BodoStringCastOptions
     return arrow::TypeHolder(state->target_type);
 }
 
@@ -2102,7 +2189,7 @@ void RegisterBodoStringCast(arrow::compute::FunctionRegistry* registry) {
             "are coerced to NULL if the `emit_null_on_failure` option is set "
             "to true.",
             {"str_array"},
-            "CastOptions"});
+            "BodoStringCastOptions"});
 
     // Use arrow::compute::OutputType(ResolveCastTargetType) for dynamic mapping
     arrow::compute::ScalarKernel kernel(
@@ -2135,6 +2222,13 @@ void EnsureBodoStringCastRegistered() {
     std::call_once(once_flag_, [&]() {
         auto* registry = arrow::compute::GetFunctionRegistry();
         RegisterBodoStringCast(registry);
+        arrow::Status add_options_type_status =
+            registry->AddFunctionOptionsType(&kBodoStringCastOptionsType);
+        if (!add_options_type_status.ok()) {
+            throw std::runtime_error(
+                "Failed to add BodoStringCastOptionsType to Arrow function "
+                "registry.");
+        }
     });
 }
 

--- a/bodo/pandas/physical/expression.h
+++ b/bodo/pandas/physical/expression.h
@@ -266,6 +266,14 @@ std::shared_ptr<array_info> do_arrow_compute_cast(
     const std::shared_ptr<arrow::DataType> &return_type);
 
 /**
+ * @brief Convert ExprResult to arrow and cast using the provided
+ * `cast_options`, which must contain the target type.
+ */
+std::shared_ptr<array_info> do_arrow_compute_cast(
+    std::shared_ptr<ExprResult> left_res,
+    const arrow::compute::FunctionOptions *cast_options);
+
+/**
  * @brief Convert ExprResult to arrow and run case compute on them.
  *
  */
@@ -294,11 +302,22 @@ arrow::Datum do_arrow_compute_binary(
     const std::shared_ptr<arrow::DataType> result_type = nullptr);
 
 /**
- * @brief Run cast on arrow Datum.
+ * @brief Run cast on arrow Datum using Bodo default cast options.
  *
  */
 arrow::Datum do_arrow_compute_cast(
     arrow::Datum left_res, const std::shared_ptr<arrow::DataType> &return_type);
+
+/**
+ * @brief Run cast on an Arrow Datum using the provided `cast_options`, which
+ * must be an instance of arrow::compute::CastOptions or BodoStringCastOptions
+ * with the `to_type` field filled in. `arrow::compute::Cast` is called if
+ * `cast_options` is an instance of arrow::compute::CastOptions, and
+ * bodo_string_cast is called if `cast_options` is an instance of
+ * BodoStringCastOptions.
+ */
+arrow::Datum do_arrow_compute_cast(
+    arrow::Datum left_res, const arrow::compute::FunctionOptions *cast_options);
 
 /**
  * @brief Physical expression tree node type for comparisons resulting in
@@ -832,15 +851,32 @@ class PhysicalConjunctionExpression : public PhysicalExpression {
 };
 
 /**
+ * @bnief Options class for the bodo_string_cast kernel
+ *
+ */
+class BodoStringCastOptions : public arrow::compute::FunctionOptions {
+   public:
+    explicit BodoStringCastOptions(arrow::TypeHolder to_type,
+                                   bool emit_null_on_failure = false);
+    BodoStringCastOptions();
+
+    static constexpr const char kTypeName[] = "BodoStringCastOptions";
+
+    arrow::TypeHolder to_type;
+    bool emit_null_on_failure = false;
+};
+
+/**
  * @brief Physical expression tree node type for casting.
  *
  */
 class PhysicalCastExpression : public PhysicalExpression {
    public:
-    PhysicalCastExpression(std::shared_ptr<PhysicalExpression> left,
-                           std::shared_ptr<arrow::DataType> _return_type)
+    PhysicalCastExpression(
+        std::shared_ptr<PhysicalExpression> left,
+        std::unique_ptr<arrow::compute::FunctionOptions> _cast_opts)
         : PhysicalExpression(PhysicalExpressionType::CAST),
-          return_type(_return_type) {
+          cast_opts(std::move(_cast_opts)) {
         children.push_back(left);
     }
 
@@ -855,7 +891,7 @@ class PhysicalCastExpression : public PhysicalExpression {
         // Process child first.
         std::shared_ptr<ExprResult> left_res =
             children[0]->ProcessBatch(input_batch);
-        auto result = do_arrow_compute_cast(left_res, return_type);
+        auto result = do_arrow_compute_cast(left_res, cast_opts.get());
         auto left_as_scalar =
             std::dynamic_pointer_cast<ScalarExprResult>(left_res);
         if (left_as_scalar) {
@@ -871,11 +907,11 @@ class PhysicalCastExpression : public PhysicalExpression {
         arrow::Datum left_datum = children[0]->join_expr_internal(
             left_table, right_table, left_data, right_data, left_null_bitmap,
             right_null_bitmap, left_index, right_index);
-        return do_arrow_compute_cast(left_datum, return_type);
+        return do_arrow_compute_cast(left_datum, cast_opts.get());
     }
 
    protected:
-    std::shared_ptr<arrow::DataType> return_type;
+    std::unique_ptr<arrow::compute::FunctionOptions> cast_opts;
 };
 
 /**

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -1020,15 +1020,18 @@ class CaseExpression(Expression):
 class CastExpression(Expression):
     """
     Expression representing a type cast in the query plan.
+    The `empty_data` type is used as the target type.
+
     `cast_opts` is an instance of `pyarrow.compute.FunctionOptions`,
     either `CastOptions` or `BodoStringOptions` to signify
     which cast compute function shoud be called.
     """
 
-    class CastOptions(pa.compute.CastOptions):
+    class CastOptions(plan_optimizer._CastOptions):
         """
-        A subclass of Arrow's CastOptions that attempts to hide the
-        target_type parameter to avoid accidental discrepancies
+        A subclass of _CastOptions for easier construction.
+        The target type cannot be set through this Python
+        wrapper. This is to avoid accidental discrepancies
         between to_type in CastOptions and schema type.
 
         The allow_int_overflow and allow_float_truncate options are
@@ -1046,14 +1049,19 @@ class CastExpression(Expression):
             allow_float_truncate=True,
             allow_invalid_utf8=None,
         ):
-            super().__init__(
-                allow_int_overflow=allow_int_overflow,
-                allow_time_truncate=allow_time_truncate,
-                allow_time_overflow=allow_time_overflow,
-                allow_decimal_truncate=allow_decimal_truncate,
-                allow_float_truncate=allow_float_truncate,
-                allow_invalid_utf8=allow_invalid_utf8,
-            )
+            super().__init__()
+            if allow_int_overflow is not None:
+                self.allow_int_overflow = allow_int_overflow
+            if allow_time_truncate is not None:
+                self.allow_time_truncate = allow_time_truncate
+            if allow_time_overflow is not None:
+                self.allow_time_overflow = allow_time_overflow
+            if allow_decimal_truncate is not None:
+                self.allow_decimal_truncate = allow_decimal_truncate
+            if allow_float_truncate is not None:
+                self.allow_float_truncate = allow_float_truncate
+            if allow_invalid_utf8 is not None:
+                self.allow_invalid_utf8 = allow_invalid_utf8
 
         @classmethod
         def safe(cls):
@@ -1096,7 +1104,7 @@ class CastExpression(Expression):
             # Use regular Arrow casting if no cast options are given
             cast_opts = CastExpression.CastOptions()
 
-        # target type is assigned in plan_optimizer.pyx
+        # target type is assigned in make_cast_expr in _plan.cpp
 
         self.cast_opts = cast_opts
         super().__init__(empty_data, source_expr, cast_opts)

--- a/bodo/pandas/plan.py
+++ b/bodo/pandas/plan.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 from pandas._libs import lib
 
 import bodo
+from bodo.ext import plan_optimizer
 from bodo.pandas.utils import (
     BODO_NONE_DUMMY,
     arrow_to_empty_df,
@@ -1017,12 +1018,88 @@ class CaseExpression(Expression):
 
 
 class CastExpression(Expression):
-    """Expression representing a type cast in the query plan."""
+    """
+    Expression representing a type cast in the query plan.
+    `cast_opts` is an instance of `pyarrow.compute.FunctionOptions`,
+    either `CastOptions` or `BodoStringOptions` to signify
+    which cast compute function shoud be called.
+    """
 
-    def __init__(self, empty_data, source_expr):
+    class CastOptions(pa.compute.CastOptions):
+        """
+        A subclass of Arrow's CastOptions that attempts to hide the
+        target_type parameter to avoid accidental discrepancies
+        between to_type in CastOptions and schema type.
+
+        The allow_int_overflow and allow_float_truncate options are
+        also set to True by default, which differs from Arrow's
+        CastOptions.
+        """
+
+        def __init__(
+            self,
+            *,
+            allow_int_overflow=True,
+            allow_time_truncate=None,
+            allow_time_overflow=None,
+            allow_decimal_truncate=None,
+            allow_float_truncate=True,
+            allow_invalid_utf8=None,
+        ):
+            super().__init__(
+                allow_int_overflow=allow_int_overflow,
+                allow_time_truncate=allow_time_truncate,
+                allow_time_overflow=allow_time_overflow,
+                allow_decimal_truncate=allow_decimal_truncate,
+                allow_float_truncate=allow_float_truncate,
+                allow_invalid_utf8=allow_invalid_utf8,
+            )
+
+        @classmethod
+        def safe(cls):
+            instance = cls()
+            instance._set_safe()
+            return instance
+
+        @classmethod
+        def unsafe(cls):
+            instance = cls()
+            instance._set_unsafe()
+            return instance
+
+    class BodoStringCastOptions(plan_optimizer._BodoStringCastOptions):
+        """
+        Options class for `bodo_string_cast`.
+        Set `emit_null_on_failure=True` if an error when parsing an element
+        should be coerced to null. If `emit_null_on_failure=False` (the
+        default), a single malformed element will result in a failure
+        for the whole operation.
+        """
+
+        def __init__(self, emit_null_on_failure=None):
+            super().__init__()
+            if emit_null_on_failure is not None:
+                self.emit_null_on_failure = emit_null_on_failure
+
+    def __init__(self, empty_data, source_expr, cast_opts=None):
         self.empty_data = empty_data
         self.source_expr = source_expr
-        super().__init__(empty_data, source_expr)
+
+        if cast_opts:
+            if not isinstance(cast_opts, CastExpression.CastOptions) and not isinstance(
+                cast_opts, CastExpression.BodoStringCastOptions
+            ):
+                raise TypeError(
+                    "Expected cast_opts to be an instance of CastExpression.CastOptions or CastExpression.BodoStringCastOptions"
+                )
+        else:
+            # Use regular Arrow casting if no cast options are given
+            cast_opts = CastExpression.CastOptions()
+
+        # target type is assigned in plan_optimizer.pyx
+
+        self.cast_opts = cast_opts
+        super().__init__(empty_data, source_expr, cast_opts)
 
     @property
     def source(self):

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -3,7 +3,8 @@
 # distutils: language = c++
 # cython: c_string_type=unicode, c_string_encoding=utf8
 
-from libcpp.memory cimport unique_ptr, make_unique, dynamic_pointer_cast
+from cython.operator cimport dereference as deref
+from libcpp.memory cimport shared_ptr, make_shared, unique_ptr, make_unique, static_pointer_cast, dynamic_pointer_cast
 from libcpp.utility cimport move, pair
 from libcpp.string cimport string as c_string
 from libcpp.vector cimport vector
@@ -20,10 +21,61 @@ import numpy as np
 import pyarrow as pa
 import bodo
 
+from pyarrow._compute cimport FunctionOptions
+from pyarrow.lib cimport DataType
+from pyarrow.includes.libarrow cimport CDataType, CFunctionOptions
+
 from cpython.ref cimport PyObject
 ctypedef PyObject* PyObjectPtr
 ctypedef unsigned long long idx_t
 ctypedef pair[int, int] int_pair
+
+cdef extern from "<arrow/python/pyarrow.h>" namespace "arrow::py" nogil:
+    int import_pyarrow()
+
+cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
+    cdef cppclass CCastOptions" arrow::compute::CastOptions"(CFunctionOptions):
+        # NOTE: Arrow's own CCastOptions defines to_type as shared_ptr[CDataType]
+        # instead of as TypeHolder which is how C++ CastOptions declares it.
+        # This discrepancy can lead to weird compilation issues where Cython
+        # expects one thing where C++ expects another, so we make a custom
+        # wrapper here to resolve this.
+        CTypeHolder to_type
+
+cdef extern from "arrow/type.h" namespace "arrow" nogil:
+    cdef cppclass CTypeHolder "arrow::TypeHolder":
+        CTypeHolder() except +
+        CTypeHolder(shared_ptr[CDataType]) except +
+        shared_ptr[CDataType] GetSharedPtr() except +
+
+cdef extern from "physical/expression.h" nogil:
+    cdef cppclass CBodoStringCastOptions "BodoStringCastOptions"(CFunctionOptions):
+        CBodoStringCastOptions() except +
+        CTypeHolder to_type
+        c_bool emit_null_on_failure
+
+# The below structure is similar to how Arrow defines function options:
+# https://github.com/apache/arrow/blob/8e63098846b6216d76605bd627a2dd89615a5328/python/pyarrow/_compute.pyx#L680
+
+cdef class _BodoStringCastOptions(FunctionOptions):
+    cdef CBodoStringCastOptions* options
+
+    def __init__(self):
+        cdef shared_ptr[CBodoStringCastOptions] wrapped = make_shared[CBodoStringCastOptions]()
+        FunctionOptions.init(self, <const shared_ptr[CFunctionOptions]> wrapped)
+        self.options = <CBodoStringCastOptions*> self.wrapped.get()
+
+    def _set_type(self, target_type=None):
+        if target_type is not None:
+            deref(self.options).to_type = CTypeHolder((<DataType>target_type).sp_type)
+
+    @property
+    def emit_null_on_failure(self):
+        return deref(self.options).emit_null_on_failure
+
+    @emit_null_on_failure.setter
+    def emit_null_on_failure(self, c_bool flag):
+        deref(self.options).emit_null_on_failure = flag
 
 cdef extern from "duckdb/common/types.hpp" namespace "duckdb" nogil:
     cpdef enum class CLogicalTypeId "duckdb::LogicalTypeId":
@@ -366,7 +418,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_comparison_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_arithop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, c_string opstr, object out_schema) except +
     cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr, object out_schema) except +
-    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema) except +
+    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema, shared_ptr[const CFunctionOptions] cast_opts) except +
     cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_unary_expr(unique_ptr[CExpression] lhs, CExpressionType etype, object out_schema) except +
     cdef unique_ptr[CExpression] make_case_expr(unique_ptr[CExpression] when, unique_ptr[CExpression] then, unique_ptr[CExpression] else_) except +
@@ -1022,15 +1074,46 @@ cdef class CastExpression(Expression):
     """Wrapper around DuckDB's BoundCastExpression to provide access in Python.
     """
 
-    def __cinit__(self, object out_schema, source):
+    def __cinit__(self, object out_schema, source, cast_opts):
         cdef unique_ptr[CExpression] source_expr
 
         source_expr = move((<Expression>source).c_expression) if isinstance(source, Expression) else move(make_const_expr(None, source))
 
+        # Get the function options object to forward to C++
+        # plan.py ensures that cast_opts is not None
+
+        import_pyarrow()
+
+        # Get shared_ptr of the function options to pass. This way we ensure
+        # that the options are kept alive.
+        cdef shared_ptr[CFunctionOptions] c_opts = (<FunctionOptions> cast_opts).unwrap()
+
+        cdef CTypeHolder to_type_holder
+        if isinstance(cast_opts, pa.compute.CastOptions):
+            to_type_holder = deref(static_pointer_cast[CCastOptions, CFunctionOptions](c_opts)).to_type
+        elif isinstance(cast_opts, _BodoStringCastOptions):
+            to_type_holder = deref(static_pointer_cast[CBodoStringCastOptions, CFunctionOptions](c_opts)).to_type
+        else:
+            # We don't expect to get here after the validation in plan.py
+            raise TypeError("Unexpected type of cast_opts in CastExpression")
+        cdef shared_ptr[CDataType] to_type = to_type_holder.GetSharedPtr()
+
+        schema_type = out_schema.field(0).type
+        if to_type != NULL:
+            # This case is unlikely since we try our best to hide the to_type field
+            # from the Python cast options API. We want to use the empty_data
+            # type to serve as the target type.
+            if not deref(to_type).Equals((<DataType> schema_type).sp_type, False):
+                raise ValueError(f"to_type ({deref(to_type).ToString()}) in cast options does not match the schema type ({str(schema_type)})")
+        else:
+            # Standard case: store the target type from the schema in the cast options
+            cast_opts._set_type(schema_type)
+
         self.out_schema = out_schema
         self.c_expression = make_cast_expr(
             source_expr,
-            out_schema)
+            out_schema,
+            <shared_ptr[const CFunctionOptions]> c_opts)
 
     def __str__(self):
         return f"CastExpression({self.out_schema})"

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -23,8 +23,8 @@ import bodo
 import decimal
 
 from pyarrow._compute cimport FunctionOptions
-from pyarrow.lib cimport DataType
-from pyarrow.includes.libarrow cimport CDataType, CFunctionOptions
+from pyarrow.lib cimport pyarrow_wrap_data_type, pyarrow_unwrap_data_type
+from pyarrow.includes.libarrow cimport CDataType, CFunctionOptions, CCastOptions
 
 from cpython.ref cimport PyObject
 ctypedef PyObject* PyObjectPtr
@@ -34,18 +34,8 @@ ctypedef pair[int, int] int_pair
 cdef extern from "<arrow/python/pyarrow.h>" namespace "arrow::py" nogil:
     int import_pyarrow()
 
-cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
-    cdef cppclass CCastOptions" arrow::compute::CastOptions"(CFunctionOptions):
-        # NOTE: Arrow's own CCastOptions defines to_type as shared_ptr[CDataType]
-        # instead of as TypeHolder which is how C++ CastOptions declares it.
-        # This discrepancy can lead to weird compilation issues where Cython
-        # expects one thing where C++ expects another, so we make a custom
-        # wrapper here to resolve this.
-        CTypeHolder to_type
-
 cdef extern from "arrow/type.h" namespace "arrow" nogil:
     cdef cppclass CTypeHolder "arrow::TypeHolder":
-        CTypeHolder() except +
         CTypeHolder(shared_ptr[CDataType]) except +
         shared_ptr[CDataType] GetSharedPtr() except +
 
@@ -54,6 +44,124 @@ cdef extern from "physical/expression.h" nogil:
         CBodoStringCastOptions() except +
         CTypeHolder to_type
         c_bool emit_null_on_failure
+
+cdef class _CastOptions(FunctionOptions):
+    """
+    _CastOptions is defined in arrow/python/pyarrow/_compute.pyx
+    but isn't declared in _compute.pxd, so we can't cimport it.
+    This makes it hard to write pickling logic, so our own version
+    of _CastOptions is below with some other modifications.
+    
+    Versus Arrow's _CastOptions, we don't define a _set_type()
+    method(). Our intention is that this wrapper class stores the
+    cast options aside from the target type, since our convention
+    is to use the schema type as the target type. Only on the C++
+    side is `to_type` filled in so that the CastOptions encapsulate
+    all the cast information.
+    """
+    cdef CCastOptions* options
+
+    def __init__(self):
+        cdef shared_ptr[CCastOptions] wrapped = make_shared[CCastOptions]()
+        FunctionOptions.init(self, <const shared_ptr[CFunctionOptions]> wrapped)
+        self.options = <CCastOptions*> self.wrapped.get()
+
+    def _set_safe(self):
+        self.init(shared_ptr[CFunctionOptions](
+            new CCastOptions(CCastOptions.Safe())))
+
+    def _set_unsafe(self):
+        self.init(shared_ptr[CFunctionOptions](
+            new CCastOptions(CCastOptions.Unsafe())))
+
+    def is_safe(self):
+        return not (deref(self.options).allow_int_overflow or
+                    deref(self.options).allow_time_truncate or
+                    deref(self.options).allow_time_overflow or
+                    deref(self.options).allow_decimal_truncate or
+                    deref(self.options).allow_float_truncate or
+                    deref(self.options).allow_invalid_utf8)
+
+    @property
+    def allow_int_overflow(self):
+        return deref(self.options).allow_int_overflow
+
+    @allow_int_overflow.setter
+    def allow_int_overflow(self, c_bool flag):
+        deref(self.options).allow_int_overflow = flag
+
+    @property
+    def allow_time_truncate(self):
+        return deref(self.options).allow_time_truncate
+
+    @allow_time_truncate.setter
+    def allow_time_truncate(self, c_bool flag):
+        deref(self.options).allow_time_truncate = flag
+
+    @property
+    def allow_time_overflow(self):
+        return deref(self.options).allow_time_overflow
+
+    @allow_time_overflow.setter
+    def allow_time_overflow(self, c_bool flag):
+        deref(self.options).allow_time_overflow = flag
+
+    @property
+    def allow_decimal_truncate(self):
+        return deref(self.options).allow_decimal_truncate
+
+    @allow_decimal_truncate.setter
+    def allow_decimal_truncate(self, c_bool flag):
+        deref(self.options).allow_decimal_truncate = flag
+
+    @property
+    def allow_float_truncate(self):
+        return deref(self.options).allow_float_truncate
+
+    @allow_float_truncate.setter
+    def allow_float_truncate(self, c_bool flag):
+        deref(self.options).allow_float_truncate = flag
+
+    @property
+    def allow_invalid_utf8(self):
+        return deref(self.options).allow_invalid_utf8
+
+    @allow_invalid_utf8.setter
+    def allow_invalid_utf8(self, c_bool flag):
+        deref(self.options).allow_invalid_utf8 = flag
+
+    def __reduce__(self):
+        state = self.__getstate__()
+        return (self.__class__, (), state)
+
+    # In the following code for pickling, we handle serializing
+    # to_type even though we never set it in Cython.
+
+    def __getstate__(self):
+        if self.options == NULL:
+            raise ValueError("CCastOptions pointer is unexpectedly NULL")
+        
+        # NOTE: Arrow's CCastOptions defines `to_type` as shared_ptr[CDataType]
+        # instead of as TypeHolder which is how C++ CastOptions declares it.
+        # To reconcile such that both the Cython and C++ builds pass, we wrap
+        # `to_type` in CTypeHolder which relies on TypeHolder having a copy
+        # constructor. Then we can get the actual CDataType.
+        cdef shared_ptr[CDataType] c_to_type = CTypeHolder(deref(self.options).to_type).GetSharedPtr()
+        py_to_type = pyarrow_wrap_data_type(c_to_type) if c_to_type.get() != NULL else None
+
+        serialized_dict = {"to_type": py_to_type}
+        for option_str in ["allow_int_overflow", "allow_time_truncate", "allow_time_overflow", "allow_decimal_truncate", "allow_float_truncate", "allow_invalid_utf8"]:
+            serialized_dict[option_str] = getattr(self, option_str, None)
+        return serialized_dict
+
+    def __setstate__(self, state):
+        self.__init__()
+        py_to_type = state["to_type"]
+        if py_to_type is not None:
+            deref(self.options).to_type = pyarrow_unwrap_data_type(py_to_type)
+        
+        for option_str in ["allow_int_overflow", "allow_time_truncate", "allow_time_overflow", "allow_decimal_truncate", "allow_float_truncate", "allow_invalid_utf8"]:
+            setattr(self, option_str, state[option_str])
 
 # The below structure is similar to how Arrow defines function options:
 # https://github.com/apache/arrow/blob/8e63098846b6216d76605bd627a2dd89615a5328/python/pyarrow/_compute.pyx#L680
@@ -66,10 +174,6 @@ cdef class _BodoStringCastOptions(FunctionOptions):
         FunctionOptions.init(self, <const shared_ptr[CFunctionOptions]> wrapped)
         self.options = <CBodoStringCastOptions*> self.wrapped.get()
 
-    def _set_type(self, target_type=None):
-        if target_type is not None:
-            deref(self.options).to_type = CTypeHolder((<DataType>target_type).sp_type)
-
     @property
     def emit_null_on_failure(self):
         return deref(self.options).emit_null_on_failure
@@ -77,6 +181,30 @@ cdef class _BodoStringCastOptions(FunctionOptions):
     @emit_null_on_failure.setter
     def emit_null_on_failure(self, c_bool flag):
         deref(self.options).emit_null_on_failure = flag
+
+    # In the following code for pickling, we handle serializing
+    # to_type even though we never set it in Cython.
+
+    def __reduce__(self):
+        state = self.__getstate__()
+        return (self.__class__, (), state)
+
+    def __getstate__(self):
+        if self.options == NULL:
+            raise ValueError("CBodoStringCastOptions pointer is unexpectedly NULL")
+        
+        cdef shared_ptr[CDataType] c_to_type = deref(self.options).to_type.GetSharedPtr()
+        py_to_type = pyarrow_wrap_data_type(c_to_type) if c_to_type.get() != NULL else None
+
+        serialized_dict = {"to_type": py_to_type, "emit_null_on_failure": self.emit_null_on_failure}
+        return serialized_dict
+
+    def __setstate__(self, state):
+        self.__init__()
+        py_to_type = state["to_type"]
+        if py_to_type is not None:
+            deref(self.options).to_type = CTypeHolder(pyarrow_unwrap_data_type(py_to_type))
+        self.emit_null_on_failure = state["emit_null_on_failure"]
 
 cdef extern from "duckdb/common/types.hpp" namespace "duckdb" nogil:
     cpdef enum class CLogicalTypeId "duckdb::LogicalTypeId":
@@ -419,7 +547,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_comparison_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_arithop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, c_string opstr, object out_schema) except +
     cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr, object out_schema) except +
-    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema, shared_ptr[const CFunctionOptions] cast_opts) except +
+    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema, unique_ptr[CFunctionOptions] cast_opts) except +
     cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_unary_expr(unique_ptr[CExpression] lhs, CExpressionType etype, object out_schema) except +
     cdef unique_ptr[CExpression] make_case_expr(unique_ptr[CExpression] when, unique_ptr[CExpression] then, unique_ptr[CExpression] else_) except +
@@ -1088,36 +1216,17 @@ cdef class CastExpression(Expression):
 
         import_pyarrow()
 
-        # Get shared_ptr of the function options to pass. This way we ensure
-        # that the options are kept alive.
+        # Make a copy of the CFunctionOptions to pass to the C++ side.
+        # This way there aren't issues when reusing the same Python cast options
+        # object for multiple CastExpressions.
         cdef shared_ptr[CFunctionOptions] c_opts = (<FunctionOptions> cast_opts).unwrap()
-
-        cdef CTypeHolder to_type_holder
-        if isinstance(cast_opts, pa.compute.CastOptions):
-            to_type_holder = deref(static_pointer_cast[CCastOptions, CFunctionOptions](c_opts)).to_type
-        elif isinstance(cast_opts, _BodoStringCastOptions):
-            to_type_holder = deref(static_pointer_cast[CBodoStringCastOptions, CFunctionOptions](c_opts)).to_type
-        else:
-            # We don't expect to get here after the validation in plan.py
-            raise TypeError("Unexpected type of cast_opts in CastExpression")
-        cdef shared_ptr[CDataType] to_type = to_type_holder.GetSharedPtr()
-
-        schema_type = out_schema.field(0).type
-        if to_type != NULL:
-            # This case is unlikely since we try our best to hide the to_type field
-            # from the Python cast options API. We want to use the empty_data
-            # type to serve as the target type.
-            if not deref(to_type).Equals((<DataType> schema_type).sp_type, False):
-                raise ValueError(f"to_type ({deref(to_type).ToString()}) in cast options does not match the schema type ({str(schema_type)})")
-        else:
-            # Standard case: store the target type from the schema in the cast options
-            cast_opts._set_type(schema_type)
+        cdef unique_ptr[CFunctionOptions] c_opts_copy = deref(c_opts).Copy()
 
         self.out_schema = out_schema
         self.c_expression = make_cast_expr(
             source_expr,
             out_schema,
-            <shared_ptr[const CFunctionOptions]> c_opts)
+            move(c_opts_copy))
 
     def __str__(self):
         return f"CastExpression({self.out_schema})"

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -22,8 +22,8 @@ import pyarrow as pa
 import bodo
 
 from pyarrow._compute cimport FunctionOptions
-from pyarrow.lib cimport DataType
-from pyarrow.includes.libarrow cimport CDataType, CFunctionOptions
+from pyarrow.lib cimport pyarrow_wrap_data_type, pyarrow_unwrap_data_type
+from pyarrow.includes.libarrow cimport CDataType, CFunctionOptions, CCastOptions
 
 from cpython.ref cimport PyObject
 ctypedef PyObject* PyObjectPtr
@@ -33,18 +33,8 @@ ctypedef pair[int, int] int_pair
 cdef extern from "<arrow/python/pyarrow.h>" namespace "arrow::py" nogil:
     int import_pyarrow()
 
-cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
-    cdef cppclass CCastOptions" arrow::compute::CastOptions"(CFunctionOptions):
-        # NOTE: Arrow's own CCastOptions defines to_type as shared_ptr[CDataType]
-        # instead of as TypeHolder which is how C++ CastOptions declares it.
-        # This discrepancy can lead to weird compilation issues where Cython
-        # expects one thing where C++ expects another, so we make a custom
-        # wrapper here to resolve this.
-        CTypeHolder to_type
-
 cdef extern from "arrow/type.h" namespace "arrow" nogil:
     cdef cppclass CTypeHolder "arrow::TypeHolder":
-        CTypeHolder() except +
         CTypeHolder(shared_ptr[CDataType]) except +
         shared_ptr[CDataType] GetSharedPtr() except +
 
@@ -53,6 +43,124 @@ cdef extern from "physical/expression.h" nogil:
         CBodoStringCastOptions() except +
         CTypeHolder to_type
         c_bool emit_null_on_failure
+
+cdef class _CastOptions(FunctionOptions):
+    """
+    _CastOptions is defined in arrow/python/pyarrow/_compute.pyx
+    but isn't declared in _compute.pxd, so we can't cimport it.
+    This makes it hard to write pickling logic, so our own version
+    of _CastOptions is below with some other modifications.
+    
+    Versus Arrow's _CastOptions, we don't define a _set_type()
+    method(). Our intention is that this wrapper class stores the
+    cast options aside from the target type, since our convention
+    is to use the schema type as the target type. Only on the C++
+    side is `to_type` filled in so that the CastOptions encapsulate
+    all the cast information.
+    """
+    cdef CCastOptions* options
+
+    def __init__(self):
+        cdef shared_ptr[CCastOptions] wrapped = make_shared[CCastOptions]()
+        FunctionOptions.init(self, <const shared_ptr[CFunctionOptions]> wrapped)
+        self.options = <CCastOptions*> self.wrapped.get()
+
+    def _set_safe(self):
+        self.init(shared_ptr[CFunctionOptions](
+            new CCastOptions(CCastOptions.Safe())))
+
+    def _set_unsafe(self):
+        self.init(shared_ptr[CFunctionOptions](
+            new CCastOptions(CCastOptions.Unsafe())))
+
+    def is_safe(self):
+        return not (deref(self.options).allow_int_overflow or
+                    deref(self.options).allow_time_truncate or
+                    deref(self.options).allow_time_overflow or
+                    deref(self.options).allow_decimal_truncate or
+                    deref(self.options).allow_float_truncate or
+                    deref(self.options).allow_invalid_utf8)
+
+    @property
+    def allow_int_overflow(self):
+        return deref(self.options).allow_int_overflow
+
+    @allow_int_overflow.setter
+    def allow_int_overflow(self, c_bool flag):
+        deref(self.options).allow_int_overflow = flag
+
+    @property
+    def allow_time_truncate(self):
+        return deref(self.options).allow_time_truncate
+
+    @allow_time_truncate.setter
+    def allow_time_truncate(self, c_bool flag):
+        deref(self.options).allow_time_truncate = flag
+
+    @property
+    def allow_time_overflow(self):
+        return deref(self.options).allow_time_overflow
+
+    @allow_time_overflow.setter
+    def allow_time_overflow(self, c_bool flag):
+        deref(self.options).allow_time_overflow = flag
+
+    @property
+    def allow_decimal_truncate(self):
+        return deref(self.options).allow_decimal_truncate
+
+    @allow_decimal_truncate.setter
+    def allow_decimal_truncate(self, c_bool flag):
+        deref(self.options).allow_decimal_truncate = flag
+
+    @property
+    def allow_float_truncate(self):
+        return deref(self.options).allow_float_truncate
+
+    @allow_float_truncate.setter
+    def allow_float_truncate(self, c_bool flag):
+        deref(self.options).allow_float_truncate = flag
+
+    @property
+    def allow_invalid_utf8(self):
+        return deref(self.options).allow_invalid_utf8
+
+    @allow_invalid_utf8.setter
+    def allow_invalid_utf8(self, c_bool flag):
+        deref(self.options).allow_invalid_utf8 = flag
+
+    def __reduce__(self):
+        state = self.__getstate__()
+        return (self.__class__, (), state)
+
+    # In the following code for pickling, we handle serializing
+    # to_type even though we never set it in Cython.
+
+    def __getstate__(self):
+        if self.options == NULL:
+            raise ValueError("CCastOptions pointer is unexpectedly NULL")
+        
+        # NOTE: Arrow's CCastOptions defines `to_type` as shared_ptr[CDataType]
+        # instead of as TypeHolder which is how C++ CastOptions declares it.
+        # To reconcile such that both the Cython and C++ builds pass, we wrap
+        # `to_type` in CTypeHolder which relies on TypeHolder having a copy
+        # constructor. Then we can get the actual CDataType.
+        cdef shared_ptr[CDataType] c_to_type = CTypeHolder(deref(self.options).to_type).GetSharedPtr()
+        py_to_type = pyarrow_wrap_data_type(c_to_type) if c_to_type.get() != NULL else None
+
+        serialized_dict = {"to_type": py_to_type}
+        for option_str in ["allow_int_overflow", "allow_time_truncate", "allow_time_overflow", "allow_decimal_truncate", "allow_float_truncate", "allow_invalid_utf8"]:
+            serialized_dict[option_str] = getattr(self, option_str, None)
+        return serialized_dict
+
+    def __setstate__(self, state):
+        self.__init__()
+        py_to_type = state["to_type"]
+        if py_to_type is not None:
+            deref(self.options).to_type = pyarrow_unwrap_data_type(py_to_type)
+        
+        for option_str in ["allow_int_overflow", "allow_time_truncate", "allow_time_overflow", "allow_decimal_truncate", "allow_float_truncate", "allow_invalid_utf8"]:
+            setattr(self, option_str, state[option_str])
 
 # The below structure is similar to how Arrow defines function options:
 # https://github.com/apache/arrow/blob/8e63098846b6216d76605bd627a2dd89615a5328/python/pyarrow/_compute.pyx#L680
@@ -65,10 +173,6 @@ cdef class _BodoStringCastOptions(FunctionOptions):
         FunctionOptions.init(self, <const shared_ptr[CFunctionOptions]> wrapped)
         self.options = <CBodoStringCastOptions*> self.wrapped.get()
 
-    def _set_type(self, target_type=None):
-        if target_type is not None:
-            deref(self.options).to_type = CTypeHolder((<DataType>target_type).sp_type)
-
     @property
     def emit_null_on_failure(self):
         return deref(self.options).emit_null_on_failure
@@ -76,6 +180,30 @@ cdef class _BodoStringCastOptions(FunctionOptions):
     @emit_null_on_failure.setter
     def emit_null_on_failure(self, c_bool flag):
         deref(self.options).emit_null_on_failure = flag
+
+    # In the following code for pickling, we handle serializing
+    # to_type even though we never set it in Cython.
+
+    def __reduce__(self):
+        state = self.__getstate__()
+        return (self.__class__, (), state)
+
+    def __getstate__(self):
+        if self.options == NULL:
+            raise ValueError("CBodoStringCastOptions pointer is unexpectedly NULL")
+        
+        cdef shared_ptr[CDataType] c_to_type = deref(self.options).to_type.GetSharedPtr()
+        py_to_type = pyarrow_wrap_data_type(c_to_type) if c_to_type.get() != NULL else None
+
+        serialized_dict = {"to_type": py_to_type, "emit_null_on_failure": self.emit_null_on_failure}
+        return serialized_dict
+
+    def __setstate__(self, state):
+        self.__init__()
+        py_to_type = state["to_type"]
+        if py_to_type is not None:
+            deref(self.options).to_type = CTypeHolder(pyarrow_unwrap_data_type(py_to_type))
+        self.emit_null_on_failure = state["emit_null_on_failure"]
 
 cdef extern from "duckdb/common/types.hpp" namespace "duckdb" nogil:
     cpdef enum class CLogicalTypeId "duckdb::LogicalTypeId":
@@ -418,7 +546,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_comparison_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_arithop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, c_string opstr, object out_schema) except +
     cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr, object out_schema) except +
-    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema, shared_ptr[const CFunctionOptions] cast_opts) except +
+    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema, unique_ptr[CFunctionOptions] cast_opts) except +
     cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_unary_expr(unique_ptr[CExpression] lhs, CExpressionType etype, object out_schema) except +
     cdef unique_ptr[CExpression] make_case_expr(unique_ptr[CExpression] when, unique_ptr[CExpression] then, unique_ptr[CExpression] else_) except +
@@ -1084,36 +1212,17 @@ cdef class CastExpression(Expression):
 
         import_pyarrow()
 
-        # Get shared_ptr of the function options to pass. This way we ensure
-        # that the options are kept alive.
+        # Make a copy of the CFunctionOptions to pass to the C++ side.
+        # This way there aren't issues when reusing the same Python cast options
+        # object for multiple CastExpressions.
         cdef shared_ptr[CFunctionOptions] c_opts = (<FunctionOptions> cast_opts).unwrap()
-
-        cdef CTypeHolder to_type_holder
-        if isinstance(cast_opts, pa.compute.CastOptions):
-            to_type_holder = deref(static_pointer_cast[CCastOptions, CFunctionOptions](c_opts)).to_type
-        elif isinstance(cast_opts, _BodoStringCastOptions):
-            to_type_holder = deref(static_pointer_cast[CBodoStringCastOptions, CFunctionOptions](c_opts)).to_type
-        else:
-            # We don't expect to get here after the validation in plan.py
-            raise TypeError("Unexpected type of cast_opts in CastExpression")
-        cdef shared_ptr[CDataType] to_type = to_type_holder.GetSharedPtr()
-
-        schema_type = out_schema.field(0).type
-        if to_type != NULL:
-            # This case is unlikely since we try our best to hide the to_type field
-            # from the Python cast options API. We want to use the empty_data
-            # type to serve as the target type.
-            if not deref(to_type).Equals((<DataType> schema_type).sp_type, False):
-                raise ValueError(f"to_type ({deref(to_type).ToString()}) in cast options does not match the schema type ({str(schema_type)})")
-        else:
-            # Standard case: store the target type from the schema in the cast options
-            cast_opts._set_type(schema_type)
+        cdef unique_ptr[CFunctionOptions] c_opts_copy = deref(c_opts).Copy()
 
         self.out_schema = out_schema
         self.c_expression = make_cast_expr(
             source_expr,
             out_schema,
-            <shared_ptr[const CFunctionOptions]> c_opts)
+            move(c_opts_copy))
 
     def __str__(self):
         return f"CastExpression({self.out_schema})"

--- a/bodo/pandas/plan_optimizer.pyx
+++ b/bodo/pandas/plan_optimizer.pyx
@@ -3,7 +3,8 @@
 # distutils: language = c++
 # cython: c_string_type=unicode, c_string_encoding=utf8
 
-from libcpp.memory cimport unique_ptr, make_unique, dynamic_pointer_cast
+from cython.operator cimport dereference as deref
+from libcpp.memory cimport shared_ptr, make_shared, unique_ptr, make_unique, static_pointer_cast, dynamic_pointer_cast
 from libcpp.utility cimport move, pair
 from libcpp.string cimport string as c_string
 from libcpp.vector cimport vector
@@ -21,10 +22,61 @@ import pyarrow as pa
 import bodo
 import decimal
 
+from pyarrow._compute cimport FunctionOptions
+from pyarrow.lib cimport DataType
+from pyarrow.includes.libarrow cimport CDataType, CFunctionOptions
+
 from cpython.ref cimport PyObject
 ctypedef PyObject* PyObjectPtr
 ctypedef unsigned long long idx_t
 ctypedef pair[int, int] int_pair
+
+cdef extern from "<arrow/python/pyarrow.h>" namespace "arrow::py" nogil:
+    int import_pyarrow()
+
+cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
+    cdef cppclass CCastOptions" arrow::compute::CastOptions"(CFunctionOptions):
+        # NOTE: Arrow's own CCastOptions defines to_type as shared_ptr[CDataType]
+        # instead of as TypeHolder which is how C++ CastOptions declares it.
+        # This discrepancy can lead to weird compilation issues where Cython
+        # expects one thing where C++ expects another, so we make a custom
+        # wrapper here to resolve this.
+        CTypeHolder to_type
+
+cdef extern from "arrow/type.h" namespace "arrow" nogil:
+    cdef cppclass CTypeHolder "arrow::TypeHolder":
+        CTypeHolder() except +
+        CTypeHolder(shared_ptr[CDataType]) except +
+        shared_ptr[CDataType] GetSharedPtr() except +
+
+cdef extern from "physical/expression.h" nogil:
+    cdef cppclass CBodoStringCastOptions "BodoStringCastOptions"(CFunctionOptions):
+        CBodoStringCastOptions() except +
+        CTypeHolder to_type
+        c_bool emit_null_on_failure
+
+# The below structure is similar to how Arrow defines function options:
+# https://github.com/apache/arrow/blob/8e63098846b6216d76605bd627a2dd89615a5328/python/pyarrow/_compute.pyx#L680
+
+cdef class _BodoStringCastOptions(FunctionOptions):
+    cdef CBodoStringCastOptions* options
+
+    def __init__(self):
+        cdef shared_ptr[CBodoStringCastOptions] wrapped = make_shared[CBodoStringCastOptions]()
+        FunctionOptions.init(self, <const shared_ptr[CFunctionOptions]> wrapped)
+        self.options = <CBodoStringCastOptions*> self.wrapped.get()
+
+    def _set_type(self, target_type=None):
+        if target_type is not None:
+            deref(self.options).to_type = CTypeHolder((<DataType>target_type).sp_type)
+
+    @property
+    def emit_null_on_failure(self):
+        return deref(self.options).emit_null_on_failure
+
+    @emit_null_on_failure.setter
+    def emit_null_on_failure(self, c_bool flag):
+        deref(self.options).emit_null_on_failure = flag
 
 cdef extern from "duckdb/common/types.hpp" namespace "duckdb" nogil:
     cpdef enum class CLogicalTypeId "duckdb::LogicalTypeId":
@@ -367,7 +419,7 @@ cdef extern from "_plan.h" nogil:
     cdef unique_ptr[CExpression] make_comparison_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_arithop_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, c_string opstr, object out_schema) except +
     cdef unique_ptr[CExpression] make_unaryop_expr(unique_ptr[CExpression] source, c_string opstr, object out_schema) except +
-    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema) except +
+    cdef unique_ptr[CExpression] make_cast_expr(unique_ptr[CExpression] source, object out_schema, shared_ptr[const CFunctionOptions] cast_opts) except +
     cdef unique_ptr[CExpression] make_conjunction_expr(unique_ptr[CExpression] lhs, unique_ptr[CExpression] rhs, CExpressionType etype) except +
     cdef unique_ptr[CExpression] make_unary_expr(unique_ptr[CExpression] lhs, CExpressionType etype, object out_schema) except +
     cdef unique_ptr[CExpression] make_case_expr(unique_ptr[CExpression] when, unique_ptr[CExpression] then, unique_ptr[CExpression] else_) except +
@@ -1026,15 +1078,46 @@ cdef class CastExpression(Expression):
     """Wrapper around DuckDB's BoundCastExpression to provide access in Python.
     """
 
-    def __cinit__(self, object out_schema, source):
+    def __cinit__(self, object out_schema, source, cast_opts):
         cdef unique_ptr[CExpression] source_expr
 
         source_expr = move((<Expression>source).c_expression) if isinstance(source, Expression) else move(make_const_expr(None, source))
 
+        # Get the function options object to forward to C++
+        # plan.py ensures that cast_opts is not None
+
+        import_pyarrow()
+
+        # Get shared_ptr of the function options to pass. This way we ensure
+        # that the options are kept alive.
+        cdef shared_ptr[CFunctionOptions] c_opts = (<FunctionOptions> cast_opts).unwrap()
+
+        cdef CTypeHolder to_type_holder
+        if isinstance(cast_opts, pa.compute.CastOptions):
+            to_type_holder = deref(static_pointer_cast[CCastOptions, CFunctionOptions](c_opts)).to_type
+        elif isinstance(cast_opts, _BodoStringCastOptions):
+            to_type_holder = deref(static_pointer_cast[CBodoStringCastOptions, CFunctionOptions](c_opts)).to_type
+        else:
+            # We don't expect to get here after the validation in plan.py
+            raise TypeError("Unexpected type of cast_opts in CastExpression")
+        cdef shared_ptr[CDataType] to_type = to_type_holder.GetSharedPtr()
+
+        schema_type = out_schema.field(0).type
+        if to_type != NULL:
+            # This case is unlikely since we try our best to hide the to_type field
+            # from the Python cast options API. We want to use the empty_data
+            # type to serve as the target type.
+            if not deref(to_type).Equals((<DataType> schema_type).sp_type, False):
+                raise ValueError(f"to_type ({deref(to_type).ToString()}) in cast options does not match the schema type ({str(schema_type)})")
+        else:
+            # Standard case: store the target type from the schema in the cast options
+            cast_opts._set_type(schema_type)
+
         self.out_schema = out_schema
         self.c_expression = make_cast_expr(
             source_expr,
-            out_schema)
+            out_schema,
+            <shared_ptr[const CFunctionOptions]> c_opts)
 
     def __str__(self):
         return f"CastExpression({self.out_schema})"

--- a/bodo/pandas/vendor/duckdb/src/function/cast/default_casts.cpp
+++ b/bodo/pandas/vendor/duckdb/src/function/cast/default_casts.cpp
@@ -19,14 +19,14 @@ BindCastInfo::~BindCastInfo() {
 BoundCastData::~BoundCastData() {
 }
 
-// Bodo change: added arrow_type
+// Bodo change: added arrow_cast_opts
 BoundCastInfo::BoundCastInfo(cast_function_t function_p, unique_ptr<BoundCastData> cast_data_p,
-                             init_cast_local_state_t init_local_state_p, std::shared_ptr<arrow::DataType> arrow_type)
-    : function(function_p), init_local_state(init_local_state_p), cast_data(std::move(cast_data_p)), arrow_type(arrow_type) {
+                             init_cast_local_state_t init_local_state_p, std::shared_ptr<const arrow::compute::FunctionOptions> arrow_cast_opts)
+    : function(function_p), init_local_state(init_local_state_p), cast_data(std::move(cast_data_p)), arrow_cast_opts(arrow_cast_opts) {
 }
 
 BoundCastInfo BoundCastInfo::Copy() const {
-	return BoundCastInfo(function, cast_data ? cast_data->Copy() : nullptr, init_local_state, arrow_type);
+	return BoundCastInfo(function, cast_data ? cast_data->Copy() : nullptr, init_local_state, arrow_cast_opts);
 }
 
 bool DefaultCasts::NopCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {

--- a/bodo/pandas/vendor/duckdb/src/include/duckdb/function/cast/default_casts.hpp
+++ b/bodo/pandas/vendor/duckdb/src/include/duckdb/function/cast/default_casts.hpp
@@ -14,8 +14,8 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/function/scalar_function.hpp"
 
-namespace arrow {
-class DataType;
+namespace arrow::compute {
+class FunctionOptions;
 }
 
 namespace duckdb {
@@ -114,14 +114,15 @@ struct BoundCastInfo {
 	DUCKDB_API
 	BoundCastInfo( // NOLINT: allow explicit cast from cast_function_t
 	    cast_function_t function, unique_ptr<BoundCastData> cast_data = nullptr,
-		// Bodo change: added arrow_type
-	    init_cast_local_state_t init_local_state = nullptr, std::shared_ptr<arrow::DataType> arrow_type = nullptr);
+		// Bodo change: added arrow_cast_opts
+	    init_cast_local_state_t init_local_state = nullptr, std::shared_ptr<const arrow::compute::FunctionOptions> arrow_cast_opts = nullptr);
 	cast_function_t function;
 	init_cast_local_state_t init_local_state;
 	unique_ptr<BoundCastData> cast_data;
 
-	// Bodo change: add a pointer to the target Arrow type (DuckDB's types lose information e.g. interval precision)
-	std::shared_ptr<arrow::DataType> arrow_type = nullptr;  // Pointer to the target Arrow type (filled by Bodo)
+	// Bodo change: add a pointer to the Arrow FunctionOptions for the cast (either CastOptions or BodoStringCastOptions).
+	// The cast options include the target Arrow type (DuckDB's types lose information e.g. interval precision)
+	std::shared_ptr<const arrow::compute::FunctionOptions> arrow_cast_opts = nullptr;
 
 public:
 	BoundCastInfo Copy() const;


### PR DESCRIPTION
## Changes included in this PR

We now pass a cast options object (`CastOptions` or `BodoStringCastOptions`) through `CastExpression`, which controls which cast function should be called ("cast" or "bodo_string_cast"). This also exposes cast options like `allow_int_overflow` and `allow_float_truncate` to Python that we were applying unilaterally because we had no way to selectively enable them for the few cases where we actually needed them. I've kept those as defaults for now so I don't accidentally break things that were relying on them, but ideally they would be off unless specifically enabled to avoid silent correctness errors where int overflow or float truncation are not expected.

## Testing strategy

Tested locally for try-casting. The plan conversions for that aren't in this PR. Since all `CastExpression`s now go through this code path, I'll run Nightly to make sure nothing accidentally broke.

## User facing changes

The new `CastExpression` API should be backwards compatible with the existing syntax where cast options are not explicitly passed. If cast options are passed, the class symbolizes which cast function should be called, and also contains options for that cast function.

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.