### PR TITLE
[BSE-5565][GPU] Make cached subplans more robust in C++ backend

### DIFF
--- a/BodoSQL/bodosql/context.py
+++ b/BodoSQL/bodosql/context.py
@@ -727,6 +727,7 @@ class BodoSQLContext:
             # Keeps track of join ids and their join filter key locations for join
             # filter translation during conversion to Python plan.
             self.join_filter_info = {}
+            self.subplan_cache = {}
             # Temporarily monkey-patch so java_plan_to_python_plan
             # can see dynamic and named params.
             self.named_params_dict = (java_named_params_map, named_params_dict)

--- a/bodo/pandas/_util.cpp
+++ b/bodo/pandas/_util.cpp
@@ -1429,7 +1429,7 @@ JoinFilterColStats::col_stats_collector::collect_min_max() const {
     return std::visit(
         [&](const auto &join_state)
             -> std::optional<JoinFilterColStats::col_min_max_t> {
-            using T = std::decay_t<decltype(join_state)>;
+            using T = std::decay_t<decltype(join_state.get())>;
             if constexpr (std::is_same_v<T, JoinState *>) {
                 std::unique_ptr<bodo::DataType> dt =
                     join_state->build_table_schema->column_types[build_key_col]

--- a/bodo/pandas/_util.h
+++ b/bodo/pandas/_util.h
@@ -409,9 +409,10 @@ arrow::Type::type GetArrowTypeOfRes(std::shared_ptr<ExprResult> res);
 arrow::Type::type GetArrowTypeOfRes(arrow::Datum res);
 
 #ifdef USE_CUDF
-using join_state_t = std::variant<JoinState *, CudaJoin *>;
+using join_state_t =
+    std::variant<std::shared_ptr<JoinState>, std::shared_ptr<CudaJoin>>;
 #else
-using join_state_t = std::variant<JoinState *>;
+using join_state_t = std::variant<std::shared_ptr<JoinState>>;
 #endif
 /**
  * @brief Collect min/max statistics from join build tables for join filter

--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -125,7 +125,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
         this->initOutputSchema(build_table_schema, probe_table_schema,
                                build_kept_cols, probe_kept_cols, false, false);
         // We use duckdb::JoinType::INVALID to mark cross join
-        this->cuda_join = std::make_unique<CudaNonEquiJoin>(
+        this->cuda_join = std::make_shared<CudaNonEquiJoin>(
             build_table_schema, probe_table_schema, build_kept_cols,
             probe_kept_cols, output_schema, duckdb::JoinType::INVALID, nullptr,
             true);
@@ -286,12 +286,12 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
                                build_table_outer, probe_table_outer);
 
         if (build_keys.empty()) {
-            this->cuda_join = std::make_unique<CudaNonEquiJoin>(
+            this->cuda_join = std::make_shared<CudaNonEquiJoin>(
                 build_table_schema, probe_table_schema, build_kept_cols,
                 probe_kept_cols, output_schema, logical_join.join_type,
                 std::move(physExprTree), is_broadcast_join);
         } else {
-            this->cuda_join = std::make_unique<CudaHashJoin>(
+            this->cuda_join = std::make_shared<CudaHashJoin>(
                 build_keys, probe_keys, build_table_schema, probe_table_schema,
                 build_kept_cols, probe_kept_cols, output_schema,
                 logical_join.join_type, std::move(physExprTree),

--- a/bodo/pandas/physical/gpu_join.h
+++ b/bodo/pandas/physical/gpu_join.h
@@ -457,7 +457,7 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
 
     int64_t getOpId() const { return PhysicalGPUSink::getOpId(); }
 
-    CudaJoin* getJoinStatePtr() { return this->cuda_join.get(); }
+    std::shared_ptr<CudaJoin> getJoinStatePtr() { return this->cuda_join; }
 
    private:
     std::shared_ptr<bodo::Schema> output_schema;
@@ -468,6 +468,6 @@ class PhysicalGPUJoin : public PhysicalGPUProcessBatch, public PhysicalGPUSink {
 
     PhysicalGPUJoinMetrics metrics;
 
-    std::unique_ptr<CudaJoin> cuda_join;
+    std::shared_ptr<CudaJoin> cuda_join;
     bool is_broadcast_join = false;
 };

--- a/bodo/pandas/physical/join.h
+++ b/bodo/pandas/physical/join.h
@@ -654,7 +654,7 @@ class PhysicalJoin : public PhysicalProcessBatch, public PhysicalSink {
     /**
      * @brief Get pointer to JoinState used in join filters
      */
-    JoinState* getJoinStatePtr() const { return join_state_.get(); }
+    std::shared_ptr<JoinState> getJoinStatePtr() const { return join_state_; }
 
    private:
     /**


### PR DESCRIPTION
## Changes included in this PR

* `join_state_map` now stores a shared_ptr to a `join_state` instead of the raw pointer to ensure the join state does not get freed before the filter is used. This is mainly done for robustness; ideally this scenario should never happen but it currently can happen when a join filter occurs inside a cached node that does not later get turned into a CTE. 

* Reset subplan cache after each plan execution in `BodoSQLContext` to avoid getting a cached subplan from previous plan executions. 

## Testing strategy
CI , defog Iceberg queries. 

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.