### PR TITLE
Require mac arm build on CI for Cpp changes

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -246,12 +246,16 @@ jobs:
     name: Mac ARM Build
     needs: [validate, get_version]
     if: needs.validate.outputs.cpp == 'true'
-    uses: ./.github/workflows/_build_bodo_pip.yml
-    with:
-      os: macos-latest
-      name: macos-arm
-      bodo_version: ${{ needs.get_version.outputs.bodo_version }}
-      python_version: '3.14'
+    runs-on: macos-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build from Source
+        uses: ./.github/actions/build-source
+        with:
+          build-all: false
 
   # 5) Collect and combine any results from runs
   collect-results:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -48,6 +48,7 @@ jobs:
       run_gpu: ${{ contains(github.event.pull_request.title, '[GPU]') || github.event_name == 'workflow_dispatch' }}
       run_bodosql_customer_tests: ${{ steps.changes.outputs.bodosql_customer_tests || github.event_name == 'workflow_dispatch' }}
       not_docs: ${{ steps.changes.outputs.not_docs }}
+      cpp: ${{ steps.changes.outputs.cpp }}
       skip_flag: ${{ contains(steps.check_msg.outputs.commit_message, '[skip]') }}
 
     steps:
@@ -65,6 +66,11 @@ jobs:
               - 'BodoSQL/calcite_sql/**'
             not_docs:
               - '!docs/**'
+            cpp:
+              - '**/*.cpp'
+              - '**/*.hpp'
+              - '**/*.c'
+              - '**/*.h'
 
       # Fetch the PR branch for the commit history
       - uses: actions/checkout@v5
@@ -236,7 +242,16 @@ jobs:
       needs.validate.outputs.run_bodosql_customer_tests == 'true'
     uses: ./.github/workflows/_test_java_source.yml
 
-
+  mac-arm-build:
+    name: Mac ARM Build
+    needs: [validate, get_version]
+    if: needs.validate.outputs.cpp == 'true'
+    uses: ./.github/workflows/_build_bodo_pip.yml
+    with:
+      os: macos-latest
+      name: macos-arm
+      bodo_version: ${{ needs.get_version.outputs.bodo_version }}
+      python_version: '3.14'
 
   # 5) Collect and combine any results from runs
   collect-results:
@@ -328,5 +343,11 @@ jobs:
         if: ${{ (needs.validate.outputs.not_docs == 'true') && (needs.validate.outputs.skip_flag != 'true') }}
         uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: ${{ needs.validate.outputs.run_gpu != 'true' && 'gpu-ci' || '' }}
+          allowed-skips: >-
+            ${{ 
+              (needs.validate.outputs.run_gpu != 'true' && needs.validate.outputs.cpp != 'true' && 'gpu-ci,mac-arm-build') ||
+              (needs.validate.outputs.run_gpu != 'true' && 'gpu-ci') ||
+              (needs.validate.outputs.cpp != 'true' && 'mac-arm-build') ||
+              ''
+            }}
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -244,7 +244,7 @@ jobs:
 
   mac-arm-build:
     name: Mac ARM Build
-    needs: [validate, get_version]
+    needs: [validate]
     if: needs.validate.outputs.cpp == 'true'
     runs-on: macos-latest
     permissions:

--- a/bodo/libs/streaming/_sort.cpp
+++ b/bodo/libs/streaming/_sort.cpp
@@ -20,6 +20,8 @@
 #include "../_utils.h"
 #include "_shuffle.h"
 
+// TEST
+
 #define QUERY_PROFILE_SORT_INIT_STAGE_ID 0
 #define QUERY_PROFILE_SORT_BUILD_STAGE_ID 1
 #define QUERY_PROFILE_SORT_OUTPUT_STAGE_ID 2

--- a/bodo/libs/streaming/_sort.cpp
+++ b/bodo/libs/streaming/_sort.cpp
@@ -19,7 +19,7 @@
 #include "../_table_builder_utils.h"
 #include "../_utils.h"
 #include "_shuffle.h"
-
+// test
 #define QUERY_PROFILE_SORT_INIT_STAGE_ID 0
 #define QUERY_PROFILE_SORT_BUILD_STAGE_ID 1
 #define QUERY_PROFILE_SORT_OUTPUT_STAGE_ID 2

--- a/bodo/libs/streaming/_sort.cpp
+++ b/bodo/libs/streaming/_sort.cpp
@@ -19,7 +19,7 @@
 #include "../_table_builder_utils.h"
 #include "../_utils.h"
 #include "_shuffle.h"
-// test
+
 #define QUERY_PROFILE_SORT_INIT_STAGE_ID 0
 #define QUERY_PROFILE_SORT_BUILD_STAGE_ID 1
 #define QUERY_PROFILE_SORT_OUTPUT_STAGE_ID 2

--- a/bodo/libs/streaming/_sort.cpp
+++ b/bodo/libs/streaming/_sort.cpp
@@ -20,8 +20,6 @@
 #include "../_utils.h"
 #include "_shuffle.h"
 
-// TEST
-
 #define QUERY_PROFILE_SORT_INIT_STAGE_ID 0
 #define QUERY_PROFILE_SORT_BUILD_STAGE_ID 1
 #define QUERY_PROFILE_SORT_OUTPUT_STAGE_ID 2


### PR DESCRIPTION
## Changes included in this PR

Add a job to build a mac-arm pip package when a PR makes changes to cpp files, to prevent merging code that compiles on linux but not mac. 

## Testing strategy

[run ci]
https://github.com/bodo-ai/Bodo/actions/runs/33880425863/job/101047752978?pr=1384 
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.