### PR TITLE
Fix gpu_build detection in mac environments

### DIFF
--- a/bodo/__init__.py
+++ b/bodo/__init__.py
@@ -189,10 +189,9 @@ sql_plan_cache_loc = os.environ.get("BODO_SQL_PLAN_CACHE_DIR")
 
 try:
     from ._build_config import DEFAULT_GPU_ENABLED
-    gpu_build = 1
 except ImportError:
     DEFAULT_GPU_ENABLED = "0"
-    gpu_build = 0
+gpu_build = DEFAULT_GPU_ENABLED != "0"
 
 # Flag to enable Bodo to use GPUs when available.
 gpu_enabled = os.environ.get("BODO_GPU", DEFAULT_GPU_ENABLED) != "0"


### PR DESCRIPTION
## Changes included in this PR

As titled, the _build_config file is generated in GPU and non-GPU build but with different values of DEFAULT_GPU_ENABLED

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.