### PR TITLE
Preserve Iceberg field nullability in simple df read/write codes

### DIFF
--- a/bodo/pandas/base.py
+++ b/bodo/pandas/base.py
@@ -340,6 +340,7 @@ def read_iceberg(
             arrow_schema.get_field_index(field_name) for field_name in selected_fields
         ]
         empty_df = empty_df[list(selected_fields)]
+        arrow_schema = pa.schema([arrow_schema.field(i) for i in col_idxs])
     else:
         # Adds logical projection layer to enable rename.
         col_idxs = range(len(empty_df.columns))
@@ -350,6 +351,9 @@ def read_iceberg(
         plan,
         exprs,
     )
+    # Set arrow_schema explicitly to preserve field nullability
+    # Important for read-write codes to maintain nullability in the output table
+    plan.pa_schema = arrow_schema
 
     if limit is not None:
         plan = LogicalLimit(
@@ -357,6 +361,7 @@ def read_iceberg(
             plan,
             limit,
         )
+        plan.pa_schema = arrow_schema
 
     return wrap_plan(plan=plan)
 

--- a/bodo/tests/iceberg_database_helpers/simple_tables.py
+++ b/bodo/tests/iceberg_database_helpers/simple_tables.py
@@ -175,7 +175,7 @@ BASE_MAP: dict[str, tuple[dict, list]] = {
             ),
         },
         [
-            ("A", "string", True),
+            ("A", "string", False),
             ("B", "string", True),
             ("C", "string", True),
             ("D", "string", True),

--- a/bodo/tests/test_df_lib/test_iceberg.py
+++ b/bodo/tests/test_df_lib/test_iceberg.py
@@ -172,6 +172,10 @@ def test_table_read_selected_fields(
         },
         selected_fields=("A", "C"),
     )
+    # Make sure nullablity is preserved during read
+    assert not bodo_out._plan.pa_schema.field("A").nullable, (
+        "Field 'A' should not be nullable"
+    )
 
     _test_equal(
         bodo_out,
@@ -254,6 +258,20 @@ def test_table_read_row_filter(
             pyiceberg.catalog.WAREHOUSE_LOCATION: warehouse_loc,
         },
         row_filter=filter_expr,
+    )
+
+    # Make sure nullablity is preserved during read
+    assert not bodo_out._plan.pa_schema.field("A").nullable, (
+        "Field 'A' should not be nullable"
+    )
+    assert not bodo_out._plan.pa_schema.field("B").nullable, (
+        "Field 'B' should not be nullable"
+    )
+    assert not bodo_out._plan.pa_schema.field("C").nullable, (
+        "Field 'C' should not be nullable"
+    )
+    assert not bodo_out._plan.pa_schema.field("D").nullable, (
+        "Field 'D' should not be nullable"
     )
 
     _test_equal(


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title. Nullability is preserved only for simple read/write codes since Pandas Arrow dtypes don't have a nullability field. Helps the SQL planner when using the written table.

## Testing strategy

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->
Added unit tests.

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->
None.

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.