### PR TITLE
Create Info for MPI_Spawn based on mpi implementation.

### DIFF
--- a/bodo/spawn/spawner.py
+++ b/bodo/spawn/spawner.py
@@ -167,7 +167,11 @@ class Spawner:
             command, args = self._get_spawn_command_args()
 
             # We need to tell OpenMPI to create ranks on other nodes
-            mpi_info = MPI.Info.Create({"map_by": "node"})
+            mpi_info = (
+                MPI.Info.Create({"map_by": "node"})
+                if MPI.get_vendor()[0] == "Open MPI"
+                else MPI.INFO_NULL
+            )
 
             # run python with -u to prevent STDOUT from buffering
             self.worker_intercomm = self.comm_world.Spawn(


### PR DESCRIPTION
## Changes included in this PR

Fixes an error when running with srun: 
```
srun: error: mpi/pmi2: unknown spawn info key 'map_by' ignored
srun: error: ip-10-30-2-170: task 0: Segmentation fault (core dumped)
srun: launch/slurm: _step_signal: Terminating StepId=1.0
srun: forcing job termination
```

`map_by` is only used when MPI implementation is Open MPI. 

## Testing strategy

Tested on the platform. Confirmed running a job now works.  

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.