### PR TITLE
Redirect stdout/err to os.devnull when running jupyter on the platform

### DIFF
--- a/BodoSQL/bodosql/py4j_gateway.py
+++ b/BodoSQL/bodosql/py4j_gateway.py
@@ -84,7 +84,10 @@ def get_gateway():
 
             # Jupyter does not support writing to stderr
             # https://discourse.jupyter.org/t/how-to-know-from-python-script-if-we-are-in-jupyterlab/23993/4
-            if bodo.spawn.utils.is_jupyter_on_windows():
+            if (
+                bodo.spawn.utils.is_jupyter_on_windows()
+                or bodo.spawn.utils.is_jupyter_on_bodo_platform()
+            ):
                 out_fd = None
                 err_fd = None
 


### PR DESCRIPTION
## Changes included in this PR

When running BodoSQL (JIT) inside a notebook, an error would occur when importing the compiler on workers during C++ backend fallback:

```
Exception: Error when launching the BodoSQL JVM. 'StdoutQueue' object has no attribute 'fileno'
```

We had to make a similar change for Windows. 

## Testing strategy

Confirmed notebooks worked after changes.

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.