### PR TITLE
Fix int literal conversion in Iceberg isin filter

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -5350,6 +5350,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
             bool_empty_data = pd.Series(dtype=pd.ArrowDtype(pa.bool_()))
             sarg = search_expr.value
             nullAs = _get_sarg_null_as(sarg)
+            s_typename = operands[1].getType().getSqlTypeName()
 
             def process_one_search_option(lower, lower_incl, upper, upper_incl):
                 """Generate an expression to check if src satisfies this
@@ -5415,7 +5416,7 @@ def java_call_to_python_call(ctx, java_call, input_plan):
 
                 return in_range
 
-            search_options = list(iter_sarg_ranges(sarg))
+            search_options = list(iter_sarg_ranges(sarg, s_typename))
             out_expr = process_one_search_option(*search_options[0])
             # The definition of search is that the value is one of the
             # possibilities in the range set.  so, "or" in the other

--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -7125,13 +7125,14 @@ def java_search_to_pyiceberg_expr(java_call, field_names):
 
     operands = java_call.getOperands()
     ref = java_expr_to_pyiceberg_expr(operands[0], field_names)
+    s_typename = operands[1].getType().getSqlTypeName()
     sarg = operands[1].getValue()
     null_as = _get_sarg_null_as(sarg)
 
     # Collect each range as a Python value (point) or a comparison pair (range).
     points = []
     range_exprs = []
-    for lower, lower_incl, upper, upper_incl in iter_sarg_ranges(sarg):
+    for lower, lower_incl, upper, upper_incl in iter_sarg_ranges(sarg, s_typename):
         if (
             lower is not None
             and upper is not None
@@ -7179,14 +7180,24 @@ def java_search_to_pyiceberg_expr(java_call, field_names):
     return expr
 
 
-def _sarg_endpoint_to_python(endpoint):
+def _sarg_endpoint_to_python(endpoint, s_typename):
     """Convert a Java Sarg range endpoint (e.g. NlsString, BigDecimal) to a
     Python value."""
+    SqlTypeName = gateway.jvm.org.apache.calcite.sql.type.SqlTypeName
+
     if isinstance(endpoint, py4j.java_gateway.JavaObject):
         # NlsString and other Calcite literal wrappers expose getValue()
         return endpoint.getValue()
     if isinstance(endpoint, decimal.Decimal):
-        return float(endpoint)
+        if (
+            s_typename.equals(SqlTypeName.TINYINT)
+            or s_typename.equals(SqlTypeName.SMALLINT)
+            or s_typename.equals(SqlTypeName.INTEGER)
+            or s_typename.equals(SqlTypeName.BIGINT)
+        ):
+            return int(endpoint)
+        else:
+            return float(endpoint)
     return endpoint
 
 
@@ -7195,7 +7206,7 @@ def _get_sarg_null_as(sarg):
     return sarg.getClass().getDeclaredField("nullAs").get(sarg).toString()
 
 
-def iter_sarg_ranges(sarg):
+def iter_sarg_ranges(sarg, s_typename):
     """Iterate over the ranges in a Calcite Sarg's range set, yielding
     ``(lower, lower_inclusive, upper, upper_inclusive)`` tuples with
     Python-typed endpoints.
@@ -7212,9 +7223,13 @@ def iter_sarg_ranges(sarg):
         has_lower = r.hasLowerBound()
         has_upper = r.hasUpperBound()
         yield (
-            _sarg_endpoint_to_python(r.lowerEndpoint()) if has_lower else None,
+            _sarg_endpoint_to_python(r.lowerEndpoint(), s_typename)
+            if has_lower
+            else None,
             r.lowerBoundType().toString() == "CLOSED" if has_lower else False,
-            _sarg_endpoint_to_python(r.upperEndpoint()) if has_upper else None,
+            _sarg_endpoint_to_python(r.upperEndpoint(), s_typename)
+            if has_upper
+            else None,
             r.upperBoundType().toString() == "CLOSED" if has_upper else False,
         )
 


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Fixes TPC-H Q16 with Iceberg data when this branch is merged with `todd/iceberg_tpch_fixes3`. Merging to main to simplify reviews.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Will enable q16 once all branches are merged.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.