### PR TITLE
[BSE-5568] Enable Predicate Metadata Pullup for Rel Subets

### DIFF
--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
@@ -17,8 +17,6 @@ package com.bodosql.calcite.application.logicalRules;
  * limitations under the License.
  */
 
-import static com.bodosql.calcite.application.logicalRules.FilterRulesCommon.rexNodeContainsCase;
-
 import com.bodosql.calcite.application.utils.BodoSQLStyleImmutable;
 import com.bodosql.calcite.application.utils.RexNormalizer;
 import com.bodosql.calcite.rel.logical.BodoLogicalProject;
@@ -115,10 +113,6 @@ public abstract class BodoSQLReduceExpressionsRule<C extends BodoSQLReduceExpres
     @Override
     public void onMatch(RelOptRuleCall call) {
       final Filter filter = call.rel(0);
-      // Bodo Change: Do not reduce filters that contain Case statements.
-      if (rexNodeContainsCase(filter.getCondition())) {
-        return;
-      }
       final List<RexNode> expList = Lists.newArrayList(filter.getCondition());
       RexNode newConditionExp;
       boolean reduced;

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
@@ -294,24 +294,12 @@ public abstract class BodoSQLReduceExpressionsRule<C extends BodoSQLReduceExpres
                   .collect(Collectors.toList());
           boolean changed = !project.getProjects().equals(finalExpList);
           if (changed) {
-            RelNode newProject =
+            call.transformTo(
                 call.builder()
                     .push(project.getInput())
                     .project(finalExpList, project.getRowType().getFieldNames())
-                    .build();
-            call.transformTo(newProject);
-            //            for (int i = 0; i < project.getProjects().size(); i++) {
-            //              RexNode before = project.getProjects().get(i);
-            //              RexNode after = finalExpList.get(i);
-            //
-            //              if (before instanceof RexInputRef
-            //                      && !(after instanceof RexInputRef)
-            //                      && !before.equals(after)) {
-            //                System.err.println("INPUT REF EXPANDED:");
-            //                System.err.println("  before: " + before);
-            //                System.err.println("  after:  " + after);
-            //              }
-            //            }
+                    .build());
+
             // New plan is absolutely better than old plan.
             call.getPlanner().prune(project);
           }

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
@@ -196,9 +196,6 @@ public abstract class BodoSQLReduceExpressionsRule<C extends BodoSQLReduceExpres
       if (rexNodeContainsCase(newConditionExp)) {
         return;
       }
-      if (rexNodeContainsCase(newConditionExp)) {
-        return;
-      }
 
       // Even if no reduction, let's still test the original
       // predicate to see if it was already a constant,

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
@@ -17,6 +17,8 @@ package com.bodosql.calcite.application.logicalRules;
  * limitations under the License.
  */
 
+import static com.bodosql.calcite.application.logicalRules.FilterRulesCommon.rexNodeContainsCase;
+
 import com.bodosql.calcite.application.utils.BodoSQLStyleImmutable;
 import com.bodosql.calcite.application.utils.RexNormalizer;
 import com.bodosql.calcite.rel.logical.BodoLogicalProject;
@@ -113,6 +115,10 @@ public abstract class BodoSQLReduceExpressionsRule<C extends BodoSQLReduceExpres
     @Override
     public void onMatch(RelOptRuleCall call) {
       final Filter filter = call.rel(0);
+      // Bodo Change: Do not reduce filters that contain Case statements.
+      if (rexNodeContainsCase(filter.getCondition())) {
+        return;
+      }
       final List<RexNode> expList = Lists.newArrayList(filter.getCondition());
       RexNode newConditionExp;
       boolean reduced;
@@ -144,6 +150,13 @@ public abstract class BodoSQLReduceExpressionsRule<C extends BodoSQLReduceExpres
       } catch (RuntimeException e) {
         // Bodo Change: If we hit an exception we cannot reduce this expression.
         // This rule should never break entirely as it's an optimization.
+        return;
+      }
+
+      // Bodo change: Do not rewrite a filter to introduce a CASE expression.
+      // FilterExtractCaseRule can extract the CASE back into a Project, causing
+      // repeated rewrites and Volcano rule explosion.
+      if (rexNodeContainsCase(newConditionExp)) {
         return;
       }
 
@@ -281,12 +294,24 @@ public abstract class BodoSQLReduceExpressionsRule<C extends BodoSQLReduceExpres
                   .collect(Collectors.toList());
           boolean changed = !project.getProjects().equals(finalExpList);
           if (changed) {
-            call.transformTo(
+            RelNode newProject =
                 call.builder()
                     .push(project.getInput())
                     .project(finalExpList, project.getRowType().getFieldNames())
-                    .build());
-
+                    .build();
+            call.transformTo(newProject);
+            //            for (int i = 0; i < project.getProjects().size(); i++) {
+            //              RexNode before = project.getProjects().get(i);
+            //              RexNode after = finalExpList.get(i);
+            //
+            //              if (before instanceof RexInputRef
+            //                      && !(after instanceof RexInputRef)
+            //                      && !before.equals(after)) {
+            //                System.err.println("INPUT REF EXPANDED:");
+            //                System.err.println("  before: " + before);
+            //                System.err.println("  after:  " + after);
+            //              }
+            //            }
             // New plan is absolutely better than old plan.
             call.getPlanner().prune(project);
           }

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/application/logicalRules/BodoSQLReduceExpressionsRule.java
@@ -154,8 +154,48 @@ public abstract class BodoSQLReduceExpressionsRule<C extends BodoSQLReduceExpres
       }
 
       // Bodo change: Do not rewrite a filter to introduce a CASE expression.
-      // FilterExtractCaseRule can extract the CASE back into a Project, causing
-      // repeated rewrites and Volcano rule explosion.
+      //
+      // Consider:
+      //
+      //   SELECT colA
+      //   FROM t1
+      //   WHERE colA =
+      //       CASE 1
+      //         WHEN 1 THEN 'xxxx'
+      //         WHEN 2 THEN 'yyyy'
+      //       END;
+      //
+      // Our CASE-extraction HEP stage rewrites the filter into a form like:
+      //
+      //   Project(col0=$0)
+      //     Filter($0 = $1)
+      //       Project(col0=$0, col1=CASE(...))
+      //
+      // Because the CASE expression is constant with respect to the input rows,
+      // pulled-up predicate metadata may allow ReduceExpressionsRule to simplify
+      // the filter back to:
+      //
+      //   Filter($0 = CASE(...))
+      //
+      // This effectively undoes the CASE extraction. FilterExtractCaseRule can
+      // then extract the CASE again, introducing additional Projects:
+      //
+      //   Project(col0=$0)
+      //     Filter($0 = CASE(...))
+      //       Project(col0=$0, col1=CASE(...))
+      //
+      // becomes:
+      //
+      //   Project(col0=$0)
+      //     Project(...)
+      //       Filter($0 = $1)
+      //         Project(col0=$0, col1=CASE(...))
+      //           Project(...)
+      //
+      // creating a cycle and rule explosion in the Volcano planner.
+      if (rexNodeContainsCase(newConditionExp)) {
+        return;
+      }
       if (rexNodeContainsCase(newConditionExp)) {
         return;
       }

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/metadata/BodoRelMdPredicates.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/metadata/BodoRelMdPredicates.java
@@ -31,8 +31,6 @@ import org.apache.calcite.rel.metadata.MetadataHandler;
 import org.apache.calcite.rel.metadata.ReflectiveRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.BodoRexSimplify;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
@@ -53,12 +51,7 @@ import org.apache.calcite.util.mapping.MappingType;
 import org.apache.calcite.util.mapping.Mappings;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/**
- * Utility to infer Predicates that are applicable above a RelNode.
- *
- * <p>The only change that Bodo makes is to Join predicate inference. This change can be undone
- * if/when the upstream calcite PR merges: https://github.com/apache/calcite/pull/3452
- */
+/** Utility to infer Predicates that are applicable above a RelNode. */
 public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Predicates> {
   public static final RelMetadataProvider SOURCE =
       ReflectiveRelMetadataProvider.reflectiveSource(
@@ -88,7 +81,10 @@ public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
       // Bodo Change: Keep Calcite <1.39 behavior of returning an empty list
       // to prevent regressions in planner tests.
       // TODO(BSE-5568) Return non-empty predicates list.
-      return RelOptPredicateList.EMPTY;
+      //      System.out.println("Getting empty");
+      //      return RelOptPredicateList.EMPTY;
+      //      System.out.println("Getting pulled up MD");
+      return mq.getPulledUpPredicates(r.stripped());
     }
     final RexBuilder rexBuilder = r.getCluster().getRexBuilder();
     RelOptPredicateList list = null;
@@ -217,44 +213,6 @@ public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
       equivalence = BitSets.closure(equivalence);
     }
 
-    // BODO CHANGE:
-    /**
-     * As RexPermuteInputsShuttle, with one exception. When visiting an inputRef, it will replace
-     * the type of the InputRef with the type found in the input fields, instead of keeping the
-     * original type. This is used within when generating the Left/RightInferredPredicates, to avoid
-     * nullability mismatches between the types of the join and the types of the inputs.
-     */
-    private class TypeChangingRexPermuteInputsShuttle
-        extends org.apache.calcite.rex.RexPermuteInputsShuttle {
-
-      private final Mappings.TargetMapping mapping;
-      private final ImmutableList<RelDataTypeField> fields;
-
-      public TypeChangingRexPermuteInputsShuttle(
-          Mappings.TargetMapping mapping, RelNode... inputs) {
-        super(mapping, inputs);
-        this.mapping = mapping;
-        this.fields = fields(inputs);
-      }
-
-      private ImmutableList<RelDataTypeField> fields(RelNode[] inputs) {
-        final ImmutableList.Builder<RelDataTypeField> fields = ImmutableList.builder();
-        for (RelNode input : inputs) {
-          fields.addAll(input.getRowType().getFieldList());
-        }
-        return fields.build();
-      }
-
-      @Override
-      public RexNode visitInputRef(RexInputRef local) {
-        final int index = local.getIndex();
-        int target = mapping.getTarget(index);
-        RelDataType oldTyp = local.getType();
-        RelDataType newTyp = fields.get(target).getType();
-        return new RexInputRef(target, newTyp);
-      }
-    }
-
     /**
      * The PullUp Strategy is sound but not complete.
      *
@@ -276,7 +234,7 @@ public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
       final List<RexNode> inferredPredicates = new ArrayList<>();
       final Set<RexNode> allExprs = new HashSet<>(this.allExprs);
       final JoinRelType joinType = joinRel.getJoinType();
-      // Bodo Change: If we know the join condition is always true we there
+      // Bodo Change: If we know the join condition is always true, there
       // is nothing to infer from the join condition.
       boolean keepAllPredicates = joinRel.getCondition().isAlwaysTrue();
       if (!keepAllPredicates) {
@@ -314,14 +272,12 @@ public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
       Mappings.TargetMapping rightMapping =
           Mappings.createShiftMapping(
               nSysFields + nFieldsLeft + nFieldsRight, 0, nSysFields + nFieldsLeft, nFieldsRight);
-      // BODO CHANGE: uses TypeChangingRexPermuteInputsShuttle instead of the default
-      // RexPermuteInputsShuttle.
       final RexPermuteInputsShuttle rightPermute =
-          new TypeChangingRexPermuteInputsShuttle(rightMapping, joinRel.getRight());
+          new RexPermuteInputsShuttle(rightMapping, true, joinRel.getRight());
       Mappings.TargetMapping leftMapping =
           Mappings.createShiftMapping(nSysFields + nFieldsLeft, 0, nSysFields, nFieldsLeft);
       final RexPermuteInputsShuttle leftPermute =
-          new TypeChangingRexPermuteInputsShuttle(leftMapping, joinRel.getLeft());
+          new RexPermuteInputsShuttle(leftMapping, true, joinRel.getLeft());
       final List<RexNode> initialLeftInferredPredicates = new ArrayList<>();
       final List<RexNode> initialRightInferredPredicates = new ArrayList<>();
 
@@ -334,7 +290,7 @@ public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
         }
       }
 
-      // Bodo change: Don't just accept they inferred predicates unless
+      // Bodo change: Don't just accept the inferred predicates unless
       // the left/right predicates simplify
       final List<RexNode> leftInferredPredicates = new ArrayList<>();
       RexNode simplifiedLeftChildPredicates =

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/metadata/BodoRelMdPredicates.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/metadata/BodoRelMdPredicates.java
@@ -85,9 +85,11 @@ public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
 
   public RelOptPredicateList getPredicates(RelSubset r, RelMetadataQuery mq) {
     if (!Bug.CALCITE_1048_FIXED) {
-      // Bodo Change: Keep Calcite <1.39 behavior of returning an empty list
-      // to prevent regressions in planner tests.
-      // TODO(BSE-5568) Return non-empty predicates list.
+      if (Boolean.parseBoolean(System.getenv().getOrDefault("BODOSQL_PREDICATE_PULLUP", "true"))) {
+        // System.out.println("Getting pulled up MD");
+        return mq.getPulledUpPredicates(r.stripped());
+      }
+      // System.out.println("Getting empty MD");
       return RelOptPredicateList.EMPTY;
     }
     final RexBuilder rexBuilder = r.getCluster().getRexBuilder();

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/metadata/BodoRelMdPredicates.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/com/bodosql/calcite/rel/metadata/BodoRelMdPredicates.java
@@ -21,7 +21,6 @@ import java.util.TreeMap;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.plan.RelOptUtil;
-import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
@@ -43,7 +42,6 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.BitSets;
-import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mapping;
@@ -74,26 +72,6 @@ public class BodoRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
   public RelOptPredicateList getPredicates(
       BodoPhysicalMinRowNumberFilter mrnf, RelMetadataQuery mq) {
     return ((BodoRelMetadataQuery) mq).getPulledUpPredicates(mrnf.asBodoProjectFilter());
-  }
-
-  public RelOptPredicateList getPredicates(RelSubset r, RelMetadataQuery mq) {
-    if (!Bug.CALCITE_1048_FIXED) {
-      if (Boolean.parseBoolean(System.getenv().getOrDefault("BODOSQL_PREDICATE_PULLUP", "true"))) {
-        // System.out.println("Getting pulled up MD");
-        return mq.getPulledUpPredicates(r.stripped());
-      }
-      // System.out.println("Getting empty MD");
-      return RelOptPredicateList.EMPTY;
-    }
-    final RexBuilder rexBuilder = r.getCluster().getRexBuilder();
-    RelOptPredicateList list = null;
-    for (RelNode r2 : r.getRels()) {
-      RelOptPredicateList list2 = mq.getPulledUpPredicates(r2);
-      if (list2 != null) {
-        list = list == null ? list2 : list.union(rexBuilder, list2);
-      }
-    }
-    return Util.first(list, RelOptPredicateList.EMPTY);
   }
 
   /**

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -443,6 +443,21 @@ public class RexUtil {
     if (!isConstant(right)) {
       return;
     }
+    /** Bodo Change:
+     * Avoid literal-to-literal entries in the constant map.
+     *
+     * predicateConstants considers equalicty constraints in both directions.
+     * For equivalent literals with different Rex representations, this can
+     * create cyclic mappings such as A -> B and B -> A.
+     *
+     * ReduceExpressionsRule may then alternate between the two representations.
+     * Because the rule prunes the expression it replaces, this can leave a
+     * Volcano subset without a usable expression and cause a
+     * CannotPlanException.
+     */
+    if (left instanceof RexLiteral) {
+      return;
+    }
     C constant = clazz.cast(right);
     if (excludeSet.contains(left)) {
       return;

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -446,14 +446,11 @@ public class RexUtil {
     /** Bodo Change:
      * Avoid literal-to-literal entries in the constant map.
      *
-     * predicateConstants considers equalicty constraints in both directions.
-     * For equivalent literals with different Rex representations, this can
-     * create cyclic mappings such as A -> B and B -> A.
-     *
-     * ReduceExpressionsRule may then alternate between the two representations.
-     * Because the rule prunes the expression it replaces, this can leave a
-     * Volcano subset without a usable expression and cause a
-     * CannotPlanException.
+     * During optimization, the planner may generate predicates like: 'a' = 'a':VARCHAR
+     * through ordinary expression transformations. These predicates create cycles in the
+     * Volcano optimizer. For example, the condition =($0, 'a') might alternate between
+     * =('a', 'a') and =('a':VARCHAR, 'a':VARCHAR) in the FilterReduceExpression rule,
+     * leading to the planner to prune both expressions and throw a CannotPlanException.
      */
     if (left instanceof RexLiteral) {
       return;

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -447,11 +447,11 @@ public class RexUtil {
      * Avoid literal-to-literal entries in the constant map.
      *
      * During optimization, the planner may generate predicates like:
-     * 'a' = 'a':VARCHAR through ordinary expression transformations. These predicates
-     * create cycles that break the Volcano planner. For example, the condition
-     * =($0, 'a') might alternate between =('a', 'a') and =('a':VARCHAR, 'a':VARCHAR)
-     * in FilterReduceExpressionsRule, causing the planner to prune both expressions
-     * and throw a CannotPlanException.
+     * 'a' = 'a':VARCHAR through ordinary expression transformations. These
+     * predicates create cycles that break the Volcano planner. For example, the
+     * condition =($0, 'a') might alternate between =('a', 'a') and
+     * =('a':VARCHAR, 'a':VARCHAR) in FilterReduceExpressionsRule, causing the
+     * planner to prune both expressions and throw a CannotPlanException.
      */
     if (left instanceof RexLiteral) {
       return;

--- a/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
+++ b/BodoSQL/calcite_sql/bodosql-calcite-application/src/main/java/org/apache/calcite/rex/RexUtil.java
@@ -446,11 +446,12 @@ public class RexUtil {
     /** Bodo Change:
      * Avoid literal-to-literal entries in the constant map.
      *
-     * During optimization, the planner may generate predicates like: 'a' = 'a':VARCHAR
-     * through ordinary expression transformations. These predicates create cycles in the
-     * Volcano optimizer. For example, the condition =($0, 'a') might alternate between
-     * =('a', 'a') and =('a':VARCHAR, 'a':VARCHAR) in the FilterReduceExpression rule,
-     * leading to the planner to prune both expressions and throw a CannotPlanException.
+     * During optimization, the planner may generate predicates like:
+     * 'a' = 'a':VARCHAR through ordinary expression transformations. These predicates
+     * create cycles that break the Volcano planner. For example, the condition
+     * =($0, 'a') might alternate between =('a', 'a') and =('a':VARCHAR, 'a':VARCHAR)
+     * in FilterReduceExpressionsRule, causing the planner to prune both expressions
+     * and throw a CannotPlanException.
      */
     if (left instanceof RexLiteral) {
       return;


### PR DESCRIPTION
## Changes included in this PR

Remove change that prevented predicated metadata from being propagated from Rel Subsets in the Volcano planner, enabling additional optimizer rules such as `ProjectReduceExpressionRule`.

Also fixes some existing bugs exposed by predicate metadata changes and removes some changes to predicates that were merged upstream. 
  
## Testing strategy

PR CI; Java plan tests (See: https://github.com/bodo-ai/customer-sample-code/pull/161)

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.