### PR TITLE
[GPU] Run CTE before first CTE reference

### DIFF
--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -895,43 +895,15 @@ void PhysicalPlanBuilder::Visit(bodo::LogicalJoinFilter& op) {
 }
 
 void PhysicalPlanBuilder::Visit(duckdb::LogicalMaterializedCTE& op) {
-    // Create pipelines for the duplicate side of the CTE.
-    this->Visit(*op.children[0]);
-    std::shared_ptr<bodo::Schema> in_table_schema =
-        this->active_pipeline->getPrevOpOutputSchema();
-    std::shared_ptr<Pipeline> done_pipeline;
-#ifdef USE_CUDF
-    std::variant<std::shared_ptr<PhysicalCTE>, std::shared_ptr<PhysicalGPUCTE>>
-        physical_cte;
+    // Store the LogicalCTE node in the global structure so that CTERef's on the
+    // non-duplicate side can find it.
+    // The physical node and pipeline root will be filled in
+    // the first time the CTE is referenced and reused afterwards.
+    ctes.insert({op.table_index,
+                 {.physical_node = nullptr,
+                  .cte_pipeline_root = nullptr,
+                  .cte_logical_node = op}});
 
-    if (node_run_on_gpu(op)) {
-        physical_cte = std::make_shared<PhysicalGPUCTE>(in_table_schema);
-    } else {
-        physical_cte = std::make_shared<PhysicalCTE>(in_table_schema);
-    }
-
-    std::visit(
-        [&](auto& vop) {
-            done_pipeline = this->active_pipeline->Build(vop);
-            ctes.insert(
-                {op.table_index,
-                 {.physical_node = vop, .cte_pipeline_root = done_pipeline}});
-        },
-        physical_cte);
-#else   // USE_CUDF
-    std::shared_ptr<PhysicalCTE> physical_cte =
-        std::make_shared<PhysicalCTE>(in_table_schema);
-    done_pipeline = this->active_pipeline->Build(physical_cte);
-    // Save the physical_cte node away so that cte ref's on the non-duplicate
-    // side can find it.
-    ctes.insert(
-        {op.table_index,
-         {.physical_node = physical_cte, .cte_pipeline_root = done_pipeline}});
-#endif  // USE_CUDF
-
-    // The active pipeline finishes after the duplicate side.
-    this->active_pipeline = nullptr;
-    // Create pipelines for the side that uses the duplicate side.
     this->Visit(*op.children[1]);
 }
 
@@ -944,6 +916,39 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalCTERef& op) {
             "LogicalCTERef couldn't find matching table_index.");
     }
     CTEInfo& cte_index_info = table_index_iter->second;
+
+    if (cte_index_info.physical_node == nullptr) {
+        this->Visit(*cte_index_info.cte_logical_node.children[0]);
+        std::shared_ptr<bodo::Schema> in_table_schema =
+            this->active_pipeline->getPrevOpOutputSchema();
+        std::shared_ptr<Pipeline> done_pipeline;
+#ifdef USE_CUDF
+        std::variant<std::shared_ptr<PhysicalCTE>,
+                     std::shared_ptr<PhysicalGPUCTE>>
+            physical_cte;
+
+        if (node_run_on_gpu(cte_index_info.cte_logical_node)) {
+            physical_cte = std::make_shared<PhysicalGPUCTE>(in_table_schema);
+        } else {
+            physical_cte = std::make_shared<PhysicalCTE>(in_table_schema);
+        }
+
+        std::visit(
+            [&](auto& vop) {
+                done_pipeline = this->active_pipeline->Build(vop);
+                cte_index_info.physical_node = vop;
+                cte_index_info.cte_pipeline_root = done_pipeline;
+            },
+            physical_cte);
+#else   // USE_CUDF
+        std::shared_ptr<PhysicalCTE> physical_cte =
+            std::make_shared<PhysicalCTE>(in_table_schema);
+        done_pipeline = this->active_pipeline->Build(physical_cte);
+        cte_index_info.physical_node = physical_cte;
+        cte_index_info.cte_pipeline_root = done_pipeline;
+#endif  // USE_CUDF
+    }
+
 #ifdef USE_CUDF
     std::variant<std::shared_ptr<PhysicalCTERef>,
                  std::shared_ptr<PhysicalGPUCTERef>>

--- a/bodo/pandas/_physical_conv.cpp
+++ b/bodo/pandas/_physical_conv.cpp
@@ -900,9 +900,7 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalMaterializedCTE& op) {
     // The physical node and pipeline root will be filled in
     // the first time the CTE is referenced and reused afterwards.
     ctes.insert({op.table_index,
-                 {.physical_node = nullptr,
-                  .cte_pipeline_root = nullptr,
-                  .cte_logical_node = op}});
+                 {.cte_pipeline_root = nullptr, .cte_logical_node = op}});
 
     this->Visit(*op.children[1]);
 }
@@ -917,7 +915,7 @@ void PhysicalPlanBuilder::Visit(duckdb::LogicalCTERef& op) {
     }
     CTEInfo& cte_index_info = table_index_iter->second;
 
-    if (cte_index_info.physical_node == nullptr) {
+    if (cte_index_info.cte_pipeline_root == nullptr) {
         this->Visit(*cte_index_info.cte_logical_node.children[0]);
         std::shared_ptr<bodo::Schema> in_table_schema =
             this->active_pipeline->getPrevOpOutputSchema();

--- a/bodo/pandas/_physical_conv.h
+++ b/bodo/pandas/_physical_conv.h
@@ -24,6 +24,7 @@ struct CTEInfo {
     std::shared_ptr<PhysicalCTE> physical_node;
 #endif  // USE_CUDF
     std::shared_ptr<Pipeline> cte_pipeline_root;
+    duckdb::LogicalMaterializedCTE& cte_logical_node;
 };
 
 class PhysicalPlanBuilder {


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
Fixes error in TPC-H Q21 with Iceberg data. Cached sub-trees cannot be evaluated ahead of time because join filters (and other kinds of "sideways information passing") require the build side to be evaluated first. Therefore, this PR evaluates the CTE cached subtree right before the first CTE reference, which matches the JIT backend.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Fixes the query.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
Bug fix.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.