### PR TITLE
[BSE-5555] Add equivalent of not null constraint for Iceberg TPCH data

### DIFF
--- a/benchmarks/tpch/generate_data_iceberg.py
+++ b/benchmarks/tpch/generate_data_iceberg.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import duckdb
+import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 from pyiceberg.catalog import WAREHOUSE_LOCATION
@@ -136,10 +137,25 @@ def create_iceberg_tables(parquet_path: str, iceberg_path: str, sf: int):
         dataset = ds.dataset(table_dir, format="parquet")
         schema = dataset.schema
 
+        # Duckdb TPCH extension includes a NOT NULL constraint on all columns,
+        # which gets dropped when copying to Parquet.
+        required_schema = pa.schema(
+            [
+                pa.field(
+                    field.name,
+                    field.type,
+                    nullable=False,
+                    metadata=field.metadata,
+                )
+                for field in schema
+            ],
+            metadata=schema.metadata,
+        )
+
         # Uses large write threshold so number of files matches parquet dataset
         iceberg_table = catalog.create_table(
             table.upper(),
-            schema,
+            required_schema,
             properties={
                 "write.target-file-size-bytes": str(100 * 1024**3),  # 100 GiB
             },
@@ -150,6 +166,10 @@ def create_iceberg_tables(parquet_path: str, iceberg_path: str, sf: int):
             desc=f"Copying {table.upper()} to Iceberg: ",
         ):
             table_fragment = pq.read_table(pq_file)
+            table_fragment = pa.Table.from_arrays(
+                table_fragment.columns,
+                schema=required_schema,
+            )
             iceberg_table.append(table_fragment)
 
 


### PR DESCRIPTION
## Changes included in this PR

DuckDB's "NOT NULL" constraints get dropped when copying to Parquet, which leads to Iceberg metadata having required: false. 

## Testing strategy

Ran script and confirmed Iceberg metadata had required: true after changes. 

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.