### PR TITLE
Re-enable join bloom filters

### DIFF
--- a/bodo/pandas/physical/join_filter.h
+++ b/bodo/pandas/physical/join_filter.h
@@ -152,12 +152,12 @@ class PhysicalJoinFilter : public PhysicalProcessBatch {
                 [&](const auto& join_state) {
                     if constexpr (std::is_same_v<
                                       std::decay_t<decltype(join_state)>,
-                                      JoinState*>) {
+                                      std::shared_ptr<JoinState>>) {
                         if (join_state->IsNestedLoopJoin()) {
                             return;
                         }
                         HashJoinState* hash_join_state =
-                            (HashJoinState*)join_state;
+                            (HashJoinState*)join_state.get();
 
                         applied_any_filter = applied_any_filter ||
                                              hash_join_state->RuntimeFilter(


### PR DESCRIPTION
Join filters were effectively disabled by this PR: https://github.com/bodo-ai/Bodo/commit/cf0f29d2a9417cd6aff057b57db7a0e21689ae92
This re-enables them. Improves the performance of Q17 significantly.