### PR TITLE
More tpch iceberg fixes.

### DIFF
--- a/BodoSQL/bodosql/plan_conversion.py
+++ b/BodoSQL/bodosql/plan_conversion.py
@@ -5650,8 +5650,10 @@ def get_binop_output_type(left, right, non_decimal_func, decimal_func):
     return bd.utils.get_binop_output_type(
         left_empty,
         left_atype,
+        left,
         right_empty,
         right_atype,
+        right,
         non_decimal_func,
         decimal_func,
     )

--- a/bodo/libs/_decimal_ext.cpp
+++ b/bodo/libs/_decimal_ext.cpp
@@ -3273,6 +3273,30 @@ std::shared_ptr<arrow::Scalar> arrow_scalar_decimal_arithmetic(
     return std::make_shared<arrow::Decimal128Scalar>(result128, dtype);
 }
 
+template <auto Op>
+std::shared_ptr<arrow::Scalar> arrow_scalar_boolean_op(
+    std::shared_ptr<arrow::Decimal128Scalar> left_scalar, int left_precision,
+    int left_scale, std::shared_ptr<arrow::Decimal128Scalar> right_scalar,
+    int right_precision, int right_scale, int result_precision,
+    int result_scale) {
+    arrow::Status status;
+    bool overflow = false;
+
+    auto dtype = std::make_shared<arrow::BooleanType>();
+    if (!left_scalar->is_valid || !right_scalar->is_valid) {
+        return arrow::MakeNullScalar(dtype);
+    }
+
+    arrow::Decimal128 left_val = left_scalar->value;
+    arrow::Decimal128 right_val = right_scalar->value;
+
+    bool result = compare_decimal_scalars_util<Op>(
+        left_val, left_precision, left_scale, right_val, right_precision,
+        right_scale, result_precision, result_scale, &overflow);
+
+    return arrow::MakeScalar(result);
+}
+
 std::shared_ptr<arrow::Scalar> arrow_scalar_decimal_arithmetic_util(
     std::shared_ptr<arrow::Decimal128Scalar> left_val, int left_precision,
     int left_scale, std::shared_ptr<arrow::Decimal128Scalar> right_val,
@@ -3292,6 +3316,30 @@ std::shared_ptr<arrow::Scalar> arrow_scalar_decimal_arithmetic_util(
             right_scale, result_precision, result_scale);
     } else if (op == "divide") {
         return arrow_scalar_decimal_arithmetic<"divide">(
+            left_val, left_precision, left_scale, right_val, right_precision,
+            right_scale, result_precision, result_scale);
+    } else if (op == "equal") {
+        return arrow_scalar_boolean_op<std::equal_to<>{}>(
+            left_val, left_precision, left_scale, right_val, right_precision,
+            right_scale, result_precision, result_scale);
+    } else if (op == "not_equal") {
+        return arrow_scalar_boolean_op<std::not_equal_to<>{}>(
+            left_val, left_precision, left_scale, right_val, right_precision,
+            right_scale, result_precision, result_scale);
+    } else if (op == "less") {
+        return arrow_scalar_boolean_op<std::less<>{}>(
+            left_val, left_precision, left_scale, right_val, right_precision,
+            right_scale, result_precision, result_scale);
+    } else if (op == "greater") {
+        return arrow_scalar_boolean_op<std::greater<>{}>(
+            left_val, left_precision, left_scale, right_val, right_precision,
+            right_scale, result_precision, result_scale);
+    } else if (op == "less_equal") {
+        return arrow_scalar_boolean_op<std::less_equal<>{}>(
+            left_val, left_precision, left_scale, right_val, right_precision,
+            right_scale, result_precision, result_scale);
+    } else if (op == "greater_equal") {
+        return arrow_scalar_boolean_op<std::greater_equal<>{}>(
             left_val, left_precision, left_scale, right_val, right_precision,
             right_scale, result_precision, result_scale);
     } else {

--- a/bodo/pandas/series.py
+++ b/bodo/pandas/series.py
@@ -432,7 +432,9 @@ class BodoSeries(pd.Series, BodoLazyWrapper):
                         None,  # not needed if guaranteed decimal
                         left_atype,
                         None,  # not needed if guaranteed decimal
+                        None,  # not needed if guaranteed decimal
                         right_atype,
+                        None,  # not needed if guaranteed decimal
                         None,
                         decimal_precision_scale_func,
                     )

--- a/bodo/pandas/utils.py
+++ b/bodo/pandas/utils.py
@@ -8,6 +8,7 @@ import time
 import types as pytypes
 import typing as pt
 import warnings
+from decimal import Decimal
 
 import numpy as np
 import pandas as pd
@@ -1708,7 +1709,27 @@ PANDAS_ARROW_TYPE_MAP = {
 }
 
 
-def to_decimal_type(atype):
+def float_to_precision_scale(x):
+    # Convert through Decimal(str(x)) to avoid binary float artifacts
+    d = Decimal(str(x))
+    tup = d.as_tuple()
+
+    digits = tup.digits
+    exponent = tup.exponent  # negative exponent → digits after decimal
+
+    if exponent >= 0:
+        # No fractional part
+        scale = 0
+        precision = len(digits) + exponent
+    else:
+        # Fractional part exists
+        scale = -exponent
+        precision = len(digits)
+
+    return precision, scale
+
+
+def to_decimal_type(atype, val):
     """Converts Arrow type to equivalent Arrow decimal type
     (currently only supports integer types)
     """
@@ -1728,6 +1749,11 @@ def to_decimal_type(atype):
         return pa.decimal128(5, 0)
     elif pa.types.is_uint8(atype):
         return pa.decimal128(3, 0)
+    elif pa.types.is_float64(atype):
+        if isinstance(val, bodo.pandas.plan.ConstantExpression):
+            return pa.decimal128(*float_to_precision_scale(val.value))
+        else:
+            raise TypeError(f"No decimal conversion from double {type(val)} yet")
     else:
         raise TypeError(f"No decimal conversion from {atype} yet")
 
@@ -1735,8 +1761,10 @@ def to_decimal_type(atype):
 def get_binop_output_type(
     left_empty,
     left_atype,
+    left,
     right_empty,
     right_atype,
+    right,
     non_decimal_func,
     decimal_func,
 ):
@@ -1755,9 +1783,9 @@ def get_binop_output_type(
     """
     if pa.types.is_decimal(left_atype) or pa.types.is_decimal(right_atype):
         if not pa.types.is_decimal(left_atype):
-            left_atype = to_decimal_type(left_atype)
+            left_atype = to_decimal_type(left_atype, left)
         if not pa.types.is_decimal(right_atype):
-            right_atype = to_decimal_type(right_atype)
+            right_atype = to_decimal_type(right_atype, right)
         output_precision, output_scale = decimal_func(
             left_atype.precision,
             left_atype.scale,


### PR DESCRIPTION
## Changes included in this PR

We previously had decimal arrow array paths for arithmetic ops and comparison ops and arrow scalar paths for arithmetic ops.  This PR adds arrow scalar support for comparison ops.
Support constant doubles converted to minimum decimal size.

## Testing strategy

run_ci

## User facing changes

None

## Checklist
- [X] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [X] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [X] I have installed + ran pre-commit hooks.