### PR TITLE
[GPU] Fix BodoSQL GPU env initialization

### DIFF
--- a/BodoSQL/bodosql/__init__.py
+++ b/BodoSQL/bodosql/__init__.py
@@ -1,5 +1,9 @@
 import os
 
+# Import bodo first to ensure bodo initialization is done before any other imports
+# (e.g. setting OMPI_MCA_pml in the GPU case)
+import bodo  # isort:skip # noqa #
+
 from bodosql.context import BodoSQLContext
 
 from bodosql.bodosql_types.table_path import TablePath

--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -189,8 +189,10 @@ sql_plan_cache_loc = os.environ.get("BODO_SQL_PLAN_CACHE_DIR")
 
 try:
     from ._build_config import DEFAULT_GPU_ENABLED
+    gpu_build = 1
 except ImportError:
     DEFAULT_GPU_ENABLED = "0"
+    gpu_build = 0
 
 # Flag to enable Bodo to use GPUs when available.
 gpu_enabled = os.environ.get("BODO_GPU", DEFAULT_GPU_ENABLED) != "0"
@@ -283,7 +285,7 @@ os.environ["OPENBLAS_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 
-if gpu_enabled:
+if gpu_build or gpu_enabled:
     os.environ["OMPI_MCA_pml"] = "ucx"
 
 # NOTE: 'pandas_compat' has to be imported first in bodo package to make sure all Numba


### PR DESCRIPTION
Fixes scatterv hang in GPU builds. BODO_GPU is on by default in GPU builds so no other action is required to avoid user errors:
https://github.com/bodo-ai/Bodo/blob/f5dddc6976e4fe27cc261b66aab9c3dd7fad69f7/buildscripts/bodo/conda-recipe/build.sh#L21