### PR TITLE
Fix schema evolve write test cases

### DIFF
--- a/bodo/tests/iceberg_database_helpers/simple_tables.py
+++ b/bodo/tests/iceberg_database_helpers/simple_tables.py
@@ -181,28 +181,6 @@ BASE_MAP: dict[str, tuple[dict, list]] = {
             ("D", "string", True),
         ],
     ),
-    "STRING_TABLE_NOTNULL": (
-        {
-            "A": np.array(["A", "B", "C", "D"] * 25),
-            "B": np.array(["lorem", "ipsum", "loden", "ion"] * 25),
-            "C": np.array((["A"] * 10) + (["b"] * 90)),
-            "D": np.array(
-                ["four hundred"] * 10
-                + ["five"] * 20
-                + [None] * 10
-                + ["forty-five"] * 10
-                + ["four"] * 20
-                + ["fifeteen"] * 20
-                + ["f"] * 10
-            ),
-        },
-        [
-            ("A", "string", False),
-            ("B", "string", True),
-            ("C", "string", True),
-            ("D", "string", True),
-        ],
-    ),
     "DICT_ENCODED_STRING_TABLE": (
         {
             "A": pa.array(
@@ -387,6 +365,31 @@ BASE_MAP: dict[str, tuple[dict, list]] = {
     ),
 }
 
+NOTNULL_MAP = {
+    "STRING_TABLE_NOTNULL": (
+        {
+            "A": np.array(["A", "B", "C", "D"] * 25),
+            "B": np.array(["lorem", "ipsum", "loden", "ion"] * 25),
+            "C": np.array((["A"] * 10) + (["b"] * 90)),
+            "D": np.array(
+                ["four hundred"] * 10
+                + ["five"] * 20
+                + [None] * 10
+                + ["forty-five"] * 10
+                + ["four"] * 20
+                + ["fifeteen"] * 20
+                + ["f"] * 10
+            ),
+        },
+        [
+            ("A", "string", False),
+            ("B", "string", True),
+            ("C", "string", True),
+            ("D", "string", True),
+        ],
+    )
+}
+
 
 def build_map(base_map):
     table_map = {}
@@ -398,7 +401,7 @@ def build_map(base_map):
     return table_map
 
 
-TABLE_MAP: dict[str, tuple[pd.DataFrame, list]] = build_map(BASE_MAP)
+TABLE_MAP: dict[str, tuple[pd.DataFrame, list]] = build_map(BASE_MAP | NOTNULL_MAP)
 
 
 def create_table(base_name: str, spark=None):


### PR DESCRIPTION
## Changes included in this PR

Remove table with required field from `BASE_MAP`, which is used for generating all-nullable tables for some iceberg write tests.  

## Testing strategy

Fixes test_iceberg_schema_evolution.py::test_write_schema_evolved_table on nightly

<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes

<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [ ] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [ ] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [ ] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [ ] I have installed + ran pre-commit hooks.