### PR TITLE
Fix windows build [run ci]

### DIFF
--- a/bodo/libs/vendored/ankerl/unordered_dense.h
+++ b/bodo/libs/vendored/ankerl/unordered_dense.h
@@ -1377,13 +1377,14 @@ public:
         #ifdef _MSC_VER
             // MSVC doesn't support __builtin_prefetch, so just return
             return;
-        #endif
+        #else
         if (ANKERL_UNORDERED_DENSE_UNLIKELY(empty())) {
             return;
         }
         auto mh = mixed_hash(key);
         auto bucket_idx = bucket_idx_from_hash(mh);
         __builtin_prefetch(&at(m_buckets, static_cast<value_idx_type>(bucket_idx)), /*read only*/ 0, /*low locality*/1);
+        #endif
     }
 
     auto find(Key const& key) const -> const_iterator {


### PR DESCRIPTION
## Changes included in this PR

<!-- Include a brief description of the changes presented in this PR and any extra context that might be helpful for reviewers. -->
As title, returning early doesn't stop msvc from parsing the __builtin_prefetch
## Testing strategy
n/a
<!--
Before requesting review, verify that your changes pass PR CI by adding "[run ci]" to your commit message (or add a new blank commit with that message) or explain why CI is not necessary (e.g. docs changes).

Briefly mention how this change is tested e.g. "new unit tests added". To pass automated coverage checks, ensure that you have added `# pragma: no cover` to jitted functions.

Ensure that newly added tests work locally on 3 ranks using both SPMD and spawn mode (default) when applicable. For example:

SPMD mode:
  `export BODO_SPAWN_MODE=0;
  mpiexec -n 3 pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`

Spawn mode (default mode):
  `export BODO_NUM_WORKERS=3;
  pytest -svW ignore bodo/tests/test_dataframe.py::my_new_test`
-->

## User facing changes
n/a
<!-- Mention any changes to user facing APIs here and ensure that the documentation is up to date in Bodo/docs/docs -->

## Checklist
- [x] PR title contains "[GPU]" if changes target Bodo DataFrames GPU acceleration.
- [x] Pipelines passed before requesting review. To run CI you must include `[run CI]` in your commit message.
- [x] I am familiar with the [Contributing Guide](https://github.com/bodo-ai/Bodo/blob/main/CONTRIBUTING.md)
- [x] I have installed + ran pre-commit hooks.